### PR TITLE
Fix ValidatedTextField badge background in dark theme

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
@@ -27,7 +27,7 @@ struct ValidatedTextField: View {
                             .frame(width: 24, height: 22)
                             .padding(.horizontal, 8)
                             .foregroundColor(.red)
-                            .background(.white)
+                            .background(Color.background)
                     }
                     .padding(.trailing, 1)
                     .opacity(isValid ? 0 : 1)


### PR DESCRIPTION
Ensures that the validation error icon will mask the text in the light and dark theme.

Extends https://github.com/subconsciousnetwork/subconscious/pull/398

Fixes #399 