### PR TITLE
Reset gateway when valid gateway URL is submitted in settings

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -431,7 +431,7 @@ struct AppModel: ModelProtocol {
         text: String
     ) -> Update<AppModel> {
         let url = URL(string: text)
-        var isGatewayURLTextFieldValid = url?.isHTTP() ?? false
+        let isGatewayURLTextFieldValid = url?.isHTTP() ?? false
 
         var model = state
         model.gatewayURLTextField = text

--- a/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
@@ -23,6 +23,9 @@ struct GatewayURLSettingsView: View {
                 caption: "The URL of your preferred Noosphere gateway",
                 isValid: app.state.isGatewayURLTextFieldValid
             )
+            .autocapitalization(.none)
+            .autocorrectionDisabled(true)
+            .keyboardType(.URL)
             .onDisappear {
                 app.send(.submitGatewayURL(app.state.gatewayURLTextField))
             }

--- a/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
@@ -21,8 +21,12 @@ struct SettingsView: View {
                             ProfileSettingsView(app: app)
                         },
                         label: {
-                            LabeledContent("Nickname", value: app.state.nickname ?? "")
-                                .textSelection(.enabled)
+                            LabeledContent(
+                                "Nickname",
+                                value: app.state.nickname ?? ""
+                            )
+                            .lineLimit(1)
+                            .textSelection(.enabled)
                         }
                     )
                     LabeledContent(

--- a/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
@@ -45,7 +45,11 @@ struct SettingsView: View {
                             GatewayURLSettingsView(app: app)
                         },
                         label: {
-                            LabeledContent("Gateway", value: app.state.gatewayURL)
+                            LabeledContent(
+                                "Gateway",
+                                value: app.state.gatewayURL
+                            )
+                            .lineLimit(1)
                         }
                     )
                     Button(

--- a/xcode/Subconscious/Shared/Library/URLUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/URLUtilities.swift
@@ -8,6 +8,11 @@
 import Foundation
 
 extension URL {
+    /// Check if URL is HTTP or HTTPs
+    func isHTTP() -> Bool {
+        return self.scheme == "http" || self.scheme == "https"
+    }
+
     /// Add file name component to URL with extension
     /// - Returns: new URL
     func appendingFilename(name: String, ext: String) -> URL {

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		B8CC434A27A0CA8D0079D2F9 /* AnimationUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8CC434827A0CA8D0079D2F9 /* AnimationUtilities.swift */; };
 		B8CE40E728D2707D00819064 /* QueryPromptGeist.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8CE40E628D2707D00819064 /* QueryPromptGeist.swift */; };
 		B8CE40E828D2707D00819064 /* QueryPromptGeist.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8CE40E628D2707D00819064 /* QueryPromptGeist.swift */; };
+		B8D328BA29A69D2D00850A37 /* Tests_URLUtiilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D328B929A69D2D00850A37 /* Tests_URLUtiilities.swift */; };
 		B8D7F03F27A4AD130042C7CF /* SuggestionLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D7F03E27A4AD130042C7CF /* SuggestionLabelView.swift */; };
 		B8D7F04027A4AD130042C7CF /* SuggestionLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D7F03E27A4AD130042C7CF /* SuggestionLabelView.swift */; };
 		B8D7F04227A4AE590042C7CF /* SuggestionViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D7F04127A4AE590042C7CF /* SuggestionViewModifier.swift */; };
@@ -508,6 +509,7 @@
 		B8CC433C27A07CE10079D2F9 /* ScrimView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrimView.swift; sourceTree = "<group>"; };
 		B8CC434827A0CA8D0079D2F9 /* AnimationUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationUtilities.swift; sourceTree = "<group>"; };
 		B8CE40E628D2707D00819064 /* QueryPromptGeist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPromptGeist.swift; sourceTree = "<group>"; };
+		B8D328B929A69D2D00850A37 /* Tests_URLUtiilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_URLUtiilities.swift; sourceTree = "<group>"; };
 		B8D7F03E27A4AD130042C7CF /* SuggestionLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionLabelView.swift; sourceTree = "<group>"; };
 		B8D7F04127A4AE590042C7CF /* SuggestionViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionViewModifier.swift; sourceTree = "<group>"; };
 		B8DEBF182798B6A8007CB528 /* NavigationToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationToolbar.swift; sourceTree = "<group>"; };
@@ -618,6 +620,7 @@
 				B84AD8E52810B74E006B3153 /* Tests_SubURLs.swift */,
 				B831BDB62824DA9700C4CE92 /* Tests_Tape.swift */,
 				B84AD8E72811C827006B3153 /* Tests_URLComponentsUtilities.swift */,
+				B8D328B929A69D2D00850A37 /* Tests_URLUtiilities.swift */,
 			);
 			path = SubconsciousTests;
 			sourceTree = "<group>";
@@ -1253,6 +1256,7 @@
 				B8B3194F2909F36800A1E62A /* Tests_FileFingerprint.swift in Sources */,
 				B8682DCB2804BF04001CD8DD /* Tests_Subtext.swift in Sources */,
 				B88CC956284FCF8C00994928 /* Tests_DatabaseService.swift in Sources */,
+				B8D328BA29A69D2D00850A37 /* Tests_URLUtiilities.swift in Sources */,
 				B831BDB72824DA9700C4CE92 /* Tests_Tape.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -271,7 +271,7 @@
 		B8CC434A27A0CA8D0079D2F9 /* AnimationUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8CC434827A0CA8D0079D2F9 /* AnimationUtilities.swift */; };
 		B8CE40E728D2707D00819064 /* QueryPromptGeist.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8CE40E628D2707D00819064 /* QueryPromptGeist.swift */; };
 		B8CE40E828D2707D00819064 /* QueryPromptGeist.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8CE40E628D2707D00819064 /* QueryPromptGeist.swift */; };
-		B8D328BA29A69D2D00850A37 /* Tests_URLUtiilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D328B929A69D2D00850A37 /* Tests_URLUtiilities.swift */; };
+		B8D328BA29A69D2D00850A37 /* Tests_URLUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D328B929A69D2D00850A37 /* Tests_URLUtilities.swift */; };
 		B8D7F03F27A4AD130042C7CF /* SuggestionLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D7F03E27A4AD130042C7CF /* SuggestionLabelView.swift */; };
 		B8D7F04027A4AD130042C7CF /* SuggestionLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D7F03E27A4AD130042C7CF /* SuggestionLabelView.swift */; };
 		B8D7F04227A4AE590042C7CF /* SuggestionViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D7F04127A4AE590042C7CF /* SuggestionViewModifier.swift */; };
@@ -509,7 +509,7 @@
 		B8CC433C27A07CE10079D2F9 /* ScrimView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrimView.swift; sourceTree = "<group>"; };
 		B8CC434827A0CA8D0079D2F9 /* AnimationUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationUtilities.swift; sourceTree = "<group>"; };
 		B8CE40E628D2707D00819064 /* QueryPromptGeist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPromptGeist.swift; sourceTree = "<group>"; };
-		B8D328B929A69D2D00850A37 /* Tests_URLUtiilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_URLUtiilities.swift; sourceTree = "<group>"; };
+		B8D328B929A69D2D00850A37 /* Tests_URLUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_URLUtilities.swift; sourceTree = "<group>"; };
 		B8D7F03E27A4AD130042C7CF /* SuggestionLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionLabelView.swift; sourceTree = "<group>"; };
 		B8D7F04127A4AE590042C7CF /* SuggestionViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionViewModifier.swift; sourceTree = "<group>"; };
 		B8DEBF182798B6A8007CB528 /* NavigationToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationToolbar.swift; sourceTree = "<group>"; };
@@ -620,7 +620,7 @@
 				B84AD8E52810B74E006B3153 /* Tests_SubURLs.swift */,
 				B831BDB62824DA9700C4CE92 /* Tests_Tape.swift */,
 				B84AD8E72811C827006B3153 /* Tests_URLComponentsUtilities.swift */,
-				B8D328B929A69D2D00850A37 /* Tests_URLUtiilities.swift */,
+				B8D328B929A69D2D00850A37 /* Tests_URLUtilities.swift */,
 			);
 			path = SubconsciousTests;
 			sourceTree = "<group>";
@@ -1256,7 +1256,7 @@
 				B8B3194F2909F36800A1E62A /* Tests_FileFingerprint.swift in Sources */,
 				B8682DCB2804BF04001CD8DD /* Tests_Subtext.swift in Sources */,
 				B88CC956284FCF8C00994928 /* Tests_DatabaseService.swift in Sources */,
-				B8D328BA29A69D2D00850A37 /* Tests_URLUtiilities.swift in Sources */,
+				B8D328BA29A69D2D00850A37 /* Tests_URLUtilities.swift in Sources */,
 				B831BDB72824DA9700C4CE92 /* Tests_Tape.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/xcode/Subconscious/SubconsciousTests/Tests_URLUtiilities.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_URLUtiilities.swift
@@ -1,0 +1,25 @@
+//
+//  Tests_URLUtiilities.swift
+//  SubconsciousTests
+//
+//  Created by Gordon Brander on 2/22/23.
+//
+
+import XCTest
+@testable import Subconscious
+
+final class Tests_URLUtiilities: XCTestCase {
+    func testIsHTTP() throws {
+        let urlA = URL(string: "http://example.com")!
+        XCTAssertTrue(urlA.isHTTP())
+
+        let urlB = URL(string: "https://example.com")!
+        XCTAssertTrue(urlB.isHTTP())
+
+        let urlC = URL(string: "ftp://example.com")!
+        XCTAssertFalse(urlC.isHTTP())
+
+        let urlD = URL(string: "file://example.com")!
+        XCTAssertFalse(urlD.isHTTP())
+    }
+}

--- a/xcode/Subconscious/SubconsciousTests/Tests_URLUtilities.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_URLUtilities.swift
@@ -1,5 +1,5 @@
 //
-//  Tests_URLUtiilities.swift
+//  Tests_URLUtilities.swift
 //  SubconsciousTests
 //
 //  Created by Gordon Brander on 2/22/23.
@@ -8,7 +8,7 @@
 import XCTest
 @testable import Subconscious
 
-final class Tests_URLUtiilities: XCTestCase {
+final class Tests_URLUtilities: XCTestCase {
     func testIsHTTP() throws {
         let urlA = URL(string: "http://example.com")!
         XCTAssertTrue(urlA.isHTTP())


### PR DESCRIPTION
Fixes #408 

Changes:

- Call `NoosphereService.resetGateway()` when a valid gateway URL is submitted in settings
- Configure gateway TextField for URLs
    - Autocapitalize off
    - Autocomplete off
    - URL keyboard
- Introduce URL.isHTTP() extension, with tests.
- Limit labeled content in settings (including gateway URL field) to one line