### PR TITLE
New subsurface look

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/FABButtonStyle.swift
+++ b/xcode/Subconscious/Shared/Components/Common/FABButtonStyle.swift
@@ -15,7 +15,7 @@ struct FABButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         ZStack {
             if orbShaderEnabled {
-                SubsurfaceView(speed: 0.05, density: 0.25, corner_radius: 64)
+                SubsurfaceView(speed: 0.05, density: 0.75, corner_radius: 64)
                     .clipped()
                     .clipShape(Circle())
                     .frame(

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/cdata/SwiftSubsurface",
         "state": {
           "branch": "main",
-          "revision": "fda863143a048db43d8bbb0bba451a177cc07527",
+          "revision": "e7f5e8dbedf94a8f53df0bebad7389893ca961b3",
           "version": null
         }
       }


### PR DESCRIPTION
This change tweaks the usage of SwiftSubsurface in order to better fit the new shader look implemented in cdata/subconscious-rs#2. It also updates the package revision to the latest change.