### PR TITLE
Fix slashlink parsing after multiple spaces

### DIFF
--- a/xcode/Subconscious/Shared/Library/Subtext.swift
+++ b/xcode/Subconscious/Shared/Library/Subtext.swift
@@ -147,7 +147,9 @@ struct Subtext: Hashable, Equatable {
     }
 
     /// Consume a well-formed bracket link, or else backtrack
-    private static func consumeBracketLink(tape: inout Tape<Substring>) -> Substring? {
+    private static func consumeBracketLink(
+        tape: inout Tape<Substring>
+    ) -> Substring? {
         tape.save()
         while !tape.isExhausted() {
             if tape.consumeMatch(" ") {
@@ -376,9 +378,9 @@ struct Subtext: Hashable, Equatable {
         if tape.consumeMatch("/") {
             let span = consumeSlashlinkBody(tape: &tape)
             return .slashlink(Slashlink(span: span))
-        } else {
-            return nil
         }
+        tape.backtrack()
+        return nil
     }
 
     /// Consume inline forms that are not sensitive to word boundaries

--- a/xcode/Subconscious/SubconsciousTests/Tests_Subtext.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Subtext.swift
@@ -284,6 +284,38 @@ class Tests_Subtext: XCTestCase {
         )
     }
 
+    func testSlashlinkParsingTwoSpaces() throws {
+        let markup = "Some text with a  /slashlink that has two spaces preceding."
+        let dom = Subtext(markup: markup)
+
+        guard case let .slashlink(slashlink) = dom.blocks[0].inline.get(0) else {
+            XCTFail("Expected slashlink")
+            return
+        }
+
+        XCTAssertEqual(
+            String(describing: slashlink),
+            "/slashlink",
+            "Slashlink parses successfully"
+        )
+    }
+
+    func testSlashlinkParsingThreeSpaces() throws {
+        let markup = "Some text with a   /slashlink that has three spaces preceding."
+        let dom = Subtext(markup: markup)
+
+        guard case let .slashlink(slashlink) = dom.blocks[0].inline.get(0) else {
+            XCTFail("Expected slashlink")
+            return
+        }
+
+        XCTAssertEqual(
+            String(describing: slashlink),
+            "/slashlink",
+            "Slashlink parses successfully"
+        )
+    }
+
     func testWikilinkParsing0() throws {
         let markup = """
         Let's test out some [[wikilinks]].


### PR DESCRIPTION
We neglected to backtrack in the previous implementation, leading to
more than one space being discarded in some cases. This meant that an
even number of leading spaces would cause slashlinks not to be detected.

This fix backtracks if inlineWordBoundaryForm returns nil, fixing the
problem.

Added tests as well.