### PR TITLE
Make many shared components equatable

### DIFF
--- a/xcode/Subconscious/Shared/Components/BacklinksView.swift
+++ b/xcode/Subconscious/Shared/Components/BacklinksView.swift
@@ -34,6 +34,7 @@ struct BacklinksView: View {
                         },
                         label: {
                             EntryRow(entry: entry)
+                                .equatable()
                         }
                     )
                     .buttonStyle(BacklinkButtonStyle())

--- a/xcode/Subconscious/Shared/Components/Common/CountChip.swift
+++ b/xcode/Subconscious/Shared/Components/Common/CountChip.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct CountChip: View {
+struct CountChip: View, Equatable {
     var count: Int?
 
     private static func asText(count: Int?) -> String {

--- a/xcode/Subconscious/Shared/Components/Common/DragHandleView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/DragHandleView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct DragHandleView: View {
+struct DragHandleView: View, Equatable {
     var body: some View {
         Capsule()
             .foregroundColor(.tertiaryIcon)

--- a/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 /// An EntryRow suitable for use in lists.
 /// Provides a preview/excerpt of the entry.
-struct EntryRow: View {
+struct EntryRow: View, Equatable {
     var entry: EntryStub
     var emptyTitle = "Untitled"
     var emptyExcerpt = "No additional text"

--- a/xcode/Subconscious/Shared/Components/Common/LinkSuggestionLabelView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/LinkSuggestionLabelView.swift
@@ -7,8 +7,9 @@
 
 import SwiftUI
 
-struct LinkSuggestionLabelView: View {
+struct LinkSuggestionLabelView: View, Equatable {
     var suggestion: LinkSuggestion
+
     var body: some View {
         switch suggestion {
         case .entry(let link):

--- a/xcode/Subconscious/Shared/Components/Common/PlaceholderTextView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/PlaceholderTextView.swift
@@ -13,6 +13,7 @@ struct PlaceholderTextView: View {
     @Binding var isFocused: Bool
     var placeholder: String
     var font: UIFont = UIFont.preferredFont(forTextStyle: .body)
+
     var body: some View {
         ZStack {
             VStack(alignment: .leading) {

--- a/xcode/Subconscious/Shared/Components/Common/ProgressScrimView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/ProgressScrimView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 /// A progress view that takes up the whole space of its parent
-struct ProgressScrimView: View {
+struct ProgressScrimView: View, Equatable {
     var body: some View {
         VStack(alignment: .center) {
             Spacer()

--- a/xcode/Subconscious/Shared/Components/Common/RenameSuggestionLabelView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/RenameSuggestionLabelView.swift
@@ -7,8 +7,9 @@
 
 import SwiftUI
 
-struct RenameSuggestionLabelView: View {
+struct RenameSuggestionLabelView: View, Equatable {
     var suggestion: RenameSuggestion
+
     var body: some View {
         switch suggestion {
         case .merge(let entryLink):

--- a/xcode/Subconscious/Shared/Components/Common/ScrimView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/ScrimView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 /// A semi-transparent overlay scrim for use in modals
-struct ScrimView: View {
+struct ScrimView: View, Equatable {
     var body: some View {
         Rectangle()
             .foregroundColor(Color.scrim)

--- a/xcode/Subconscious/Shared/Components/Common/SuggestionLabelView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SuggestionLabelView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct SuggestionLabelView: View {
+struct SuggestionLabelView: View, Equatable {
     var suggestion: Suggestion
     var untitled = "Untitled"
 

--- a/xcode/Subconscious/Shared/Components/Common/ThickDividerView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/ThickDividerView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct ThickDividerView: View {
+struct ThickDividerView: View, Equatable {
     var body: some View {
         Color.secondaryBackground
             .frame(height: AppTheme.unit2)

--- a/xcode/Subconscious/Shared/Components/Common/TitleGroupView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/TitleGroupView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// A title/subtitle pair.
 /// Often used in list views.
 /// Each line is at least 1 icon in height.
-struct TitleGroupView: View {
+struct TitleGroupView: View, Equatable {
     var title: Text
     var subtitle: Text
     var lineHeight: CGFloat = AppTheme.icon

--- a/xcode/Subconscious/Shared/Components/Common/ToolbarTitleGroupView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/ToolbarTitleGroupView.swift
@@ -7,10 +7,11 @@
 
 import SwiftUI
 
-struct ToolbarTitleGroupView: View {
+struct ToolbarTitleGroupView: View, Equatable {
     var title: String
     var slug: Slug?
     var untitled = "Untitled"
+
     var body: some View {
         HStack {
             Spacer()

--- a/xcode/Subconscious/Shared/Components/EntryListView.swift
+++ b/xcode/Subconscious/Shared/Components/EntryListView.swift
@@ -24,6 +24,7 @@ struct EntryListView: View {
                             }
                         ) {
                             EntryRow(entry: entry)
+                                .equatable()
                         }
                         .modifier(RowViewModifier())
                         .swipeActions(

--- a/xcode/Subconscious/Shared/Components/LinkSearchView.swift
+++ b/xcode/Subconscious/Shared/Components/LinkSearchView.swift
@@ -43,6 +43,7 @@ struct LinkSearchView: View {
                     },
                     label: {
                         LinkSuggestionLabelView(suggestion: suggestion)
+                            .equatable()
                     }
                 )
                 .modifier(SuggestionViewModifier())

--- a/xcode/Subconscious/Shared/Components/RenameSearchView.swift
+++ b/xcode/Subconscious/Shared/Components/RenameSearchView.swift
@@ -52,6 +52,7 @@ struct RenameSearchView: View {
                     },
                     label: {
                         RenameSuggestionLabelView(suggestion: suggestion)
+                            .equatable()
                     }
                 )
                 .modifier(SuggestionViewModifier())

--- a/xcode/Subconscious/Shared/Components/SearchView.swift
+++ b/xcode/Subconscious/Shared/Components/SearchView.swift
@@ -64,6 +64,7 @@ struct SearchView: View {
                     },
                     label: {
                         SuggestionLabelView(suggestion: suggestion)
+                            .equatable()
                     }
                 )
                 .modifier(

--- a/xcode/Subconscious/Shared/Models/EntryStub.swift
+++ b/xcode/Subconscious/Shared/Models/EntryStub.swift
@@ -9,7 +9,12 @@ import Foundation
 
 /// A EntryLink is a model that contains a title and slug description of a note
 /// suitable for list views.
-struct EntryStub: Hashable, Identifiable, CustomDebugStringConvertible {
+struct EntryStub:
+    Hashable,
+    Equatable,
+    Identifiable,
+    CustomDebugStringConvertible
+{
     var debugDescription: String {
         "Subconscious.EntryStub(\(slug))"
     }

--- a/xcode/Subconscious/Shared/Models/LinkSuggestion.swift
+++ b/xcode/Subconscious/Shared/Models/LinkSuggestion.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 enum LinkSuggestion:
-Hashable,
-Equatable,
-Identifiable,
-CustomStringConvertible
+    Hashable,
+    Equatable,
+    Identifiable,
+    CustomStringConvertible
 {
     case entry(EntryLink)
     case new(EntryLink)

--- a/xcode/Subconscious/Shared/Models/RenameSuggestion.swift
+++ b/xcode/Subconscious/Shared/Models/RenameSuggestion.swift
@@ -7,7 +7,12 @@
 
 import Foundation
 
-enum RenameSuggestion: Hashable, Identifiable, CustomStringConvertible {
+enum RenameSuggestion:
+    Hashable,
+    Equatable,
+    Identifiable,
+    CustomStringConvertible
+{
     case rename(EntryLink)
     case merge(EntryLink)
 

--- a/xcode/Subconscious/Shared/Models/Suggestion.swift
+++ b/xcode/Subconscious/Shared/Models/Suggestion.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum Suggestion: Hashable, Identifiable {
+enum Suggestion: Hashable, Equatable, Identifiable {
     case entry(EntryLink)
     case search(EntryLink)
     case journal(EntryLink)


### PR DESCRIPTION
Equatable views can be decorated with `.equatable()`, meaning their body will not be re-evaluated unless the equatable value of the struct changes.