### PR TITLE
Handle empty search input / invalid slugs

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppNavigationView.swift
+++ b/xcode/Subconscious/Shared/Components/AppNavigationView.swift
@@ -112,9 +112,9 @@ struct AppNavigationView: View {
                             },
                             onCommitSearch: { query in
                                 store.send(
-                                    action: .requestDetail(
+                                    action: .submitSearch(
                                         slug: query.slugify(),
-                                        fallback: query
+                                        query: query
                                     )
                                 )
                             },

--- a/xcode/Subconscious/Shared/Components/Common/LinkSuggestionLabelView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/LinkSuggestionLabelView.swift
@@ -50,7 +50,10 @@ struct LinkSuggestionLabel_Previews: PreviewProvider {
     static var previews: some View {
         LinkSuggestionLabelView(
             suggestion: .search(
-                EntryLink(title: "Floop the pig")
+                EntryLink(
+                    slug: "floop",
+                    title: "Floop the pig"
+                )
             )
         )
     }

--- a/xcode/Subconscious/Shared/Components/Common/RenameSuggestionLabelView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/RenameSuggestionLabelView.swift
@@ -15,7 +15,7 @@ struct RenameSuggestionLabelView: View {
             Label(
                 title: {
                     TitleGroup(
-                        title: stub.title.slugifyString(),
+                        title: stub.slug,
                         subtitle: "Merge ideas"
                     )
                 },
@@ -27,7 +27,7 @@ struct RenameSuggestionLabelView: View {
             Label(
                 title: {
                     TitleGroup(
-                        title: stub.title.slugifyString(),
+                        title: stub.slug,
                         subtitle: "Rename idea"
                     )
                 },
@@ -43,7 +43,10 @@ struct RenameSuggestionLabel_Previews: PreviewProvider {
     static var previews: some View {
         RenameSuggestionLabelView(
             suggestion: .search(
-                EntryLink(title: "Floop the pig")
+                EntryLink(
+                    slug: "floop",
+                    title: "Floop the pig"
+                )
             )
         )
     }

--- a/xcode/Subconscious/Shared/Components/Common/SuggestionLabelView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SuggestionLabelView.swift
@@ -43,7 +43,10 @@ struct SuggestionLabel_Previews: PreviewProvider {
     static var previews: some View {
         SuggestionLabelView(
             suggestion: .search(
-                EntryLink(title: "Floop the pig")
+                EntryLink(
+                    slug: "floop",
+                    title: "Floop the pig"
+                )
             )
         )
     }

--- a/xcode/Subconscious/Shared/Components/KeyboardToolbarView.swift
+++ b/xcode/Subconscious/Shared/Components/KeyboardToolbarView.swift
@@ -55,6 +55,7 @@ struct KeyboardToolbarView_Previews: PreviewProvider {
             suggestions: .constant([
                 .search(
                     EntryLink(
+                        slug: "an-organism-is-a-living-system",
                         title: "An organism is a living system maintaining both a higher level of internal cooperation"
                     )
                 )

--- a/xcode/Subconscious/Shared/Components/RenameSearchView.swift
+++ b/xcode/Subconscious/Shared/Components/RenameSearchView.swift
@@ -15,7 +15,7 @@ struct RenameSearchView: View {
     @Binding var text: String
     @Binding var focus: AppModel.Focus?
     var onCancel: () -> Void
-    var onCommit: (Slug?, Slug) -> Void
+    var onCommit: (Slug?, Slug?) -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -84,8 +84,18 @@ struct RenameSearchView_Previews: PreviewProvider {
         RenameSearchView(
             slug: "floop",
             suggestions: [
-                .search(EntryLink(title: "Floop")),
-                .entry(EntryLink(title: "Card wars"))
+                .search(
+                    EntryLink(
+                        slug: "floop",
+                        title: "Floop"
+                    )
+                ),
+                .entry(
+                    EntryLink(
+                        slug: "card-wars",
+                        title: "Card wars"
+                    )
+                )
             ],
             text: .constant(""),
             focus: .constant(nil),

--- a/xcode/Subconscious/Shared/Components/SearchView.swift
+++ b/xcode/Subconscious/Shared/Components/SearchView.swift
@@ -12,7 +12,7 @@ struct SearchView: View {
     @Binding var text: String
     @Binding var focus: AppModel.Focus?
     @Binding var suggestions: [Suggestion]
-    var onCommit: (Slug, String) -> Void
+    var onCommit: (Slug?, String) -> Void
     var onCancel: () -> Void
 
     var body: some View {

--- a/xcode/Subconscious/Shared/Library/Slashlink.swift
+++ b/xcode/Subconscious/Shared/Library/Slashlink.swift
@@ -40,8 +40,10 @@ extension Slashlink {
     }
 
     static func slashlinkToURLString(_ text: String) -> String? {
-        let slashlink = text.slugifyString()
-        if let url = URL(string: "sub://slashlink/\(slashlink)") {
+        if
+            let slashlink = text.slugifyString(),
+            let url = URL(string: "sub://slashlink/\(slashlink)")
+        {
             return url.absoluteString
         }
         return nil
@@ -63,8 +65,10 @@ extension Slashlink {
         at base: URL,
         name: String,
         ext: String
-    ) -> URL {
-        let slug = name.slugifyString()
+    ) -> URL? {
+        guard let slug = name.slugifyString() else {
+            return nil
+        }
         let url = base.appendingFilename(name: slug, ext: ext)
         if !FileManager.default.fileExists(atPath: url.path) {
             return url

--- a/xcode/Subconscious/Shared/Models/EntryLink.swift
+++ b/xcode/Subconscious/Shared/Models/EntryLink.swift
@@ -18,9 +18,13 @@ struct EntryLink: Hashable, Identifiable {
         self.title = title
     }
 
-    init(title: String) {
-        self.title = title
-        self.slug = title.slugify()
+    init?(title: String) {
+        if let slug = title.slugify() {
+            self.title = title
+            self.slug = slug
+        } else {
+            return nil
+        }
     }
 
     var id: Slug { slug }

--- a/xcode/Subconscious/Shared/Models/Slug.swift
+++ b/xcode/Subconscious/Shared/Models/Slug.swift
@@ -15,9 +15,12 @@ typealias Slug = String
 
 extension String {
     /// Slugify a string, returning a slug.
-    func slugify() -> Slug {
-        self
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+    func slugify() -> Slug? {
+        let trimmed = self.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
             .lowercased()
             // Replace runs of one or more space with a single dash
             .replacingOccurrences(
@@ -39,13 +42,14 @@ extension String {
 
     /// Slugify a string, returning a string.
     /// For now, this is just a proxy to toSlug.
-    func slugifyString() -> String {
+    func slugifyString() -> String? {
         self.slugify()
     }
 }
 
 extension URL {
-    /// Convert URL to slug
+    /// Convert URL to a slug.
+    /// In other words, return the last path component without the extension.
     func toSlug() -> Slug {
         self.deletingPathExtension().lastPathComponent
     }


### PR DESCRIPTION
Fixes https://github.com/gordonbrander/subconscious/issues/73

Change `slugify` to return a `Slug?` so that we can handle invalid input
strings such as all-whitespace strings.

- Update the various callsites for new type signature.
- New submitSearch action takes an optional slug
- requestDetail requires a concrete slug

Together these changes allow us to gracefully reject whitespace queries
in search-or-create.