### PR TITLE
Fix renaming deep slugs

### DIFF
--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -206,9 +206,13 @@ struct DatabaseService {
 
     /// Rename file in file system
     private func moveEntryFile(from: Slug, to: Slug) throws {
-        let fromURL = from.toURL(directory: documentURL, ext: "subtext")
-        let toURL = to.toURL(directory: documentURL, ext: "subtext")
-        try FileManager.default.moveItem(at: fromURL, to: toURL)
+        let fromFile = try SubtextFile(slug: from, directory: documentURL)
+            .unwrap()
+        let toFile = SubtextFile(slug: to, content: fromFile.content)
+        try toFile.write(directory: documentURL)
+        try FileManager.default.removeItem(
+            at: fromFile.url(directory: documentURL)
+        )
     }
 
     /// Merge two files together


### PR DESCRIPTION
Fixes https://github.com/gordonbrander/subconscious/issues/263

Previously we used file manager's removeEntry method to move the file,
but this is unable to create interim directories where needed.

This new approach uses the same logic as creating a new note. It first
reads the contents of the old note, then creates a new note with the old
contents at the new locations, writes it, then deletes the old one.