### PR TITLE
Hide backlinks in edit mode

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppNavigationView.swift
+++ b/xcode/Subconscious/Shared/Components/AppNavigationView.swift
@@ -38,7 +38,8 @@ struct AppNavigationView: View {
                                 DetailView(
                                     focus: store.binding(
                                         get: \.focus,
-                                        tag: AppAction.setFocus
+                                        tag: AppAction.setFocus,
+                                        animation: .easeOut(duration: .normal)
                                     ),
                                     editorAttributedText: store.binding(
                                         get: \.editorAttributedText,

--- a/xcode/Subconscious/Shared/Components/Common/PseudoKeyboardToolbarView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/PseudoKeyboardToolbarView.swift
@@ -15,7 +15,7 @@ where Content: View, Toolbar: View
     var isKeyboardUp: Bool
     var toolbarHeight: CGFloat
     var toolbar: Toolbar
-    var content: (CGSize) -> Content
+    var content: (Bool, CGSize) -> Content
 
     /// Set fixed toolbar height for view.
     /// Defaults to 48pt.
@@ -27,30 +27,22 @@ where Content: View, Toolbar: View
 
     var body: some View {
         GeometryReader { geometry in
-            ZStack {
-                VStack(spacing: 0) {
-                    content(
-                        (
-                            isKeyboardUp ?
-                            CGSize(
-                                width: geometry.size.width,
-                                height: geometry.size.height - toolbarHeight
-                            ) :
-                            geometry.size
-                         )
-                    )
-                }
-                .padding(.bottom, isKeyboardUp ? toolbarHeight : 0)
-                VStack(spacing: 0) {
-                    Spacer()
+            VStack(spacing: 0) {
+                content(
+                    isKeyboardUp,
+                    (
+                        isKeyboardUp ?
+                        CGSize(
+                            width: geometry.size.width,
+                            height: geometry.size.height - toolbarHeight
+                        ) :
+                        geometry.size
+                     )
+                )
+                if isKeyboardUp {
                     toolbar
                         .frame(height: toolbarHeight)
-                        .opacity(isKeyboardUp ? 1 : 0)
-                        .offset(
-                            x: 0,
-                            y: isKeyboardUp ? 0 : toolbarHeight
-                        )
-                        .animation(.default, value: isKeyboardUp)
+                        .transition(.opacity)
                 }
             }
         }

--- a/xcode/Subconscious/Shared/Components/DetailView.swift
+++ b/xcode/Subconscious/Shared/Components/DetailView.swift
@@ -34,7 +34,7 @@ struct DetailView: View {
                     isSheetPresented: $isLinkSheetPresented,
                     suggestions: .constant([])
                 ),
-                content: { size in
+                content: { isKeyboardUp, size in
                     ScrollView(.vertical) {
                         VStack(spacing: 0) {
                             GrowableAttributedTextViewRepresentable(
@@ -56,8 +56,8 @@ struct DetailView: View {
                             .frame(
                                 minHeight: size.height
                             )
-                            Divider()
-                            if backlinks.count > 0 {
+                            if !isKeyboardUp && backlinks.count > 0 {
+                                Divider()
                                 BacklinksView(
                                     backlinks: backlinks,
                                     onActivateBacklink: onCommitSearch


### PR DESCRIPTION
Fixes #26.

Transition animation not working (it should). Might be a swift issue. We can investigate later.