### PR TITLE
Use file info as source of truth for modified/size

### DIFF
--- a/xcode/Subconscious/Shared/Library/FileSync.swift
+++ b/xcode/Subconscious/Shared/Library/FileSync.swift
@@ -42,8 +42,12 @@ struct FileFingerprint: Hashable, Equatable, Identifiable {
             self.size = size
         }
 
+        /// Initialize Fingerprint from a Date and an Int.
+        /// Date is rounded DOWN to the nearest second.
         init(modified: Date, size: Int) {
-            self.modified = Int(modified.timeIntervalSince1970)
+            self.modified = Int(
+                modified.timeIntervalSince1970.rounded(.towardZero)
+            )
             self.size = size
         }
     }


### PR DESCRIPTION
Fixes #378

Still need to test a bit to make sure the rounded modified time (for sync) is still working as intended. Context there is that unless we round modified to nearest second, we tend to get funny business with sync due to difference in microtime.