### PR TITLE
Remove buttonStyle(.plain) from cancel

### DIFF
--- a/xcode/Subconscious/Shared/Components/SearchView.swift
+++ b/xcode/Subconscious/Shared/Components/SearchView.swift
@@ -56,7 +56,7 @@ struct SearchView: View {
                     label: {
                         Text("Cancel")
                     }
-                ).buttonStyle(.plain)
+                )
             }
             .frame(height: AppTheme.unit * 10)
             .padding(AppTheme.tightPadding)


### PR DESCRIPTION
Allows cancel button to inherit accent color.