### PR TITLE
Check intended focus field before setting focus nil

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppNavigationView.swift
+++ b/xcode/Subconscious/Shared/Components/AppNavigationView.swift
@@ -65,7 +65,12 @@ struct AppNavigationView: View {
                             linkSuggestions: store.state.linkSuggestions,
                             focus: store.binding(
                                 get: \.focus,
-                                tag: AppAction.setFocus
+                                tag: { focus in
+                                    AppAction.setFocus(
+                                        focus: focus,
+                                        field: .editor
+                                    )
+                                }
                             ),
                             editorText: store.binding(
                                 get: \.editorText,

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -65,7 +65,12 @@ struct AppView: View {
                         ),
                         focus: store.binding(
                             get: \.focus,
-                            tag: AppAction.setFocus
+                            tag: { focus in
+                                AppAction.setFocus(
+                                    focus: focus,
+                                    field: .search
+                                )
+                            }
                         ),
                         suggestions: store.binding(
                             get: \.suggestions,
@@ -107,7 +112,12 @@ struct AppView: View {
                         ),
                         focus: store.binding(
                             get: \.focus,
-                            tag: AppAction.setFocus
+                            tag: { focus in
+                                AppAction.setFocus(
+                                    focus: focus,
+                                    field: .rename
+                                )
+                            }
                         ),
                         onCancel: {
                             store.send(action: .hideRenameSheet)
@@ -134,7 +144,12 @@ struct AppView: View {
                         ),
                         focus: store.binding(
                             get: \.focus,
-                            tag: AppAction.setFocus
+                            tag: { focus in
+                                AppAction.setFocus(
+                                    focus: focus,
+                                    field: .linkSearch
+                                )
+                            }
                         ),
                         onCancel: {
                             store.send(

--- a/xcode/Subconscious/Shared/Components/DetailView.swift
+++ b/xcode/Subconscious/Shared/Components/DetailView.swift
@@ -133,7 +133,7 @@ struct DetailView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             DetailToolbarContent(
-                isEditing: (focus == .editor),
+                isEditing: isKeyboardUp,
                 title: Subtext(markup: editorText).title(),
                 slug: slug,
                 onRename: onRename,


### PR DESCRIPTION
Introduce `field` field to setFocus. When focus is resigned, we check
that the current focus state is actually the field that is expected
before setting nil. If it is some other state, we leave it alone.

In general nil focus means "relinquish my focus", not "relinquish all
focus". Since focus APIs are async, this distinction matters. If we're
trying to resign focus and someone else has taken focus in the meantime,
then we consider it job well done, and leave the state alone. This
prevents race conditions where the focus state gets stomped.

This PR also removes `resignFocus` in favor of using `setFocus` everywhere, since now `setFocus` has essentially the same behavior as `resignFocus` in cases where the focus being set is nil.

Fixes https://github.com/gordonbrander/subconscious/issues/242