### PR TITLE
Remove syntax that was causing Swift compiler crash

### DIFF
--- a/xcode/Subconscious/Shared/Components/RenameSearchView.swift
+++ b/xcode/Subconscious/Shared/Components/RenameSearchView.swift
@@ -51,7 +51,6 @@ struct RenameSearchView: View {
                     },
                     label: {
                         RenameSuggestionLabelView(suggestion: suggestion)
-                            .equatable()
                     }
                 )
                 .modifier(SuggestionViewModifier())

--- a/xcode/Subconscious/Shared/Components/SearchView.swift
+++ b/xcode/Subconscious/Shared/Components/SearchView.swift
@@ -64,7 +64,6 @@ struct SearchView: View {
                     },
                     label: {
                         SuggestionLabelView(suggestion: suggestion)
-                            .equatable()
                     }
                 )
                 .modifier(


### PR DESCRIPTION
For whatever wild reason, Swift and Xcode 13.4.1 (13F100) decided that these particular instances of `.equatable()` chaining were something to throw a `error: Bus error: 10 (in target 'Subconscious (iOS)' from project 'Subconscious')` over. This would only happen when Archiving the build.

Fixed by removing.