### PR TITLE
Clear search on submit

### DIFF
--- a/xcode/Subconscious/Shared/Components/Feed.swift
+++ b/xcode/Subconscious/Shared/Components/Feed.swift
@@ -133,7 +133,9 @@ struct FeedDetailCursor: CursorProtocol {
 /// A feed of stories
 struct FeedModel: ModelProtocol {
     /// Search HUD
-    var search = SearchModel()
+    var search = SearchModel(
+        placeholder: "Search or create..."
+    )
     /// Entry detail
     var detail = DetailModel()
     var stories: [Story] = []

--- a/xcode/Subconscious/Shared/Components/Notebook.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook.swift
@@ -218,7 +218,9 @@ struct NotebookModel: ModelProtocol {
     var isFabShowing = true
 
     /// Search HUD
-    var search = SearchModel()
+    var search = SearchModel(
+        placeholder: "Search or create..."
+    )
 
     /// Entry detail
     var detail = DetailModel()

--- a/xcode/Subconscious/SubconsciousTests/Tests_Search.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Search.swift
@@ -11,7 +11,7 @@ import ObservableStore
 
 class Tests_Search: XCTestCase {
     let environment = AppEnvironment()
-
+    
     func testSetSearch() throws {
         let state = SearchModel()
         let update = SearchModel.update(
@@ -19,14 +19,14 @@ class Tests_Search: XCTestCase {
             action: .setQuery("Mother Nature seems to love us so"),
             environment: environment
         )
-
+        
         XCTAssertEqual(
             update.state.query,
             "Mother Nature seems to love us so",
             "Set search returns same string"
         )
     }
-
+    
     func testSearchPresented() throws {
         let state = SearchModel()
         let update = SearchModel.update(
@@ -34,17 +34,88 @@ class Tests_Search: XCTestCase {
             action: .setPresented(false),
             environment: environment
         )
-
+        
         XCTAssertEqual(
             update.state.isPresented,
             false,
             "isPresented is false"
         )
-
+    }
+    
+    func testSearchHideAndClearQuery() throws {
+        let state = SearchModel(
+            query: "I see red and orange and purple"
+        )
+        let update = SearchModel.update(
+            state: state,
+            action: .hideAndClearQuery,
+            environment: environment
+        )
+        XCTAssertEqual(
+            update.state.isPresented,
+            false,
+            "Search is hidden"
+        )
         XCTAssertEqual(
             update.state.query,
             "",
-            "Search Text Returns Blank"
+            "Query is cleared"
+        )
+        XCTAssertNotNil(
+            update.transaction,
+            "Transaction is not nil (for hide animation)"
+        )
+    }
+
+    /// Test search submit from keyboard "go" button
+    func testSearchSubmitQuery() throws {
+        let state = SearchModel()
+        let update = SearchModel.update(
+            state: state,
+            action: .submitQuery("When she smiles there is a subtle glow"),
+            environment: environment
+        )
+        XCTAssertEqual(
+            update.state.isPresented,
+            false,
+            "Search is hidden"
+        )
+        XCTAssertEqual(
+            update.state.query,
+            "",
+            "Query is cleared"
+        )
+        XCTAssertNotNil(
+            update.transaction,
+            "Transaction is not nil (hide animation)"
+        )
+    }
+
+    /// Test search search suggestion activation
+    func testActivateSuggestion() throws {
+        let state = SearchModel()
+        let update = SearchModel.update(
+            state: state,
+            action: .activateSuggestion(
+                Suggestion.entry(
+                    EntryLink(title: "Red and orange and purple")!
+                )
+            ),
+            environment: environment
+        )
+        XCTAssertEqual(
+            update.state.isPresented,
+            false,
+            "isPresented is false"
+        )
+        XCTAssertEqual(
+            update.state.query,
+            "",
+            "Query is cleared"
+        )
+        XCTAssertNotNil(
+            update.transaction,
+            "Transaction is not nil (hide animation)"
         )
     }
 }


### PR DESCRIPTION
Introduces 'SearchAction.hideAndClearQuery`, which hides the search and clears the query. Also add tests for search actions.

Fixes #343.