### PR TITLE
Allow custom fallback content

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/MarkupTextViewRepresentable.swift
+++ b/xcode/Subconscious/Shared/Components/Common/MarkupTextViewRepresentable.swift
@@ -41,6 +41,8 @@ enum MarkupTextAction: Hashable, CustomLogStringConvertible {
     case focusChange(Bool)
     case setText(String)
     case setSelection(range: NSRange, text: String)
+    /// Set selection at the end of the text
+    case setSelectionAtEnd
 
     var logDescription: String {
         switch self {
@@ -93,6 +95,16 @@ struct MarkupTextModel: ModelProtocol {
             var model = state
             model.selection = selection
             return Update(state: model)
+        case .setSelectionAtEnd:
+            let range = NSRange(
+                state.text.endIndex...,
+                in: state.text
+            )
+            return update(
+                state: state,
+                action: .setSelection(range: range, text: state.text),
+                environment: ()
+            )
         }
     }
 }

--- a/xcode/Subconscious/Shared/Components/Common/StoryPromptView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/StoryPromptView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// A story is a single update within the FeedView
 struct StoryPromptView: View {
     var story: StoryPrompt
-    var action: (EntryLink) -> Void
+    var action: (EntryLink, String) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -30,7 +30,10 @@ struct StoryPromptView: View {
                 Text(story.prompt)
                 Button(
                     action: {
-                        action(story.entry.link)
+                        action(
+                            story.entry.link,
+                            story.entry.link.linkableTitle
+                        )
                     },
                     label: {
                         TranscludeView(entry: story.entry)
@@ -43,7 +46,10 @@ struct StoryPromptView: View {
             HStack {
                 Button(
                     action: {
-                        action(story.entry.link)
+                        action(
+                            story.entry.link,
+                            story.entry.link.linkableTitle
+                        )
                     },
                     label: {
                         Text("Open")
@@ -77,7 +83,7 @@ struct StoryPromptView_Previews: PreviewProvider {
                 ),
                 prompt: "Can I invert this?"
             ),
-            action: { entry in }
+            action: { link, fallback in }
         )
     }
 }

--- a/xcode/Subconscious/Shared/Components/Common/StoryView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/StoryView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// Wrapper view for various types of story view
 struct StoryView: View {
     var story: Story
-    var action: (EntryLink) -> Void
+    var action: (EntryLink, String) -> Void
 
     var body: some View {
         switch story {

--- a/xcode/Subconscious/Shared/Components/Detail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail.swift
@@ -23,7 +23,11 @@ enum DetailAction: Hashable, CustomLogStringConvertible {
     // Detail
     /// Load detail, using a last-write-wins strategy for replacement
     /// if detail is already loaded.
-    case loadAndPresentDetail(slug: Slug?, fallback: String, autofocus: Bool)
+    case loadAndPresentDetail(
+        link: EntryLink?,
+        fallback: String,
+        autofocus: Bool
+    )
     /// Reload detail from source of truth
     case refreshDetail
     case refreshDetailIfStale
@@ -41,7 +45,7 @@ enum DetailAction: Hashable, CustomLogStringConvertible {
     /// Load detail
     /// request detail for slug, using template file as a fallback
     case loadAndPresentTemplateDetail(
-        slug: Slug,
+        link: EntryLink,
         template: Slug,
         autofocus: Bool
     )
@@ -152,26 +156,26 @@ enum DetailAction: Hashable, CustomLogStringConvertible {
         switch suggestion {
         case .entry(let entryLink):
             return .loadAndPresentDetail(
-                slug: entryLink.slug,
+                link: entryLink,
                 fallback: entryLink.linkableTitle,
                 autofocus: false
             )
         case .search(let entryLink):
             return .loadAndPresentDetail(
-                slug: entryLink.slug,
+                link: entryLink,
                 fallback: entryLink.linkableTitle,
                 autofocus: true
             )
         case .journal(let entryLink):
             return .loadAndPresentTemplateDetail(
-                slug: entryLink.slug,
+                link: entryLink,
                 template: Config.default.journalTemplate,
                 // Autofocus note because we're creating it from scratch
                 autofocus: true
             )
         case .scratch(let entryLink):
             return .loadAndPresentDetail(
-                slug: entryLink.slug,
+                link: entryLink,
                 fallback: entryLink.linkableTitle,
                 autofocus: true
             )
@@ -378,11 +382,11 @@ struct DetailModel: ModelProtocol {
                 environment: environment,
                 isPresented: isPresented
             )
-        case let .loadAndPresentDetail(slug, fallback, autofocus):
+        case let .loadAndPresentDetail(link, fallback, autofocus):
             return loadAndPresentDetail(
                 state: state,
                 environment: environment,
-                slug: slug,
+                link: link,
                 fallback: fallback,
                 autofocus: autofocus
             )
@@ -421,11 +425,11 @@ struct DetailModel: ModelProtocol {
                 environment: environment,
                 detail: detail
             )
-        case let .loadAndPresentTemplateDetail(slug, template, autofocus):
+        case let .loadAndPresentTemplateDetail(link, template, autofocus):
             return loadAndPresentTemplateDetail(
                 state: state,
                 environment: environment,
-                slug: slug,
+                link: link,
                 template: template,
                 autofocus: autofocus
             )
@@ -595,7 +599,7 @@ struct DetailModel: ModelProtocol {
             return update(
                 state: state,
                 action: .loadAndPresentDetail(
-                    slug: link.slug,
+                    link: link,
                     fallback: link.linkableTitle,
                     autofocus: false
                 ),
@@ -711,8 +715,8 @@ struct DetailModel: ModelProtocol {
         return update(
             state: state,
             action: .loadAndPresentDetail(
-                slug: link?.slug,
-                fallback: link?.title ?? "",
+                link: link,
+                fallback: link?.linkableTitle ?? "",
                 autofocus: false
             ),
             environment: environment
@@ -884,11 +888,11 @@ struct DetailModel: ModelProtocol {
     static func loadAndPresentDetail(
         state: DetailModel,
         environment: AppEnvironment,
-        slug: Slug?,
+        link: EntryLink?,
         fallback: String,
         autofocus: Bool
     ) -> Update<DetailModel> {
-        guard let slug = slug else {
+        guard let link = link else {
             environment.logger.log(
                 "Load and present detail requested, but nothing was being edited. Skipping."
             )
@@ -897,7 +901,7 @@ struct DetailModel: ModelProtocol {
 
         let fx: Fx<DetailAction> = environment.database
             .readEntryDetail(
-                slug: slug,
+                link: link,
                 fallback: fallback
             )
             .map({ detail in
@@ -931,7 +935,7 @@ struct DetailModel: ModelProtocol {
 
         let fx: Fx<DetailAction> = environment.database
             .readEntryDetail(
-                slug: slug,
+                link: EntryLink(slug: slug),
                 fallback: model.markupEditor.text
             )
             .map({ detail in
@@ -1093,12 +1097,12 @@ struct DetailModel: ModelProtocol {
     static func loadAndPresentTemplateDetail(
         state: DetailModel,
         environment: AppEnvironment,
-        slug: Slug,
+        link: EntryLink,
         template: Slug,
         autofocus: Bool
     ) -> Update<DetailModel> {
         let fx: Fx<DetailAction> = environment.database
-            .readEntryDetail(slug: slug, template: template)
+            .readEntryDetail(link: link, template: template)
             .map({ detail in
                 DetailAction.setAndPresentDetail(
                     detail: detail,
@@ -1120,11 +1124,11 @@ struct DetailModel: ModelProtocol {
         environment: AppEnvironment,
         autofocus: Bool
     ) -> Update<DetailModel> {
-        let fx: Fx<DetailAction> = environment.database.readRandomEntrySlug()
-            .map({ slug in
+        let fx: Fx<DetailAction> = environment.database.readRandomEntryLink()
+            .map({ link in
                 DetailAction.loadAndPresentDetail(
-                    slug: slug,
-                    fallback: slug.toTitle(),
+                    link: link,
+                    fallback: link.linkableTitle,
                     autofocus: autofocus
                 )
             })
@@ -1532,7 +1536,7 @@ struct DetailModel: ModelProtocol {
             state: state,
             actions: [
                 .loadAndPresentDetail(
-                    slug: to.slug,
+                    link: to,
                     fallback: to.linkableTitle,
                     autofocus: false
                 ),
@@ -1593,7 +1597,7 @@ struct DetailModel: ModelProtocol {
             state: state,
             actions: [
                 .loadAndPresentDetail(
-                    slug: parent.slug,
+                    link: parent,
                     fallback: parent.linkableTitle,
                     autofocus: false
                 ),

--- a/xcode/Subconscious/Shared/Components/Feed.swift
+++ b/xcode/Subconscious/Shared/Components/Feed.swift
@@ -25,7 +25,6 @@ enum FeedAction {
     /// Fetch feed failed
     case failFetchFeed(Error)
     case activatedSuggestion(Suggestion)
-    case openStory(EntryLink)
 
     //  Entry deletion
     case requestDeleteEntry(Slug?)
@@ -42,6 +41,20 @@ enum FeedAction {
     /// Show/hide the search HUD
     static func setSearchPresented(_ isPresented: Bool) -> FeedAction {
         .search(.setPresented(isPresented))
+    }
+
+    static func loadAndPresentDetail(
+        link: EntryLink?,
+        fallback: String,
+        autofocus: Bool
+    ) -> FeedAction {
+        .detail(
+            .loadAndPresentDetail(
+                link: link,
+                fallback: fallback,
+                autofocus: autofocus
+            )
+        )
     }
 
     static func presentDetail(_ isPresented: Bool) -> FeedAction {
@@ -186,16 +199,6 @@ struct FeedModel: ModelProtocol {
                 action: DetailAction.fromSuggestion(suggestion),
                 environment: environment
             )
-        case .openStory(let entryLink):
-            return FeedDetailCursor.update(
-                state: state,
-                action: .loadAndPresentDetail(
-                    link: entryLink,
-                    fallback: entryLink.linkableTitle,
-                    autofocus: false
-                ),
-                environment: environment
-            )
         case .requestDeleteEntry(_):
             environment.logger.debug(
                 "requestDeleteEntry should be handled by parent component"
@@ -338,8 +341,14 @@ struct FeedView: View {
                             ForEach(store.state.stories) { story in
                                 StoryView(
                                     story: story,
-                                    action: { link in
-                                        store.send(FeedAction.openStory(link))
+                                    action: { link, fallback in
+                                        store.send(
+                                            FeedAction.loadAndPresentDetail(
+                                                link: link,
+                                                fallback: fallback,
+                                                autofocus: false
+                                            )
+                                        )
                                     }
                                 )
                             }

--- a/xcode/Subconscious/Shared/Components/Feed.swift
+++ b/xcode/Subconscious/Shared/Components/Feed.swift
@@ -190,7 +190,7 @@ struct FeedModel: ModelProtocol {
             return FeedDetailCursor.update(
                 state: state,
                 action: .loadAndPresentDetail(
-                    slug: entryLink.slug,
+                    link: entryLink,
                     fallback: entryLink.linkableTitle,
                     autofocus: false
                 ),

--- a/xcode/Subconscious/Shared/Components/Notebook.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook.swift
@@ -84,13 +84,13 @@ enum NotebookAction {
 
     /// Forward requestDetail action to detail
     static func loadAndPresentDetail(
-        slug: Slug?,
+        link: EntryLink?,
         fallback: String,
         autofocus: Bool
     ) -> Self {
         .detail(
             .loadAndPresentDetail(
-                slug: slug,
+                link: link,
                 fallback: fallback,
                 autofocus: autofocus
             )
@@ -99,13 +99,13 @@ enum NotebookAction {
 
     /// request detail for slug, using template file as a fallback
     static func loadAndPresentTemplateDetail(
-        slug: Slug,
+        link: EntryLink,
         template: Slug,
         autofocus: Bool
     ) -> Self {
         .detail(
             .loadAndPresentTemplateDetail(
-                slug: slug,
+                link: link,
                 template: template,
                 autofocus: autofocus
             )
@@ -562,16 +562,16 @@ struct NotebookModel: ModelProtocol {
 
         // Derive slug. If we can't (e.g. invalid query such as empty string),
         // just hide the search HUD and do nothing.
-        guard let slug = Slug(formatting: query) else {
+        guard let link = EntryLink(title: query) else {
             environment.logger.log(
-                "Query could not be converted to slug: \(query)"
+                "Query could not be converted to link: \(query)"
             )
             return update
         }
 
         let fx: Fx<NotebookAction> = Just(
             NotebookAction.loadAndPresentDetail(
-                slug: slug,
+                link: link,
                 fallback: query,
                 autofocus: true
             )

--- a/xcode/Subconscious/Shared/Components/NotebookNavigationView.swift
+++ b/xcode/Subconscious/Shared/Components/NotebookNavigationView.swift
@@ -18,7 +18,7 @@ struct NotebookNavigationView: View {
                     onEntryPress: { entry in
                         store.send(
                             .loadAndPresentDetail(
-                                slug: entry.slug,
+                                link: entry.link,
                                 fallback: entry.linkableTitle,
                                 autofocus: false
                             )

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -746,7 +746,7 @@ struct DatabaseService {
     /// Sync version of readEntryDetail
     /// Use `readEntryDetail` API to call this async.
     private func readEntryDetail(
-        slug: Slug,
+        link: EntryLink,
         fallback: String
     ) throws -> EntryDetail {
         // Get backlinks.
@@ -760,8 +760,8 @@ struct DatabaseService {
             LIMIT 200
             """,
             parameters: [
-                .text(slug.description),
-                .queryFTS5(slug.description)
+                .text(link.slug.description),
+                .queryFTS5(link.slug.description)
             ]
         )
         .compactMap({ row in
@@ -777,16 +777,16 @@ struct DatabaseService {
         })
         // Retreive top entry from file system to ensure it is fresh.
         // If no file exists, return a draft, using fallback for title.
-        guard let entry = readEntry(slug: slug) else {
+        guard let entry = readEntry(slug: link.slug) else {
             let now = Date.now
             return EntryDetail(
                 saveState: .draft,
                 entry: SubtextFile(
-                    slug: slug,
-                    title: fallback,
+                    slug: link.slug,
+                    title: link.linkableTitle,
                     modified: now,
                     created: now,
-                    body: ""
+                    body: fallback
                 ),
                 backlinks: backlinks
             )
@@ -804,23 +804,23 @@ struct DatabaseService {
     /// Allowing any string allows us to retreive files that don't have a
     /// clean slug.
     func readEntryDetail(
-        slug: Slug,
+        link: EntryLink,
         fallback: String
     ) -> AnyPublisher<EntryDetail, Error> {
         CombineUtilities.async(qos: .utility) {
-            try readEntryDetail(slug: slug, fallback: fallback)
+            try readEntryDetail(link: link, fallback: fallback)
         }
     }
 
     /// Get entry and backlinks from slug, using template file as a fallback.
     func readEntryDetail(
-        slug: Slug,
+        link: EntryLink,
         template: Slug
     ) -> AnyPublisher<EntryDetail, Error> {
         CombineUtilities.async(qos: .utility) {
             let fallback = readEntry(slug: template)?.body ?? ""
             return try readEntryDetail(
-                slug: slug,
+                link: link,
                 fallback: fallback
             )
         }
@@ -880,19 +880,25 @@ struct DatabaseService {
         .first
     }
 
-    /// Choose a random entry and read detailz
-    func readRandomEntrySlug() -> AnyPublisher<Slug, Error> {
+    /// Choose a random entry and publish slug
+    func readRandomEntryLink() -> AnyPublisher<EntryLink, Error> {
         CombineUtilities.async(qos: .userInteractive) {
             try database.execute(
                 sql: """
-                SELECT slug
+                SELECT slug, title
                 FROM entry
                 ORDER BY RANDOM()
                 LIMIT 1
                 """
             )
             .compactMap({ row in
-                row.get(0).flatMap({ string in Slug(string) })
+                if
+                    let slug: Slug = row.get(0),
+                    let title: String = row.get(1)
+                {
+                    return EntryLink(slug: slug, title: title)
+                }
+                return nil
             })
             .first
             .unwrap(DatabaseServiceError.randomEntryFailed)

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -882,7 +882,7 @@ struct DatabaseService {
 
     /// Choose a random entry and publish slug
     func readRandomEntryLink() -> AnyPublisher<EntryLink, Error> {
-        CombineUtilities.async(qos: .userInteractive) {
+        CombineUtilities.async(qos: .default) {
             try database.execute(
                 sql: """
                 SELECT slug, title
@@ -892,13 +892,17 @@ struct DatabaseService {
                 """
             )
             .compactMap({ row in
-                if
-                    let slug: Slug = row.get(0),
+                guard
+                    let slugString: String = row.get(0),
+                    let slug = Slug(slugString),
                     let title: String = row.get(1)
-                {
-                    return EntryLink(slug: slug, title: title)
+                else {
+                    return nil
                 }
-                return nil
+                return EntryLink(
+                    slug: slug,
+                    title: title
+                )
             })
             .first
             .unwrap(DatabaseServiceError.randomEntryFailed)

--- a/xcode/Subconscious/SubconsciousTests/Tests_Detail.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Detail.swift
@@ -231,17 +231,14 @@ class Tests_Detail: XCTestCase {
 
     func testDetailActionFromEntrySuggestion() throws {
         let entrySuggestion = Suggestion.entry(
-            EntryLink(
-                slug: Slug("systems-generating-systems")!,
-                title: "Systems Generating Systems"
-            )
+            EntryLink(title: "Systems Generating Systems")!
         )
         let action = DetailAction.fromSuggestion(entrySuggestion)
 
         XCTAssertEqual(
             action,
             DetailAction.loadAndPresentDetail(
-                slug: Slug("systems-generating-systems")!,
+                link: EntryLink(title: "Systems Generating Systems")!,
                 fallback: "Systems Generating Systems",
                 autofocus: false
             )
@@ -260,7 +257,7 @@ class Tests_Detail: XCTestCase {
         XCTAssertEqual(
             action,
             DetailAction.loadAndPresentDetail(
-                slug: Slug("systems-generating-systems")!,
+                link: EntryLink(title: "Systems Generating Systems")!,
                 fallback: "Systems Generating Systems",
                 autofocus: true
             )
@@ -279,7 +276,7 @@ class Tests_Detail: XCTestCase {
         XCTAssertEqual(
             action,
             DetailAction.loadAndPresentTemplateDetail(
-                slug: Slug("systems-generating-systems")!,
+                link: EntryLink(title: "Systems Generating Systems")!,
                 template: Config.default.journalTemplate,
                 autofocus: true
             )
@@ -298,7 +295,7 @@ class Tests_Detail: XCTestCase {
         XCTAssertEqual(
             action,
             DetailAction.loadAndPresentDetail(
-                slug: Slug("systems-generating-systems")!,
+                link: EntryLink(title: "Systems Generating Systems")!,
                 fallback: "Systems Generating Systems",
                 autofocus: true
             )


### PR DESCRIPTION
This PR updates search-or-create actions to allow for the customization of fallback content that is distinct from the title of the note.

Previously we were using title as the fallback always, so these actions/APIs took a slug as a reference to the entry. This PR updates these actions/APIs to take an `EntryLink` instead, describing both a slug and a title. In some cases we continue to use entry title as fallback. However, adding this additional data to the APIs allows us to specify a title AND custom content if we wish.

This PR enables the work being done in https://github.com/subconsciousnetwork/subconscious/pull/340.