### PR TITLE
Introduce short log strings for actions

### DIFF
--- a/xcode/Subconscious/Shared/SubconsciousApp.swift
+++ b/xcode/Subconscious/Shared/SubconsciousApp.swift
@@ -175,7 +175,7 @@ extension AppAction {
         case .setRenameSuggestions(let items):
             return "setRenameSuggestions(...) (\(items.count) items)"
         case .updateDetail(let detail):
-            return "updateDetail(\(detail.slug))"
+            return "updateDetail(\(detail.slug)) (saved state: \(detail.entry.state))"
         default:
             return String(describing: self)
         }


### PR DESCRIPTION
This PR changes logging in the following ways:

- Actions are always logged
- Introduce `AppAction.toLogString()`, a new extension method that generates an approximately one-line string suitable for logging. This gives us an opportunity to create shorter log messages for chattier actions, like those which pass around long lists.

Logging state is still behind a `Config.debug` flag.

Note that actions are still `log.debug`, which means they are only output in memory, not saved to disk. We may wish to change this in future.