### PR TITLE
Fade in transition when clicking link

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppNavigationView.swift
+++ b/xcode/Subconscious/Shared/Components/AppNavigationView.swift
@@ -60,6 +60,7 @@ struct AppNavigationView: View {
                     destination: {
                         DetailView(
                             slug: store.state.slug,
+                            isLoading: store.state.isDetailLoading,
                             backlinks: store.state.backlinks,
                             linkSuggestions: store.state.linkSuggestions,
                             focus: store.binding(


### PR DESCRIPTION
We were previously getting occasional "jumps" and even what looked like brief gfx tears when clicking links. This PR resolves the issue by reducing the amount of render thrashing, and by placing a scrim over the contents that change, and fading it out when the next detail state is ready.

Implementation:
UIViewRepresentable seems unable to play nicely with SwiftUI animations.
Given this, we instead overlay a white rect, show it immediately when
clicking a link, then fade it out.

We also introduce "isDetailLoading" flag that allows us to show loading
scrim without resetting editor. This prevents a reflow of the contents
of the editor, and avoids the visual tearing that we were getting.

The result is a smooth animated transition between detail states.