### PR TITLE
Refactor Subtext w/ isAtBeginning

### DIFF
--- a/xcode/Subconscious/Shared/Library/Tape.swift
+++ b/xcode/Subconscious/Shared/Library/Tape.swift
@@ -23,9 +23,8 @@ where T: Collection,
         self.savedIndex = collection.startIndex
     }
 
-    /// Get current subsequence
-    var subsequence: T.SubSequence {
-        collection[startIndex..<currentIndex]
+    var isAtBeginning: Bool {
+        self.startIndex == self.collection.startIndex
     }
 
     func isExhausted() -> Bool {


### PR DESCRIPTION
This allows us to check for the equivalent of `^` in Regex terms.

This simplifies the while loop, and allows us to get rid of the "inline forms" function.