### PR TITLE
Add short log string for succeedSaveEntry

### DIFF
--- a/xcode/Subconscious/Shared/Components/Notebook.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook.swift
@@ -145,6 +145,8 @@ extension NotebookAction: CustomLogStringConvertible {
             return "search(\(String.loggable(action)))"
         case .setRecent(let items):
             return "setRecent(\(items.count) items)"
+        case .succeedSaveEntry(let entry):
+            return "succeedSaveEntry(\(entry.slug))"
         default:
             return String(describing: self)
         }


### PR DESCRIPTION
This PR adds a short log string for `NotebookAction.succeedSaveEntry` to keep the logs tidy.

Since Notebook intercepts `DetailAction.succeedSave` in order to refresh lists, we need to handle the log string at this level too.