### PR TITLE
Update Noosphere package

### DIFF
--- a/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/subconsciousnetwork/noosphere",
       "state" : {
         "branch" : "main",
-        "revision" : "96a3752c1f70e8d088293c98d2638b67f1a733f5"
+        "revision" : "791bc3996cfac12cb077c3721f22d080a71d33ba"
       }
     },
     {


### PR DESCRIPTION
This picks up changes from Noosphere@v0.6.3 which fix the saving/rollback bug we encountered in #397.

The v0.6.3 release branch Package.swift was incorrect, and points to the v0.6.2 build artifact. Therefore, we stay on Noosphere@main, which picks up the v0.6.3 build artifact.

Tested and confirmed that it resolves the saving problem.