### PR TITLE
Return excerpt for first non-empty block

### DIFF
--- a/xcode/Subconscious/Shared/Parsers/Subtext.swift
+++ b/xcode/Subconscious/Shared/Parsers/Subtext.swift
@@ -609,36 +609,6 @@ extension Subtext {
 }
 
 extension Subtext {
-    /// A summary of a Subtext document, including title and excerpt
-    struct Summary {
-        var title: String?
-        var excerpt: String?
-    }
-
-    /// Derive a short summary of a Subtext document.
-    func summarize() -> Summary {
-        let content = blocks.filter({ block in
-            switch block {
-            case .empty:
-                return false
-            default:
-                return true
-            }
-        })
-        return Summary(
-            title: content.get(0).map({ block in String(block.body()) }),
-            excerpt: content.get(1).map({ block in String(block.body()) })
-        )
-    }
-
-    /// Derive a title
-    func title() -> String {
-        for block in blocks {
-            return String(block.body())
-        }
-        return ""
-    }
-
     /// Derive an excerpt
     func excerpt() -> String {
         for block in blocks {

--- a/xcode/Subconscious/Shared/Parsers/Subtext.swift
+++ b/xcode/Subconscious/Shared/Parsers/Subtext.swift
@@ -642,7 +642,12 @@ extension Subtext {
     /// Derive an excerpt
     func excerpt() -> String {
         for block in blocks {
-            return String(block.body())
+            switch block {
+            case .empty:
+                continue
+            default:
+                return String(block.body())
+            }
         }
         return ""
     }

--- a/xcode/Subconscious/SubconsciousTests/Tests_Subtext.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Subtext.swift
@@ -12,43 +12,43 @@ class Tests_Subtext: XCTestCase {
     func testHeadingParsing() throws {
         let markup = "# Some text"
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case .heading(_) = dom.blocks[0] else {
             XCTFail("Expected heading")
             return
         }
     }
-
+    
     func testQuoteParsing() throws {
         let markup = "> Some text"
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case .quote(_, _) = dom.blocks[0] else {
             XCTFail("Expected quote")
             return
         }
     }
-
+    
     func testListParsing() throws {
         let markup = "- Some text"
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case .list(_, _) = dom.blocks[0] else {
             XCTFail("Expected list")
             return
         }
     }
-
+    
     func testTextParsing() throws {
         let markup = "Some text"
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case .text(_, _) = dom.blocks[0] else {
             XCTFail("Expected text")
             return
         }
     }
-
+    
     func testEmptyParsing() throws {
         let markup = """
         Text
@@ -56,267 +56,267 @@ class Tests_Subtext: XCTestCase {
         Some text after an empty block
         """
         let dom = Subtext.parse(markup: markup)
-
+        
         let block = dom.blocks[1]
         guard case .empty = block else {
             XCTFail("Expected empty, got \(block)")
             return
         }
     }
-
+    
     func testSpaceParsesAsTextNotEmpty() throws {
         let markup = """
          
         Some text after an empty block
         """
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case .text(_, _) = dom.blocks[0] else {
             XCTFail("Expected text")
             return
         }
     }
-
+    
     func testLinkParsing0() throws {
         let markup = "Some text with a http://example.com link"
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case let .link(link) = dom.blocks[0].inline[0] else {
             XCTFail("Expected link")
             return
         }
-
+        
         XCTAssertEqual(
             String(describing: link),
             "http://example.com",
             "Link parses successfully"
         )
     }
-
+    
     func testLinkParsingHttps() throws {
         let markup = "Some text with a https://example.com link"
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case let .link(link) = dom.blocks[0].inline[0] else {
             XCTFail("Expected link")
             return
         }
-
+        
         XCTAssertEqual(
             String(describing: link),
             "https://example.com",
             "HTTPS link parses successfully"
         )
     }
-
+    
     func testLinkParsingQueryParams() throws {
         let markup = "Some text with a http://example.com?foo=bar&baz=bing link"
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case let .link(link) = dom.blocks[0].inline[0] else {
             XCTFail("Expected link")
             return
         }
-
+        
         XCTAssertEqual(
             String(describing: link),
             "http://example.com?foo=bar&baz=bing",
             "Link with query params parses successfully"
         )
     }
-
+    
     func testLinkParsingTrailingPunctuation0() throws {
         let markup = "Some text with a https://example.com. Yes!"
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case let .link(link) = dom.blocks[0].inline[0] else {
             XCTFail("Expected link")
             return
         }
-
+        
         XCTAssertEqual(
             String(describing: link),
             "https://example.com",
             "Link with trailing punctuation parses successfully"
         )
     }
-
+    
     func testLinkParsingTrailingPunctuation1() throws {
         let markup = "Some text with a https://example.com! Yes!"
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case let .link(link) = dom.blocks[0].inline[0] else {
             XCTFail("Expected link")
             return
         }
-
+        
         XCTAssertEqual(
             String(describing: link),
             "https://example.com",
             "Link with trailing punctuation parses successfully"
         )
     }
-
+    
     func testLinkParsingTrailingPunctuation2() throws {
         let markup = "Some text with a https://example.com? Yes!"
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case let .link(link) = dom.blocks[0].inline[0] else {
             XCTFail("Expected link")
             return
         }
-
+        
         XCTAssertEqual(
             String(describing: link),
             "https://example.com",
             "Link with trailing punctuation parses successfully"
         )
     }
-
+    
     func testLinkParsingTrailingPunctuation3() throws {
         let markup = "Some text with a https://example.com, yes!"
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case let .link(link) = dom.blocks[0].inline[0] else {
             XCTFail("Expected link")
             return
         }
-
+        
         XCTAssertEqual(
             String(describing: link),
             "https://example.com",
             "Link with trailing punctuation parses successfully"
         )
     }
-
+    
     func testLinkParsingTrailingPunctuation4() throws {
         let markup = "Some text with a https://example.com; yes!"
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case let .link(link) = dom.blocks[0].inline[0] else {
             XCTFail("Expected link")
             return
         }
-
+        
         XCTAssertEqual(
             String(describing: link),
             "https://example.com",
             "Link with trailing punctuation parses successfully"
         )
     }
-
+    
     func testLinkParsingTrailingPunctuation5() throws {
         let markup = "Some text with a https://example.com( Yes!"
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case let .link(link) = dom.blocks[0].inline[0] else {
             XCTFail("Expected link")
             return
         }
-
+        
         XCTAssertEqual(
             String(describing: link),
             "https://example.com",
             "Link with trailing punctuation parses successfully"
         )
     }
-
+    
     func testLinkParsingTrailingSlash() throws {
         let markup = "Some text with a https://example.com/ Yes!"
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case let .link(link) = dom.blocks[0].inline[0] else {
             XCTFail("Expected link")
             return
         }
-
+        
         XCTAssertEqual(
             String(describing: link),
             "https://example.com/",
             "Link with trailing punctuation parses successfully"
         )
     }
-
+    
     func testSlashlinkParsing0() throws {
         let markup = "Some text with a /slashlink."
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case let .slashlink(slashlink) = dom.blocks[0].inline[0] else {
             XCTFail("Expected slashlink")
             return
         }
-
+        
         XCTAssertEqual(
             String(describing: slashlink),
             "/slashlink",
             "Slashlink parses successfully"
         )
     }
-
+    
     func testSlashlinkParsing1() throws {
         let markup = "/slashlink at the beginning."
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case let .slashlink(slashlink) = dom.blocks[0].inline[0] else {
             XCTFail("Expected slashlink")
             return
         }
-
+        
         XCTAssertEqual(
             String(describing: slashlink),
             "/slashlink",
             "Slashlink parses successfully"
         )
     }
-
+    
     func testSlashlinkParsingUnderscore() throws {
         let markup = "A /_slashlink-with-an-underscore."
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case let .slashlink(slashlink) = dom.blocks[0].inline[0] else {
             XCTFail("Expected slashlink")
             return
         }
-
+        
         XCTAssertEqual(
             String(describing: slashlink),
             "/_slashlink-with-an-underscore",
             "Slashlink with underscore parses successfully"
         )
     }
-
+    
     func testSlashlinkParsingTwoSpaces() throws {
         let markup = "Some text with a  /slashlink that has two spaces preceding."
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case let .slashlink(slashlink) = dom.blocks[0].inline.get(0) else {
             XCTFail("Expected slashlink")
             return
         }
-
+        
         XCTAssertEqual(
             String(describing: slashlink),
             "/slashlink",
             "Slashlink parses successfully"
         )
     }
-
+    
     func testSlashlinkParsingThreeSpaces() throws {
         let markup = "Some text with a   /slashlink that has three spaces preceding."
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case let .slashlink(slashlink) = dom.blocks[0].inline.get(0) else {
             XCTFail("Expected slashlink")
             return
         }
-
+        
         XCTAssertEqual(
             String(describing: slashlink),
             "/slashlink",
             "Slashlink parses successfully"
         )
     }
-
+    
     func testSlashlinkLineBreak() throws {
         let markup = """
         Some text
@@ -325,22 +325,22 @@ class Tests_Subtext: XCTestCase {
         /a-third-slashlink followed by some text
         """
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case let .slashlink(slashlink1) = dom.blocks[1].inline[0] else {
             XCTFail("Expected slashlink")
             return
         }
-
+        
         guard case let .slashlink(slashlink2) = dom.blocks[2].inline[0] else {
             XCTFail("Expected slashlink")
             return
         }
-
+        
         guard case let .slashlink(slashlink3) = dom.blocks[3].inline[0] else {
             XCTFail("Expected slashlink")
             return
         }
-
+        
         XCTAssertEqual(
             String(describing: slashlink1),
             "/slashlink",
@@ -357,24 +357,24 @@ class Tests_Subtext: XCTestCase {
             "Slashlink parses successfully"
         )
     }
-
+    
     func testSlashlinkUnicode() throws {
         let markup = "A /_slashlink-with-😤-unicode."
         let dom = Subtext.parse(markup: markup)
         let inline = dom.blocks.get(0)?.inline.get(0)
-
+        
         guard case let .slashlink(slashlink) = inline else {
             XCTFail("Expected slashlink but was \(String(describing: inline))")
             return
         }
-
+        
         XCTAssertEqual(
             String(describing: slashlink),
             "/_slashlink-with-😤-unicode",
             "Slashlink with unicode parses correctly"
         )
     }
-
+    
     func testWikilinkParsing0() throws {
         let markup = """
         Let's test out some [[wikilinks]].
@@ -391,7 +391,7 @@ class Tests_Subtext: XCTestCase {
             "Wikilink markup parses to wikilink"
         )
     }
-
+    
     func testWikilinkParsing1() throws {
         let markup = """
         [[Wikilink]] leading the block.
@@ -408,7 +408,7 @@ class Tests_Subtext: XCTestCase {
             "Wikilink markup parses to wikilink"
         )
     }
-
+    
     func testWikilinkParsing3() throws {
         let markup = """
         [[Wikilink]]! with some trailing punctuation.
@@ -425,7 +425,7 @@ class Tests_Subtext: XCTestCase {
             "Wikilink markup parses to wikilink"
         )
     }
-
+    
     func testWikilinkParsing4() throws {
         let markup = """
         Here's a[[wikilink]]embedded in some text.
@@ -442,7 +442,7 @@ class Tests_Subtext: XCTestCase {
             "Wikilink is detected when embedded in text"
         )
     }
-
+    
     func testWikilinkParsingBrokenClosingBracket() throws {
         let markup = """
         Here's a [[wikilink]] followed by ]] in some text.
@@ -459,7 +459,7 @@ class Tests_Subtext: XCTestCase {
             "Wikilink closes at the first closing bracket"
         )
     }
-
+    
     func testWikilinkParsingSpaceInBrackets() throws {
         let markup = """
         Here's a [[wikilink] ] except it's broken.
@@ -470,7 +470,7 @@ class Tests_Subtext: XCTestCase {
             "Broken wikilink with space in brackets is not parsed as wikilink"
         )
     }
-
+    
     func testWikilinkParsingSpaceInBrackets2() throws {
         let markup = """
         Here's a [[wikilink] text] except it's broken.
@@ -481,7 +481,7 @@ class Tests_Subtext: XCTestCase {
             "Broken wikilink with space in brackets is not parsed as wikilink"
         )
     }
-
+    
     func testWikilinkParsingBrokenOpenBracket() throws {
         let markup = """
         Here's a [[nonwikilink in some text.
@@ -494,7 +494,7 @@ class Tests_Subtext: XCTestCase {
             "Wikilink requires closing bracket"
         )
     }
-
+    
     func testWikilinkDoubleOpenBracket() throws {
         let markup = """
         Here's a [[ [[wikilink]] with an additional opening bracket preceding.
@@ -511,7 +511,7 @@ class Tests_Subtext: XCTestCase {
             "Wikilink requires closing bracket"
         )
     }
-
+    
     func testWikilinkText() throws {
         let markup = """
         Let's test out a [[wikilink]].
@@ -528,7 +528,7 @@ class Tests_Subtext: XCTestCase {
             "Wikilink text omits brackets"
         )
     }
-
+    
     func testWikilinkUnicode() throws {
         let markup = "A [[wikilink with 😤 unicode]]."
         let dom = Subtext.parse(markup: markup)
@@ -543,7 +543,7 @@ class Tests_Subtext: XCTestCase {
             "Rejects unicode in slashlinks"
         )
     }
-
+    
     func testItalicParsing0() throws {
         let markup = """
         _Italics_ in the front
@@ -560,7 +560,7 @@ class Tests_Subtext: XCTestCase {
             "Italic markup parses to italic"
         )
     }
-
+    
     func testItalicParsing1() throws {
         let markup = """
         Some _italic_ in the middle
@@ -577,7 +577,7 @@ class Tests_Subtext: XCTestCase {
             "Italic markup parses to italic"
         )
     }
-
+    
     func testItalicParsing2() throws {
         let markup = """
         Heres some_italic_embedded in the text
@@ -594,7 +594,7 @@ class Tests_Subtext: XCTestCase {
             "Italic markup parses to italic"
         )
     }
-
+    
     func testItalicParsing3() throws {
         let markup = """
         Here's some _italic_ with_ a stray tag in the text
@@ -616,7 +616,7 @@ class Tests_Subtext: XCTestCase {
             "Italic markup parses to italic"
         )
     }
-
+    
     func testItalicText() throws {
         let markup = """
         Let's test out _italic_
@@ -633,7 +633,7 @@ class Tests_Subtext: XCTestCase {
             "Italic text field omits markup"
         )
     }
-
+    
     func testBoldParsing0() throws {
         let markup = """
         *Bold* in the front
@@ -650,7 +650,7 @@ class Tests_Subtext: XCTestCase {
             "Bold markup parses to bold"
         )
     }
-
+    
     func testBoldParsing1() throws {
         let markup = """
         Some *bold* in the middle
@@ -667,7 +667,7 @@ class Tests_Subtext: XCTestCase {
             "Bold markup parses to bold"
         )
     }
-
+    
     func testBoldParsing2() throws {
         let markup = """
         Heres some*bold*embedded in the text
@@ -684,7 +684,7 @@ class Tests_Subtext: XCTestCase {
             "Bold markup parses to bold"
         )
     }
-
+    
     func testBoldParsing3() throws {
         let markup = """
         Here's some *bold* with* a stray tag in the text
@@ -706,7 +706,7 @@ class Tests_Subtext: XCTestCase {
             "Bold markup parses to bold"
         )
     }
-
+    
     func testBoldText() throws {
         let markup = """
         Let's test out *bold*.
@@ -723,7 +723,7 @@ class Tests_Subtext: XCTestCase {
             "Bold text field omits markup"
         )
     }
-
+    
     func testCodeParsing0() throws {
         let markup = """
         `Code` in the front
@@ -740,7 +740,7 @@ class Tests_Subtext: XCTestCase {
             "Code markup parses to code"
         )
     }
-
+    
     func testCodeParsing1() throws {
         let markup = """
         Some `code text` in the middle
@@ -757,7 +757,7 @@ class Tests_Subtext: XCTestCase {
             "Code markup parses to code"
         )
     }
-
+    
     func testCodeParsing2() throws {
         let markup = """
         Heres some`code`embedded in the text
@@ -774,7 +774,7 @@ class Tests_Subtext: XCTestCase {
             "Code markup parses to code"
         )
     }
-
+    
     func testCodeParsing3() throws {
         let markup = """
         Here's some `code` with` a stray tag in the text
@@ -796,7 +796,7 @@ class Tests_Subtext: XCTestCase {
             "Code markup parses to code"
         )
     }
-
+    
     func testCodeText() throws {
         let markup = """
         Let's test out `code`.
@@ -813,7 +813,7 @@ class Tests_Subtext: XCTestCase {
             "Code text field omits markup"
         )
     }
-
+    
     func testInlineCollisions0() throws {
         let markup = """
         Let's test out *bo_ld*_.
@@ -830,7 +830,7 @@ class Tests_Subtext: XCTestCase {
             "Opening * parses until closing, * or backtracks"
         )
     }
-
+    
     func testInlineCollisions2() throws {
         let markup = """
         Let's test out _it*al*ic_ly*.
@@ -847,16 +847,16 @@ class Tests_Subtext: XCTestCase {
             "Opening _ parses until closing, _ or backtracks"
         )
     }
-
+    
     func testInlineCollisions3() throws {
         let markup = """
         Let's test out `_`it*al*ic_ly*.
         """
         let dom = Subtext.parse(markup: markup)
         let block = dom.blocks[0]
-
+        
         XCTAssertEqual(block.inline.count, 2, "Two inlines parsed")
-
+        
         guard case let .code(code) = block.inline[0] else {
             XCTFail("Expected code")
             return
@@ -865,20 +865,20 @@ class Tests_Subtext: XCTestCase {
             XCTFail("Expected bold")
             return
         }
-
+        
         XCTAssertEqual(
             String(describing: code),
             "`_`",
             "First inline is code"
         )
-
+        
         XCTAssertEqual(
             String(describing: bold),
             "*al*",
             "Second inline is bold"
         )
     }
-
+    
     func testEntryLinksCount() throws {
         let markup = """
         [[The quick]] [[brown]]
@@ -891,13 +891,13 @@ class Tests_Subtext: XCTestCase {
             "Correct number of links parsed"
         )
     }
-
+    
     func testEntryLinksCasing() throws {
         let markup = """
         [[HAMLET]]
         Let me see.
         Takes the /skull
-
+        
         Alas, poor [[Yorick]]! I knew him, [[Horatio]]: a fellow
         of [[infinite jest]], of most /excellent-fancy: he hath
         borne me on his back a thousand times; and now, how
@@ -930,7 +930,7 @@ class Tests_Subtext: XCTestCase {
             "Excellent fancy"
         )
     }
-
+    
     func testWikilinkForRange() throws {
         let markup = """
         To what base uses we may return, [[Horatio]]! Why may
@@ -949,7 +949,7 @@ class Tests_Subtext: XCTestCase {
             "[[Horatio]]"
         )
     }
-
+    
     func testSlashlinkForRange() throws {
         let markup = """
         To what base uses we may return, /Horatio! Why may
@@ -968,7 +968,7 @@ class Tests_Subtext: XCTestCase {
             "/Horatio"
         )
     }
-
+    
     func testEntryLinkMarkupForRange0() throws {
         let markup = """
         To what [[base uses]] we may return, /Horatio! Why may
@@ -992,7 +992,7 @@ class Tests_Subtext: XCTestCase {
             "Finds slashlink when cursor is at end of slashlink"
         )
     }
-
+    
     func testEntryLinkMarkupForRange1() throws {
         let markup = """
         To what [[base uses]] we may return, /Horatio! Why may
@@ -1016,24 +1016,24 @@ class Tests_Subtext: XCTestCase {
             "Finds wikilink when cursor is at end of text"
         )
     }
-
+    
     func testBlockDoesNotEndInLinebreak() throws {
         let markup = """
         Some text after an empty block
-
+        
         # A heading block
         - A list block [[with a wikilink]]
         > A quote block /with-slashlink
         """
         let dom = Subtext.parse(markup: markup)
-
+        
         guard case .text(let text, _) = dom.blocks[0] else {
             XCTFail("Expected text")
             return
         }
         XCTAssertEqual(text.first, "S")
         XCTAssertEqual(text.last, "k")
-
+        
         guard case .empty(let empty) = dom.blocks[1] else {
             XCTFail("Expected empty")
             return
@@ -1041,21 +1041,21 @@ class Tests_Subtext: XCTestCase {
         XCTAssertEqual(empty.count, 0)
         XCTAssertEqual(empty.first, nil)
         XCTAssertEqual(empty.last, nil)
-
+        
         guard case .heading(let heading) = dom.blocks[2] else {
             XCTFail("Expected heading")
             return
         }
         XCTAssertEqual(heading.first, "#")
         XCTAssertEqual(heading.last, "k")
-
+        
         guard case .list(let list, _) = dom.blocks[3] else {
             XCTFail("Expected list")
             return
         }
         XCTAssertEqual(list.first, "-")
         XCTAssertEqual(list.last, "]")
-
+        
         guard case .quote(let quote, _) = dom.blocks[4] else {
             XCTFail("Expected quote")
             return
@@ -1063,7 +1063,7 @@ class Tests_Subtext: XCTestCase {
         XCTAssertEqual(quote.first, ">")
         XCTAssertEqual(quote.last, "k")
     }
-
+    
     func testAppend() throws {
         let a = Subtext.parse(
             markup: """
@@ -1085,6 +1085,36 @@ class Tests_Subtext: XCTestCase {
             It's all right
             """,
             "Append concatenates two subtext instances, joining them with a single newline"
+        )
+    }
+
+    func testExcerpt() throws {
+        let subtext = Subtext.parse(
+            markup: """
+            Here comes the sun, doo da doo doo
+            Here comes the sun, and I say
+            """
+        )
+        XCTAssertEqual(
+            subtext.excerpt(),
+            "Here comes the sun, doo da doo doo",
+            "Excerpt returns string for first block"
+        )
+    }
+
+    func testExcerptEmptyFirstLines() throws {
+        let subtext = Subtext.parse(
+            markup: """
+
+
+            Here comes the sun, doo da doo doo
+            Here comes the sun, and I say
+            """
+        )
+        XCTAssertEqual(
+            subtext.excerpt(),
+            "Here comes the sun, doo da doo doo",
+            "Excerpt returns string for first non-empty block"
         )
     }
 }


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/358.

We want to derive the excerpt from the first non-empty block.

Adds unit tests to test this behavior.