### PR TITLE
Make list rows more compact

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
@@ -17,7 +17,7 @@ struct EntryRow: View {
             HStack {
                 Text(entry.title)
                     .font(Font.appText)
-                    .lineLimit(2)
+                    .lineLimit(1)
                     .foregroundColor(Color.text)
                     .multilineTextAlignment(.leading)
                 Spacer()
@@ -25,7 +25,7 @@ struct EntryRow: View {
             HStack {
                 Text(entry.excerpt)
                     .font(Font.appText)
-                    .lineLimit(3)
+                    .lineLimit(2)
                     .foregroundColor(Color.secondaryText)
                     .multilineTextAlignment(.leading)
                 Spacer()


### PR DESCRIPTION
1 line for title
2 lines for content

This is closer to most iOS apps.