### PR TITLE
Add copy/copied states to recovery phrase view

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -230,7 +230,7 @@ struct AppModel: ModelProtocol {
             return AppRecoveryPhraseCursor.update(
                 state: state,
                 action: action,
-                environment: ()
+                environment: environment.recoveryPhrase
             )
         case .scenePhaseChange(let scenePhase):
             return scenePhaseChange(
@@ -831,6 +831,8 @@ struct AppEnvironment {
     var data: DataService
     var feed: FeedService
     
+    var recoveryPhrase = RecoveryPhraseEnvironment()
+
     /// Create a long polling publisher that never completes
     static func poll(every interval: Double) -> AnyPublisher<Date, Never> {
         Timer.publish(

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunCreateSphereView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunCreateSphereView.swift
@@ -17,11 +17,17 @@ struct FirstRunCreateSphereView: View {
                 VStack(alignment: .center, spacing: AppTheme.unit4) {
                     Text("Recovery Phrase")
                         .font(.headline)
-                    RecoveryPhraseView(text: app.state.sphereMnemonic ?? "")
+                    RecoveryPhraseView(
+                        state: app.state.recoveryPhrase,
+                        send: Address.forward(
+                            send: app.send,
+                            tag: AppRecoveryPhraseCursor.tag
+                        )
+                    )
                     VStack(alignment: .leading, spacing: AppTheme.unit2) {
                         Text("This is your secret recovery phrase. You can use it to recover your data if you lose access.")
                             .foregroundColor(.secondary)
-                        Text("This is for your eyes only. We don't store it. Write it down. Keep it secret, keep it safe.")
+                        Text("This is for your eyes only. We don't store it. Write it down or add it to your password manager. Keep it secret, keep it safe.")
                             .foregroundColor(.secondary)
                     }
                 }

--- a/xcode/Subconscious/Shared/Components/FirstRun/RecoveryPhraseView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/RecoveryPhraseView.swift
@@ -6,14 +6,17 @@
 //
 
 import SwiftUI
+import ObservableStore
+import os
 
 struct RecoveryPhraseView: View {
-    var text: String
+    var state: RecoveryPhraseModel
+    var send: (RecoveryPhraseAction) -> Void
 
     var body: some View {
         VStack(spacing: 0) {
             HStack {
-                Text(text)
+                Text(state.phrase)
                     .monospaced()
                     .textSelection(.enabled)
                 Spacer()
@@ -21,12 +24,30 @@ struct RecoveryPhraseView: View {
             .padding()
             Button(
                 action: {
-                    UIPasteboard.general.string = text
+                    send(.copy)
                 },
                 label: {
-                    HStack {
-                        Image(systemName: "doc.on.doc")
-                        Text("Copy to clipboard")
+                    if !state.didCopy {
+                        HStack {
+                            Image(systemName: "doc.on.doc")
+                            Text("Copy to clipboard")
+                        }
+                        .transition(
+                            .asymmetric(
+                                insertion: .identity,
+                                removal: .move(
+                                    edge: .top
+                                ).combined(
+                                    with: .opacity
+                                )
+                            )
+                        )
+                    } else {
+                        HStack {
+                            Image(systemName: "checkmark.circle")
+                            Text("Copied!")
+                        }
+                        .transition(.opacity)
                     }
                 }
             )
@@ -42,10 +63,61 @@ struct RecoveryPhraseView: View {
     }
 }
 
+enum RecoveryPhraseAction: Hashable {
+    case setPhrase(_ phrase: String)
+    case copy
+}
+
+struct RecoveryPhraseModel: ModelProtocol {
+    var phrase: String = ""
+    var didCopy: Bool = false
+
+    static let logger = Logger(
+        subsystem: Config.default.rdns,
+        category: "RecoveryPhrase"
+    )
+
+    static func update(
+        state: RecoveryPhraseModel,
+        action: RecoveryPhraseAction,
+        environment: Void
+    ) -> Update<RecoveryPhraseModel> {
+        switch action {
+        case .setPhrase(let phrase):
+            var model = state
+            model.phrase = phrase
+            return Update(state: model)
+        case .copy:
+            // Copy to clipboard
+            UIPasteboard.general.string = state.phrase
+            logger.log("Copied recovery phrase to clipboard")
+            var model = state
+            model.didCopy = true
+            return Update(state: model)
+                .animation(.default)
+        }
+    }
+}
+
+
 struct RecoveryPhraseView_Previews: PreviewProvider {
-    static var previews: some View {
-        RecoveryPhraseView(
-            text: "foo bar baz bing bong boo biz boz bonk bink boop bop beep bleep bloop blorp blonk blink blip blop boom"
+    struct TestView: View {
+        @StateObject private var store = Store(
+            state: RecoveryPhraseModel(
+                phrase: "foo bar baz bing bong boo biz boz bonk bink boop bop beep bleep bloop blorp blonk blink blip blop boom"
+            ),
+            environment: ()
         )
+
+        var body: some View {
+            RecoveryPhraseView(
+                state: store.state,
+                send: store.send
+            )
+        }
+    }
+
+    static var previews: some View {
+        TestView()
     }
 }

--- a/xcode/Subconscious/Shared/Components/FirstRun/RecoveryPhraseView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/RecoveryPhraseView.swift
@@ -80,7 +80,7 @@ struct RecoveryPhraseModel: ModelProtocol {
     static func update(
         state: RecoveryPhraseModel,
         action: RecoveryPhraseAction,
-        environment: Void
+        environment: RecoveryPhraseEnvironment
     ) -> Update<RecoveryPhraseModel> {
         switch action {
         case .setPhrase(let phrase):
@@ -89,7 +89,7 @@ struct RecoveryPhraseModel: ModelProtocol {
             return Update(state: model)
         case .copy:
             // Copy to clipboard
-            UIPasteboard.general.string = state.phrase
+            environment.pasteboard.string = state.phrase
             logger.log("Copied recovery phrase to clipboard")
             var model = state
             model.didCopy = true
@@ -99,6 +99,18 @@ struct RecoveryPhraseModel: ModelProtocol {
     }
 }
 
+/// Exposes a minimal API surface to the pasteboard.
+/// Just the parts we use here.
+protocol RecoveryPhrasePasteboardProtocol {
+    var string: String? { get nonmutating set }
+}
+
+extension UIPasteboard: RecoveryPhrasePasteboardProtocol {}
+
+struct RecoveryPhraseEnvironment {
+    // Pasteboard is defined as a protocol. This allows us to mock for testing.
+    var pasteboard: RecoveryPhrasePasteboardProtocol = UIPasteboard.general
+}
 
 struct RecoveryPhraseView_Previews: PreviewProvider {
     struct TestView: View {
@@ -106,7 +118,7 @@ struct RecoveryPhraseView_Previews: PreviewProvider {
             state: RecoveryPhraseModel(
                 phrase: "foo bar baz bing bong boo biz boz bonk bink boop bop beep bleep bloop blorp blonk blink blip blop boom"
             ),
-            environment: ()
+            environment: RecoveryPhraseEnvironment()
         )
 
         var body: some View {

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		B8CC434A27A0CA8D0079D2F9 /* AnimationUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8CC434827A0CA8D0079D2F9 /* AnimationUtilities.swift */; };
 		B8CE40E728D2707D00819064 /* QueryPromptGeist.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8CE40E628D2707D00819064 /* QueryPromptGeist.swift */; };
 		B8CE40E828D2707D00819064 /* QueryPromptGeist.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8CE40E628D2707D00819064 /* QueryPromptGeist.swift */; };
+		B8D328B529A640F200850A37 /* Tests_RecoveryPhrase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D328B429A640F200850A37 /* Tests_RecoveryPhrase.swift */; };
 		B8D7F03F27A4AD130042C7CF /* SuggestionLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D7F03E27A4AD130042C7CF /* SuggestionLabelView.swift */; };
 		B8D7F04027A4AD130042C7CF /* SuggestionLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D7F03E27A4AD130042C7CF /* SuggestionLabelView.swift */; };
 		B8D7F04227A4AE590042C7CF /* SuggestionViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D7F04127A4AE590042C7CF /* SuggestionViewModifier.swift */; };
@@ -508,6 +509,7 @@
 		B8CC433C27A07CE10079D2F9 /* ScrimView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrimView.swift; sourceTree = "<group>"; };
 		B8CC434827A0CA8D0079D2F9 /* AnimationUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationUtilities.swift; sourceTree = "<group>"; };
 		B8CE40E628D2707D00819064 /* QueryPromptGeist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPromptGeist.swift; sourceTree = "<group>"; };
+		B8D328B429A640F200850A37 /* Tests_RecoveryPhrase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_RecoveryPhrase.swift; sourceTree = "<group>"; };
 		B8D7F03E27A4AD130042C7CF /* SuggestionLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionLabelView.swift; sourceTree = "<group>"; };
 		B8D7F04127A4AE590042C7CF /* SuggestionViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionViewModifier.swift; sourceTree = "<group>"; };
 		B8DEBF182798B6A8007CB528 /* NavigationToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationToolbar.swift; sourceTree = "<group>"; };
@@ -608,6 +610,7 @@
 				B85D5E3C28BE4B2C00EE0078 /* Tests_NotebookUpdate.swift */,
 				B88CC95A284FF64300994928 /* Tests_OrderedCollectionUtilities.swift */,
 				B82BB7FD28243F32000C9FCC /* Tests_Parser.swift */,
+				B8D328B429A640F200850A37 /* Tests_RecoveryPhrase.swift */,
 				B8AAAADA28CBDED800DBC8A9 /* Tests_Search.swift */,
 				B8A617212971E4860054D410 /* Tests_Slashlink.swift */,
 				B80057F327DC35BE002C0129 /* Tests_Slug.swift */,
@@ -1244,6 +1247,7 @@
 				B8EA3757299EBA5500D98E2B /* Tests_NoosphereService.swift in Sources */,
 				B88CC95B284FF64300994928 /* Tests_OrderedCollectionUtilities.swift in Sources */,
 				B80057F427DC35BE002C0129 /* Tests_Slug.swift in Sources */,
+				B8D328B529A640F200850A37 /* Tests_RecoveryPhrase.swift in Sources */,
 				B831BDBC2825A4E700C4CE92 /* Tests_Header.swift in Sources */,
 				B85D5E3F28BE4B4600EE0078 /* Tests_FeedUpdate.swift in Sources */,
 				B80057EB27DC355E002C0129 /* SubconsciousTests.swift in Sources */,

--- a/xcode/Subconscious/SubconsciousTests/Tests_RecoveryPhrase.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_RecoveryPhrase.swift
@@ -1,0 +1,61 @@
+//
+//  Tests_RecoveryPhrase.swift
+//  SubconsciousTests
+//
+//  Created by Gordon Brander on 2/22/23.
+//
+
+import XCTest
+@testable import Subconscious
+
+final class Tests_RecoveryPhrase: XCTestCase {
+    final class MockPasteboard: RecoveryPhrasePasteboardProtocol {
+        var sets: Int = 0
+        var _string: String? = nil
+
+        var string: String? {
+            get { _string }
+            set {
+                self._string = newValue
+                self.sets = self.sets + 1
+            }
+        }
+    }
+
+    func testSetPhrase() throws {
+        let environment = RecoveryPhraseEnvironment(
+            pasteboard: MockPasteboard()
+        )
+
+        let state = RecoveryPhraseModel()
+        XCTAssertEqual(state.phrase, "")
+
+        let update = RecoveryPhraseModel.update(
+            state: state,
+            action: .setPhrase("foo bar baz"),
+            environment: environment
+        )
+        XCTAssertEqual(update.state.phrase, "foo bar baz", "Set phrase")
+    }
+    
+    func testCopy() throws {
+        let pasteboard = MockPasteboard()
+        let environment = RecoveryPhraseEnvironment(
+            pasteboard: pasteboard
+        )
+
+        let state = RecoveryPhraseModel(
+            phrase: "foo bar baz"
+        )
+        XCTAssertEqual(state.didCopy, false, "didCopy defaults to false")
+
+        let update = RecoveryPhraseModel.update(
+            state: state,
+            action: .copy,
+            environment: environment
+        )
+        XCTAssertEqual(update.state.didCopy, true, "Updated didCopy")
+        XCTAssertEqual(pasteboard.sets, 1, "Copied")
+        XCTAssertNotNil(update.transaction, "Has animation")
+    }
+}


### PR DESCRIPTION
We make RecoveryPhraseView a component that knows how to manage its own state and side-effects, when stitched into a larger component.

Fixes #400.

Introduces:

- RecoveryPhraseModel
- RecoveryPhraseAction
- AppRecoveryPhraseCursor to map from app domain to recovery phrase domain