### PR TITLE
ComboGeist - randomly juxtapose two notes

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/StoryComboView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/StoryComboView.swift
@@ -27,6 +27,8 @@ struct StoryComboView: View {
             .frame(height: AppTheme.unit * 11)
             Divider()
             VStack(alignment: .leading, spacing: AppTheme.unit4) {
+                Text(story.prompt)
+                
                 Button(
                     action: {
                         action(story.entryA.link, story.entryA.linkableTitle)
@@ -73,6 +75,7 @@ struct StoryComboView_Previews: PreviewProvider {
     static var previews: some View {
         StoryComboView(
             story: StoryCombo(
+                prompt: "How are these similar?",
                 entryA: EntryStub(
                     SubtextFile(
                         slug: Slug("meme")!,

--- a/xcode/Subconscious/Shared/Components/Common/StoryComboView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/StoryComboView.swift
@@ -29,7 +29,9 @@ struct StoryComboView: View {
             \(first.toSlashlink()) \(second.toSlashlink())
             """
         
-        guard let slug = Slug(formatting: "\(first) \(second)") else { return }
+        guard let slug = Slug(formatting: "\(first) \(second)") else {
+            return
+        }
         let link = EntryLink.init(slug: slug)
         
         action(link, content)

--- a/xcode/Subconscious/Shared/Components/Common/StoryComboView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/StoryComboView.swift
@@ -12,13 +12,24 @@ struct StoryComboView: View {
     var story: StoryCombo
     var action: (EntryLink, String) -> Void
     
+    /// Sort entries by slug
+    /// (this should be factored out eventually)
+    func orderedSlugPair() -> (Slug, Slug) {
+        var entries = [story.entryA.slug, story.entryB.slug]
+        entries.sort(by: { $0.description < $1.description })
+        
+        return (entries[0], entries[1])
+    }
+    
+    /// Construct combined slug and default content, then open editor
     func synthesize() {
-        let slug = "combo/\(story.entryA.slug.description)/\(story.entryB.slug.description)"
+        let (first, second) = orderedSlugPair()
+        let slug = "\(first.description)-\(second.description)"
         let content =
             """
             \(story.prompt)
             
-            \(story.entryA.slug.toSlashlink()) \(story.entryB.slug.toSlashlink())
+            \(first.toSlashlink()) \(second.toSlashlink())
             """
         
         guard let link = EntryLink.init(title: slug) else { return }

--- a/xcode/Subconscious/Shared/Components/Common/StoryComboView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/StoryComboView.swift
@@ -10,8 +10,7 @@ import SwiftUI
 /// A story is a single update within the FeedView
 struct StoryComboView: View {
     var story: StoryCombo
-    var viewAction: (EntryLink) -> Void
-    var synthesizeAction: (EntryLink, EntryLink) -> Void
+    var action: (EntryLink, String) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -30,7 +29,7 @@ struct StoryComboView: View {
             VStack(alignment: .leading, spacing: AppTheme.unit4) {
                 Button(
                     action: {
-                        viewAction(story.entryA.link)
+                        action(story.entryA.link, story.entryA.linkableTitle)
                     },
                     label: {
                         TranscludeView(entry: story.entryA)
@@ -40,7 +39,7 @@ struct StoryComboView: View {
                 
                 Button(
                     action: {
-                        viewAction(story.entryB.link)
+                        action(story.entryB.link, story.entryB.linkableTitle)
                     },
                     label: {
                         TranscludeView(entry: story.entryB)
@@ -55,7 +54,7 @@ struct StoryComboView: View {
                 // pop open a new note with the other two notes already transcluded in it
                 Button(
                     action: {
-                        synthesizeAction(story.entryA.link, story.entryB.link)
+                        action(story.entryA.link, story.entryA.linkableTitle)
                     },
                     label: {
                         Text("Synthesize")
@@ -101,8 +100,7 @@ struct StoryComboView_Previews: PreviewProvider {
                     )
                 )
             ),
-            viewAction: { entryA in },
-            synthesizeAction: { entryA, entryB in }
+            action: { link, fallback in }
         )
     }
 }

--- a/xcode/Subconscious/Shared/Components/Common/StoryComboView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/StoryComboView.swift
@@ -59,7 +59,7 @@ struct StoryComboView: View {
                         action(story.entryA.link, story.entryA.linkableTitle)
                     },
                     label: {
-                        Text("Open")
+                        Text("Create")
                     }
                 )
                 Spacer()

--- a/xcode/Subconscious/Shared/Components/Common/StoryComboView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/StoryComboView.swift
@@ -59,7 +59,7 @@ struct StoryComboView: View {
                         action(story.entryA.link, story.entryA.linkableTitle)
                     },
                     label: {
-                        Text("Synthesize")
+                        Text("Open")
                     }
                 )
                 Spacer()

--- a/xcode/Subconscious/Shared/Components/Common/StoryComboView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/StoryComboView.swift
@@ -24,7 +24,6 @@ struct StoryComboView: View {
     /// Construct combined slug and default content, then open editor
     func synthesize() {
         let (first, second) = orderedSlugPair()
-        let slug = "\(first.description)-\(second.description)"
         let content =
             """
             \(story.prompt)
@@ -32,7 +31,8 @@ struct StoryComboView: View {
             \(first.toSlashlink()) \(second.toSlashlink())
             """
         
-        guard let link = EntryLink.init(title: slug) else { return }
+        guard let slug = Slug(formatting: "\(first) \(second)") else { return }
+        let link = EntryLink.init(slug: slug)
         
         action(link, content)
     }

--- a/xcode/Subconscious/Shared/Components/Common/StoryComboView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/StoryComboView.swift
@@ -11,6 +11,20 @@ import SwiftUI
 struct StoryComboView: View {
     var story: StoryCombo
     var action: (EntryLink, String) -> Void
+    
+    func synthesize() {
+        let slug = "combo/\(story.entryA.slug.description)/\(story.entryB.slug.description)"
+        let content =
+            """
+            \(story.prompt)
+            
+            \(story.entryA.slug.toSlashlink()) \(story.entryB.slug.toSlashlink())
+            """
+        
+        guard let link = EntryLink.init(title: slug) else { return }
+        
+        action(link, content)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -52,12 +66,8 @@ struct StoryComboView: View {
             .padding()
             Divider()
             HStack {
-                // TODO: make this actually do something
-                // pop open a new note with the other two notes already transcluded in it
                 Button(
-                    action: {
-                        action(story.entryA.link, story.entryA.linkableTitle)
-                    },
+                    action: { synthesize() },
                     label: {
                         Text("Create")
                     }

--- a/xcode/Subconscious/Shared/Components/Common/StoryComboView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/StoryComboView.swift
@@ -12,9 +12,7 @@ struct StoryComboView: View {
     var story: StoryCombo
     var action: (EntryLink, String) -> Void
     
-    /// Sort entries by slug
-    /// (this should be factored out eventually)
-    func orderedSlugPair() -> (Slug, Slug) {
+    var orderedSlugPair: (Slug, Slug) {
         var entries = [story.entryA.slug, story.entryB.slug]
         entries.sort(by: { $0.description < $1.description })
         
@@ -23,7 +21,7 @@ struct StoryComboView: View {
     
     /// Construct combined slug and default content, then open editor
     func synthesize() {
-        let (first, second) = orderedSlugPair()
+        let (first, second) = orderedSlugPair
         let content =
             """
             \(story.prompt)

--- a/xcode/Subconscious/Shared/Components/Common/StoryComboView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/StoryComboView.swift
@@ -1,0 +1,108 @@
+//
+//  StoryComboView.swift
+//  Subconscious (iOS)
+//
+//  Created by Ben Follington on 24/9/2022.
+//
+
+import SwiftUI
+
+/// A story is a single update within the FeedView
+struct StoryComboView: View {
+    var story: StoryCombo
+    var viewAction: (EntryLink) -> Void
+    var synthesizeAction: (EntryLink, EntryLink) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: AppTheme.unit) {
+                Text("@bfollington")
+                Text("at")
+                    .foregroundColor(Color.secondary)
+                Text(story.entryA.modified.formatted())
+                    .foregroundColor(Color.secondary)
+                Spacer()
+            }
+            .font(Font(UIFont.appTextSmall))
+            .padding()
+            .frame(height: AppTheme.unit * 11)
+            Divider()
+            VStack(alignment: .leading, spacing: AppTheme.unit4) {
+                Button(
+                    action: {
+                        viewAction(story.entryA.link)
+                    },
+                    label: {
+                        TranscludeView(entry: story.entryA)
+                    }
+                )
+                .buttonStyle(.plain)
+                
+                Button(
+                    action: {
+                        viewAction(story.entryB.link)
+                    },
+                    label: {
+                        TranscludeView(entry: story.entryB)
+                    }
+                )
+                .buttonStyle(.plain)
+            }
+            .padding()
+            Divider()
+            HStack {
+                // TODO: make this actually do something
+                // pop open a new note with the other two notes already transcluded in it
+                Button(
+                    action: {
+                        synthesizeAction(story.entryA.link, story.entryB.link)
+                    },
+                    label: {
+                        Text("Synthesize")
+                    }
+                )
+                Spacer()
+            }
+            .padding()
+            .frame(height: AppTheme.unit * 15)
+            ThickDividerView()
+        }
+    }
+}
+
+struct StoryComboView_Previews: PreviewProvider {
+    static var previews: some View {
+        StoryComboView(
+            story: StoryCombo(
+                entryA: EntryStub(
+                    SubtextFile(
+                        slug: Slug("meme")!,
+                        content: """
+                        Title: Meme
+                        Modified: 2022-08-23
+                        
+                        The gene, the DNA molecule, happens to be the replicating entity that prevails on our own planet. There may be others.
+
+                        But do we have to go to distant worlds to find other kinds of replicator and other, consequent, kinds of evolution? I think that a new kind of replicator has recently emerged on this very planet. It is staring us in the face.
+                        """
+                    )
+                ),
+                entryB: EntryStub(
+                    SubtextFile(
+                        slug: Slug("meme")!,
+                        content: """
+                        Title: Meme
+                        Modified: 2022-08-23
+                        
+                        The gene, the DNA molecule, happens to be the replicating entity that prevails on our own planet. There may be others.
+
+                        But do we have to go to distant worlds to find other kinds of replicator and other, consequent, kinds of evolution? I think that a new kind of replicator has recently emerged on this very planet. It is staring us in the face.
+                        """
+                    )
+                )
+            ),
+            viewAction: { entryA in },
+            synthesizeAction: { entryA, entryB in }
+        )
+    }
+}

--- a/xcode/Subconscious/Shared/Components/Common/StoryView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/StoryView.swift
@@ -19,6 +19,11 @@ struct StoryView: View {
                 story: storyPrompt,
                 action: action
             )
+        case .combo(let combo):
+            StoryComboView(
+                story: combo,
+                action: action
+            )
         }
     }
 }

--- a/xcode/Subconscious/Shared/Config.swift
+++ b/xcode/Subconscious/Shared/Config.swift
@@ -49,6 +49,7 @@ struct Config: Equatable {
 
     /// Toggle on/off simple Tracery-based Geists
     var traceryZettelkasten = "zettelkasten"
+    var traceryCombo = "combo"
 }
 
 extension Config {

--- a/xcode/Subconscious/Shared/Data/Geists/combo.json
+++ b/xcode/Subconscious/Shared/Data/Geists/combo.json
@@ -1,0 +1,9 @@
+{
+  "combo_followup": [
+      "How might these be connected?",
+      "What similarities can I see between these? Differences?",
+      "Can I combine these to create something new?",
+      "Can I find three ways in which these might be connected?",
+      "What could I add to these to form a set?"
+  ]
+}

--- a/xcode/Subconscious/Shared/Data/Geists/zettelkasten.json
+++ b/xcode/Subconscious/Shared/Data/Geists/zettelkasten.json
@@ -21,6 +21,13 @@
       "What questions does this answer?",
       "What new questions does this trigger?"
   ],
+  "combo_followup": [
+      "How might these be connected?",
+      "What similarities can I see between these? Differences?",
+      "Can I combine these to create something new?",
+      "Can I find three ways in which these might be connected?",
+      "What could I add to these to form a set?"
+  ],
   "similar_followup": [
       "What are the differences between these things?",
       "In what ways are they similar?",

--- a/xcode/Subconscious/Shared/Data/Geists/zettelkasten.json
+++ b/xcode/Subconscious/Shared/Data/Geists/zettelkasten.json
@@ -21,13 +21,6 @@
       "What questions does this answer?",
       "What new questions does this trigger?"
   ],
-  "combo_followup": [
-      "How might these be connected?",
-      "What similarities can I see between these? Differences?",
-      "Can I combine these to create something new?",
-      "Can I find three ways in which these might be connected?",
-      "What could I add to these to form a set?"
-  ],
   "similar_followup": [
       "What are the differences between these things?",
       "In what ways are they similar?",

--- a/xcode/Subconscious/Shared/Models/Story.swift
+++ b/xcode/Subconscious/Shared/Models/Story.swift
@@ -10,11 +10,14 @@ import Foundation
 /// Enum of possible story types for feed
 enum Story: Hashable, Identifiable {
     case prompt(StoryPrompt)
+    case combo(StoryCombo)
 
     var id: UUID {
         switch self {
         case .prompt(let prompt):
             return prompt.id
+        case .combo(let combo):
+            return combo.id
         }
     }
 }

--- a/xcode/Subconscious/Shared/Models/StoryCombo.swift
+++ b/xcode/Subconscious/Shared/Models/StoryCombo.swift
@@ -10,11 +10,14 @@ import Foundation
 /// Story prompt model
 struct StoryCombo: Hashable, Identifiable, CustomStringConvertible {
     var id = UUID()
+    var prompt: String
     var entryA: EntryStub
     var entryB: EntryStub
 
     var description: String {
         """
+        \(prompt)
+        
         \(entryA)
         +
         \(entryB)

--- a/xcode/Subconscious/Shared/Models/StoryCombo.swift
+++ b/xcode/Subconscious/Shared/Models/StoryCombo.swift
@@ -1,0 +1,23 @@
+//
+//  StoryCombo.swift
+//  Subconscious (iOS)
+//
+//  Created by Ben Follington on 24/9/2022.
+//
+
+import Foundation
+
+/// Story prompt model
+struct StoryCombo: Hashable, Identifiable, CustomStringConvertible {
+    var id = UUID()
+    var entryA: EntryStub
+    var entryB: EntryStub
+
+    var description: String {
+        """
+        \(entryA)
+        +
+        \(entryB)
+        """
+    }
+}

--- a/xcode/Subconscious/Shared/Services/ComboGeist.swift
+++ b/xcode/Subconscious/Shared/Services/ComboGeist.swift
@@ -1,0 +1,35 @@
+//
+//  ComboGeist.swift
+//  Subconscious (iOS)
+//
+//  Created by Ben Follington on 24/9/2022.
+//
+
+import Foundation
+
+struct ComboGeist: Geist {
+    private let database: DatabaseService
+
+    init(database: DatabaseService) {
+        self.database = database
+    }
+
+    func ask(query: String) -> Story? {
+        guard let stubA = database.readRandomEntry() else {
+            return nil
+        }
+        guard let stubB = database.readRandomEntry() else {
+            return nil
+        }
+        return Story.combo(StoryCombo(entryA: stubA, entryB: stubB))
+    }
+}
+
+extension ComboGeist {
+    init(
+        database: DatabaseService,
+        data: Data
+    ) throws {
+        self.init(database: database)
+    }
+}

--- a/xcode/Subconscious/Shared/Services/ComboGeist.swift
+++ b/xcode/Subconscious/Shared/Services/ComboGeist.swift
@@ -6,22 +6,26 @@
 //
 
 import Foundation
+import Tracery
 
 struct ComboGeist: Geist {
     private let database: DatabaseService
+    private let tracery: Tracery
 
-    init(database: DatabaseService) {
+    init(database: DatabaseService, grammar: TraceryGrammar) {
         self.database = database
+        self.tracery = Tracery(rules: { grammar })
     }
 
     func ask(query: String) -> Story? {
+        let prompt = tracery.expand("#combo_followup#")
         guard let stubA = database.readRandomEntry() else {
             return nil
         }
         guard let stubB = database.readRandomEntry() else {
             return nil
         }
-        return Story.combo(StoryCombo(entryA: stubA, entryB: stubB))
+        return Story.combo(StoryCombo(prompt: prompt, entryA: stubA, entryB: stubB))
     }
 }
 
@@ -30,6 +34,11 @@ extension ComboGeist {
         database: DatabaseService,
         data: Data
     ) throws {
-        self.init(database: database)
+        let decoder = JSONDecoder()
+        let grammar = try decoder.decode(TraceryGrammar.self, from: data)
+        self.init(
+            database: database,
+            grammar: grammar
+        )
     }
 }

--- a/xcode/Subconscious/Shared/SubconsciousApp.swift
+++ b/xcode/Subconscious/Shared/SubconsciousApp.swift
@@ -677,6 +677,9 @@ struct AppEnvironment {
             data: zettelkastenGrammar
         )
         self.feed.register(name: "zettelkasten", geist: zettelkastenGeist)
+        
+        let comboGeist = ComboGeist(database: database)
+        self.feed.register(name: "combo", geist: comboGeist)
     }
 }
 

--- a/xcode/Subconscious/Shared/SubconsciousApp.swift
+++ b/xcode/Subconscious/Shared/SubconsciousApp.swift
@@ -668,25 +668,38 @@ struct AppEnvironment {
 
         self.feed = FeedService()
 
-        let zettelkastenGrammar = try! Bundle.main.read(
-            resource: Config.default.traceryZettelkasten,
-            withExtension: "json"
-        )
-        let zettelkastenGeist = try! RandomPromptGeist(
-            database: database,
-            data: zettelkastenGrammar
-        )
-        self.feed.register(name: "zettelkasten", geist: zettelkastenGeist)
+        // MARK: zettelkasten geist
+        do {
+            let zettelkastenGrammar = try Bundle.main.read(
+                resource: Config.default.traceryZettelkasten,
+                withExtension: "json"
+            )
+            let zettelkastenGeist = try RandomPromptGeist(
+                database: database,
+                data: zettelkastenGrammar
+            )
+            self.feed.register(name: "zettelkasten", geist: zettelkastenGeist)
+            logger.debug("Registered zettelkasten geist")
+        } catch {
+            logger.debug("Failed to load zettelkasten geist: \(error)")
+        }
         
-        let comboGrammar = try! Bundle.main.read(
-            resource: Config.default.traceryCombo,
-            withExtension: "json"
-        )
-        let comboGeist = try! ComboGeist(
-            database: database,
-            data: comboGrammar
-        )
-        self.feed.register(name: "combo", geist: comboGeist)
+        // MARK: combo geist
+        do {
+            let comboGrammar = try Bundle.main.read(
+                resource: Config.default.traceryCombo,
+                withExtension: "json"
+            )
+            let comboGeist = try ComboGeist(
+                database: database,
+                data: comboGrammar
+            )
+            
+            self.feed.register(name: "combo", geist: comboGeist)
+            logger.debug("Registered combo geist")
+        } catch {
+            logger.debug("Failed to load combo geist: \(error)")
+        }
     }
 }
 

--- a/xcode/Subconscious/Shared/SubconsciousApp.swift
+++ b/xcode/Subconscious/Shared/SubconsciousApp.swift
@@ -678,7 +678,10 @@ struct AppEnvironment {
         )
         self.feed.register(name: "zettelkasten", geist: zettelkastenGeist)
         
-        let comboGeist = ComboGeist(database: database)
+        let comboGeist = try! ComboGeist(
+            database: database,
+            data: zettelkastenGrammar
+        )
         self.feed.register(name: "combo", geist: comboGeist)
     }
 }

--- a/xcode/Subconscious/Shared/SubconsciousApp.swift
+++ b/xcode/Subconscious/Shared/SubconsciousApp.swift
@@ -678,9 +678,13 @@ struct AppEnvironment {
         )
         self.feed.register(name: "zettelkasten", geist: zettelkastenGeist)
         
+        let comboGrammar = try! Bundle.main.read(
+            resource: Config.default.traceryCombo,
+            withExtension: "json"
+        )
         let comboGeist = try! ComboGeist(
             database: database,
-            data: zettelkastenGrammar
+            data: comboGrammar
         )
         self.feed.register(name: "combo", geist: comboGeist)
     }

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B58FE48A28DED93F00E000CC /* ComboGeist.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58FE48928DED93F00E000CC /* ComboGeist.swift */; };
+		B58FE48C28DED9B600E000CC /* StoryCombo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58FE48B28DED9B600E000CC /* StoryCombo.swift */; };
+		B58FE48E28DEDAEA00E000CC /* StoryComboView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58FE48D28DEDAEA00E000CC /* StoryComboView.swift */; };
 		B80057EB27DC355E002C0129 /* SubconsciousTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80057EA27DC355E002C0129 /* SubconsciousTests.swift */; };
 		B80057F427DC35BE002C0129 /* Tests_Slug.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80057F327DC35BE002C0129 /* Tests_Slug.swift */; };
 		B809AFF428D8E7BC00D0589A /* Tests_MarkupText.swift in Sources */ = {isa = PBXBuildFile; fileRef = B809AFF328D8E7BC00D0589A /* Tests_MarkupText.swift */; };
@@ -255,6 +258,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B58FE48928DED93F00E000CC /* ComboGeist.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComboGeist.swift; sourceTree = "<group>"; };
+		B58FE48B28DED9B600E000CC /* StoryCombo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryCombo.swift; sourceTree = "<group>"; };
+		B58FE48D28DEDAEA00E000CC /* StoryComboView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryComboView.swift; sourceTree = "<group>"; };
 		B80057E827DC355E002C0129 /* SubconsciousTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SubconsciousTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B80057EA27DC355E002C0129 /* SubconsciousTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubconsciousTests.swift; sourceTree = "<group>"; };
 		B80057F327DC35BE002C0129 /* Tests_Slug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_Slug.swift; sourceTree = "<group>"; };
@@ -488,6 +494,7 @@
 				B877A6E427A1C2BC00F11A90 /* KeyboardService.swift */,
 				B8CE40E628D2707D00819064 /* QueryPromptGeist.swift */,
 				B8CA8F1F288F1875005F8802 /* RandomPromptGeist.swift */,
+				B58FE48928DED93F00E000CC /* ComboGeist.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -523,6 +530,7 @@
 				B8901CF227978FDE007C9021 /* Slug.swift */,
 				B8A59D6B28B692A00010DB2F /* Story.swift */,
 				B8A59D6828B692900010DB2F /* StoryPrompt.swift */,
+				B58FE48B28DED9B600E000CC /* StoryCombo.swift */,
 				B824FDCD26FA662200B81BBD /* SubtextFile.swift */,
 				B8B54F3C271F7C6B00B9B507 /* Suggestion.swift */,
 			);
@@ -701,6 +709,7 @@
 				B8AE34C7276BF77000777FF0 /* SearchTextField.swift */,
 				B8A41D502811F87C0096D2E7 /* SlashlinkBarView.swift */,
 				B8CA8F2728909FBA005F8802 /* StoryPromptView.swift */,
+				B58FE48D28DEDAEA00E000CC /* StoryComboView.swift */,
 				B8A59D7128B693100010DB2F /* StoryView.swift */,
 				B8AE34C1276BD77C00777FF0 /* SuggestionLabelStyle.swift */,
 				B8D7F03E27A4AD130042C7CF /* SuggestionLabelView.swift */,
@@ -991,6 +1000,7 @@
 				B8109C2827A8879C00CD2B6D /* AppTheme.swift in Sources */,
 				B8D7F03F27A4AD130042C7CF /* SuggestionLabelView.swift in Sources */,
 				B8B4D7EE27EA8AA000633B5F /* DragHandleView.swift in Sources */,
+				B58FE48A28DED93F00E000CC /* ComboGeist.swift in Sources */,
 				B813749A28BFCCCA00CCC6FB /* MarkupTextViewRepresentable.swift in Sources */,
 				B8A59D6628B690B20010DB2F /* FeedService.swift in Sources */,
 				B8CC434327A0815E0079D2F9 /* ModalView.swift in Sources */,
@@ -998,6 +1008,7 @@
 				B8879EA926F93EBF00A0B4FF /* BacklinksView.swift in Sources */,
 				B86DFF2827BF02F0002E57ED /* CollectionUtilities.swift in Sources */,
 				B82F053728D60EE60025A8B5 /* AppTabView.swift in Sources */,
+				B58FE48E28DEDAEA00E000CC /* StoryComboView.swift in Sources */,
 				B824FDD426FAB1BC00B81BBD /* Truncate.swift in Sources */,
 				B86DFF3327C072CD002E57ED /* Func.swift in Sources */,
 				B8901CF327978FDE007C9021 /* Slug.swift in Sources */,
@@ -1046,6 +1057,7 @@
 				B8DEBF1F2798EC23007CB528 /* TitleGroupView.swift in Sources */,
 				B8AE34BF276BD61400777FF0 /* RowButtonStyle.swift in Sources */,
 				B8CA8F2628909E66005F8802 /* Feed.swift in Sources */,
+				B58FE48C28DED9B600E000CC /* StoryCombo.swift in Sources */,
 				B86DFF3727C09CA2002E57ED /* DateUtilities.swift in Sources */,
 				B8CC434927A0CA8D0079D2F9 /* AnimationUtilities.swift in Sources */,
 				B89966C728B6EE2300DF1F8C /* Notebook.swift in Sources */,

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B575834528ED8D9100F6EE88 /* combo.json in Resources */ = {isa = PBXBuildFile; fileRef = B575834428ED8D9100F6EE88 /* combo.json */; };
 		B58FE48A28DED93F00E000CC /* ComboGeist.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58FE48928DED93F00E000CC /* ComboGeist.swift */; };
 		B58FE48C28DED9B600E000CC /* StoryCombo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58FE48B28DED9B600E000CC /* StoryCombo.swift */; };
 		B58FE48E28DEDAEA00E000CC /* StoryComboView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58FE48D28DEDAEA00E000CC /* StoryComboView.swift */; };
@@ -258,6 +259,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B575834428ED8D9100F6EE88 /* combo.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = combo.json; sourceTree = "<group>"; };
 		B58FE48928DED93F00E000CC /* ComboGeist.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComboGeist.swift; sourceTree = "<group>"; };
 		B58FE48B28DED9B600E000CC /* StoryCombo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryCombo.swift; sourceTree = "<group>"; };
 		B58FE48D28DEDAEA00E000CC /* StoryComboView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryComboView.swift; sourceTree = "<group>"; };
@@ -548,6 +550,7 @@
 		B8CA8F1C288F07E8005F8802 /* Geists */ = {
 			isa = PBXGroup;
 			children = (
+				B575834428ED8D9100F6EE88 /* combo.json */,
 				B8CA8F1D288F07F9005F8802 /* zettelkasten.json */,
 			);
 			path = Geists;
@@ -907,6 +910,7 @@
 				B88C9781276425E800B27DF0 /* IBMPlexMono-Italic.ttf in Resources */,
 				B88C979F2764266A00B27DF0 /* IBMPlexSans-Medium.ttf in Resources */,
 				B88C97952764264300B27DF0 /* IBMPlexSans-Italic.ttf in Resources */,
+				B575834528ED8D9100F6EE88 /* combo.json in Resources */,
 				B88C97992764264300B27DF0 /* IBMPlexSans-Bold.ttf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Before trying to port my genetic algorithm over I figured it would be smart to take some baby steps. 

The intention of this PR is to introduce the `ComboGeist`, which randomly picks two entries and presents them together in the feed (screenshot attached).

I want to add a `Synthesize` action that would create a new entry _pre-populated_ with the `/slashlinks` to both the entries shown in the feed. I'm not quite sure how to do this as the current flow requires the user to enter a slug for the entry before reaching the editor. That's not a problem in-and-of-itself but we'd need to thread some context through to support the pre-populated editor content.

Keen to hear any suggestions for how to achieve this 😁 

<img src="https://user-images.githubusercontent.com/5009316/192085193-b47749cd-f484-4555-914c-1f67bceb36f9.png" width=256 />

- [x] Register geist
- [x] Display combination of entries
- [x] Synthesize new entry from combination
- [x] Finalise naming scheme 