### PR TITLE
Call first responder method sync in makeUIView

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/MarkupTextViewRepresentable.swift
+++ b/xcode/Subconscious/Shared/Components/Common/MarkupTextViewRepresentable.swift
@@ -251,7 +251,7 @@ where Focus: Hashable
         // and an NSTextStorageDelegate.
         // Set delegate on textview (coordinator)
         view.delegate = context.coordinator
-        // Set delegate on textstorage (coordinator).
+        // Set delegate on textstorage (coordinator)
         view.textStorage.delegate = context.coordinator
 
         // Set inner padding


### PR DESCRIPTION
Fixes https://github.com/gordonbrander/subconscious/issues/253

Follow-up to #251.

Fixes keyboard tearing for NavigationView animation while still allowing
us to call first responder change methods async in updateUIView, fixing
attribute graph cycle warnings.