### PR TITLE
Fix note creation on link click

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/SuggestionLabelView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SuggestionLabelView.swift
@@ -9,9 +9,10 @@ import SwiftUI
 
 struct SuggestionLabelView: View {
     var suggestion: Suggestion
+    var untitled = "Empty"
 
     private func readTitle(_ text: String) -> String {
-        text.isEmpty ? "Untitled" : text
+        text.isEmpty ? untitled : text
     }
 
     var body: some View {

--- a/xcode/Subconscious/Shared/Components/Common/ToolbarTitleGroupView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/ToolbarTitleGroupView.swift
@@ -10,16 +10,17 @@ import SwiftUI
 struct ToolbarTitleGroupView: View {
     var title: String
     var slug: Slug?
+    var untitled = "Empty"
     var body: some View {
         HStack {
             Spacer()
             VStack(spacing: AppTheme.unit) {
-                Text(title.isEmpty ? "Untitled" : title)
+                Text(title.isEmpty ? untitled : title)
                     .font(Font(UIFont.appText))
                     .foregroundColor(Color.text)
                     .frame(height: AppTheme.textSize)
                     .lineLimit(1)
-                Text(slug?.description ?? "untitled")
+                Text(slug?.description ?? untitled)
                     .font(Font(UIFont.appCaption))
                     .frame(height: AppTheme.captionSize)
                     .foregroundColor(Color.secondaryText)

--- a/xcode/Subconscious/Shared/Models/EntryStub.swift
+++ b/xcode/Subconscious/Shared/Models/EntryStub.swift
@@ -9,7 +9,11 @@ import Foundation
 
 /// A EntryLink is a model that contains a title and slug description of a note
 /// suitable for list views.
-struct EntryStub: Hashable, Identifiable {
+struct EntryStub: Hashable, Identifiable, CustomDebugStringConvertible {
+    var debugDescription: String {
+        "Subconscious.EntryStub(\(slug))"
+    }
+
     var slug: Slug
     var title: String
     var excerpt: String


### PR DESCRIPTION
Notes were not being created for link clicks when they didn't exist. This PR fixes that by resolving a bug in setEditorDom.

- Remove guard from setEditorDom that was preventing notes from being
  saved when they should be. Fixes link click problem.
- Change "untitled" to "empty"
- Add custom debug string for EntryStubs. They were clogging the log to
  an extent that it was truncating the model. Did this to troubleshoot.
- Don't select links when tapping in edit mode. This was causing
  problems with not being able to edit slashlinks.