### PR TITLE
Fix link search getting blown away by save

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -1507,8 +1507,17 @@ struct AppUpdate {
         let sluglike = Slug.sanitizeString(text).unwrap(or: "")
         model.linkSearchText = sluglike
 
+        // Omit current slug from results
+        let omitting = state.slug.mapOr(
+            { slug in Set([slug]) },
+            default: Set()
+        )
+
         let fx: Fx<AppAction> = environment.database
-            .searchLinkSuggestions(query: text)
+            .searchLinkSuggestions(
+                query: text,
+                omitting: omitting
+            )
             .map({ suggestions in
                 AppAction.setLinkSuggestions(suggestions)
             })

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -533,7 +533,8 @@ struct DatabaseService {
     /// Fetch search suggestions
     /// A whitespace query string will fetch zero-query suggestions.
     func searchLinkSuggestions(
-        query: String
+        query: String,
+        omitting invalidSuggestions: Set<Slug> = Set()
     ) -> AnyPublisher<[LinkSuggestion], Error> {
         CombineUtilities.async(qos: .userInitiated) {
             guard let sluglike = Slug.sanitizeString(query) else {
@@ -578,7 +579,11 @@ struct DatabaseService {
             // If literal query and an entry have the same slug,
             // entry will overwrite query.
             for entry in entries {
-                suggestions.updateValue(.entry(entry), forKey: entry.slug)
+                // Only insert suggestion if it is not in the set of
+                // suggestions to omit.
+                if !invalidSuggestions.contains(entry.slug) {
+                    suggestions.updateValue(.entry(entry), forKey: entry.slug)
+                }
             }
 
             return Array(suggestions.values)


### PR DESCRIPTION
Fixes #168 

Maintain search field state when `.refreshAll`.