### PR TITLE
Change fade scrim to background color

### DIFF
--- a/xcode/Subconscious/Shared/Components/DetailView.swift
+++ b/xcode/Subconscious/Shared/Components/DetailView.swift
@@ -46,7 +46,7 @@ struct DetailView: View {
     var body: some View {
         ZStack {
             if isLoading || slug == nil {
-                Color.white
+                Color.background
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .transition(
                         .asymmetric(


### PR DESCRIPTION
We were using `Color.white`, which doesn't work in dark mode. 🤦‍♂️