### PR TITLE
Change link search to prefix search

### DIFF
--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -508,10 +508,10 @@ struct DatabaseService {
                     FROM entry_search
                     WHERE entry_search MATCH ?
                     ORDER BY rank
-                    LIMIT 5
+                    LIMIT 25
                     """,
                     parameters: [
-                        .queryFTS5(sluglike)
+                        .prefixQueryFTS5(sluglike)
                     ]
                 )
                 .compactMap({ row in


### PR DESCRIPTION
Fixes #151 

Also increase limit to 25 for searches across the board.

We do a prefix search over entire contents of note, not just title and slug. This is good enough for now. To do better would require indexing a separate table, and at least so far there is no reason to believe there will be performance impact.