### PR TITLE
Fix backtrack infinite loop in slashlink parse

### DIFF
--- a/xcode/Subconscious/Shared/Library/Subtext.swift
+++ b/xcode/Subconscious/Shared/Library/Subtext.swift
@@ -374,7 +374,7 @@ struct Subtext: Hashable, Equatable {
         guard isAtStart || tape.consumeMatch(" ") else {
             return nil
         }
-        tape.start()
+        tape.save()
         if tape.consumeMatch("/") {
             let span = consumeSlashlinkBody(tape: &tape)
             return .slashlink(Slashlink(span: span))

--- a/xcode/Subconscious/SubconsciousTests/Tests_Subtext.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Subtext.swift
@@ -316,6 +316,47 @@ class Tests_Subtext: XCTestCase {
         )
     }
 
+    func testSlashlinkLineBreak() throws {
+        let markup = """
+        Some text
+        /slashlink
+        /another-slashlink
+        /a-third-slashlink followed by some text
+        """
+        let dom = Subtext(markup: markup)
+
+        guard case let .slashlink(slashlink1) = dom.blocks[1].inline[0] else {
+            XCTFail("Expected slashlink")
+            return
+        }
+
+        guard case let .slashlink(slashlink2) = dom.blocks[2].inline[0] else {
+            XCTFail("Expected slashlink")
+            return
+        }
+
+        guard case let .slashlink(slashlink3) = dom.blocks[3].inline[0] else {
+            XCTFail("Expected slashlink")
+            return
+        }
+
+        XCTAssertEqual(
+            String(describing: slashlink1),
+            "/slashlink",
+            "Slashlink parses successfully"
+        )
+        XCTAssertEqual(
+            String(describing: slashlink2),
+            "/another-slashlink",
+            "Slashlink parses successfully"
+        )
+        XCTAssertEqual(
+            String(describing: slashlink3),
+            "/a-third-slashlink",
+            "Slashlink parses successfully"
+        )
+    }
+
     func testWikilinkParsing0() throws {
         let markup = """
         Let's test out some [[wikilinks]].


### PR DESCRIPTION
We mistakenly called `tape.start()` instead of `tape.save()` in
`consumeInlineWordBoundaryForm`. This caused an infinite loop when the
slashlink was placed at the beginning of the line, because backtracking
would jump to the beginning of the line, then go again, etc.

This PR fixes the mistake and also adds regression tests.

Followup to https://github.com/gordonbrander/subconscious/pull/294