### PR TITLE
Toggle fab on/off with disabled

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -11,6 +11,9 @@ import SwiftUI
 struct AppView: View {
     @ObservedObject var store: AppStore
     @Environment(\.scenePhase) var scenePhase: ScenePhase
+    var isFabPresented: Bool {
+        store.state.focus == nil
+    }
 
     var body: some View {
         // Give each element in this ZStack an explicit z-index.
@@ -26,29 +29,28 @@ struct AppView: View {
             if store.state.isReadyForInteraction {
                 AppNavigationView(store: store)
                     .zIndex(1)
-                if store.state.focus == nil {
-                    Button(
-                        action: {
-                            withAnimation(
-                                .easeOutCubic(duration: Duration.keyboard)
-                            ) {
-                                store.send(action: .showSearch)
-                            }
-                        },
-                        label: {
-                            Image(systemName: "doc.text.magnifyingglass")
-                                .font(.system(size: 20))
+                Button(
+                    action: {
+                        withAnimation(
+                            .easeOutCubic(duration: Duration.keyboard)
+                        ) {
+                            store.send(action: .showSearch)
                         }
+                    },
+                    label: {
+                        Image(systemName: "doc.text.magnifyingglass")
+                            .font(.system(size: 20))
+                    }
+                )
+                .buttonStyle(
+                    FABButtonStyle(
+                        orbShaderEnabled:
+                            store.state.config.orbShaderEnabled
                     )
-                    .buttonStyle(
-                        FABButtonStyle(
-                            orbShaderEnabled:
-                                store.state.config.orbShaderEnabled
-                        )
-                    )
-                    .padding()
-                    .zIndex(2)
-                }
+                )
+                .padding()
+                .disabled(!isFabPresented)
+                .zIndex(2)
                 ModalView(
                     isPresented: store.binding(
                         get: \.isSearchShowing,

--- a/xcode/Subconscious/Shared/Components/Common/FABButtonStyle.swift
+++ b/xcode/Subconscious/Shared/Components/Common/FABButtonStyle.swift
@@ -55,6 +55,11 @@ struct FABButtonStyle: ButtonStyle {
             .easeOutCubic(duration: Duration.fast),
             value: configuration.isPressed
         )
+        .animation(
+            .easeOutCubic(duration: Duration.keyboard),
+            value: isEnabled
+        )
+        .opacity(isEnabled ? 1 : 0)
         .transition(
             .opacity.combined(
                 with: .scale(scale: 0.8, anchor: .center)


### PR DESCRIPTION
This makes FAB lifecycle as long as the app, and means that the shader
is not recreated, reset.