### PR TITLE
Update detail after moving/retitling

### DIFF
--- a/xcode/Subconscious/Shared/Components/Detail/Detail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/Detail.swift
@@ -1832,8 +1832,12 @@ struct DetailModel: ModelProtocol {
         from: EntryLink,
         to: EntryLink
     ) -> Update<DetailModel> {
+        var model = state
+        model.address = to.address
+        model.headers.title = to.linkableTitle
+
         return update(
-            state: state,
+            state: model,
             actions: [.unpresentRenameSheet, .refreshLists],
             environment: environment
         )
@@ -1937,8 +1941,10 @@ struct DetailModel: ModelProtocol {
         from: EntryLink,
         to: EntryLink
     ) -> Update<DetailModel> {
+        var model = state
+        model.headers.title = to.linkableTitle
         return update(
-            state: state,
+            state: model,
             actions: [.refreshLists, .unpresentRenameSheet],
             environment: environment
         )

--- a/xcode/Subconscious/Shared/Components/Detail/Detail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/Detail.swift
@@ -1832,6 +1832,18 @@ struct DetailModel: ModelProtocol {
         from: EntryLink,
         to: EntryLink
     ) -> Update<DetailModel> {
+        guard state.address == from.address else {
+            logger.warning(
+                """
+                Detail got a succeedMoveEntry action that doesn't match address. Doing nothing.
+                Detail address: \(state.address?.description ?? "None")
+                From address: \(from.address.description)
+                To address: \(to.address.description)
+                """
+            )
+            return Update(state: state)
+        }
+        
         var model = state
         model.address = to.address
         model.headers.title = to.linkableTitle
@@ -1941,6 +1953,20 @@ struct DetailModel: ModelProtocol {
         from: EntryLink,
         to: EntryLink
     ) -> Update<DetailModel> {
+        guard
+            state.address == from.address &&
+            from.address == to.address
+        else {
+            logger.warning(
+                """
+                Detail got a succeedRetitleEntry action that doesn't match detail address. Doing nothing.
+                Detail address: \(state.address?.description ?? "None")
+                From address: \(from.address.description)
+                To address: \(to.address.description)
+                """
+            )
+            return Update(state: state)
+        }
         var model = state
         model.headers.title = to.linkableTitle
         return update(

--- a/xcode/Subconscious/SubconsciousTests/Tests_Detail.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Detail.swift
@@ -291,7 +291,7 @@ class Tests_Detail: XCTestCase {
             "Changes title"
         )
     }
-
+    
     func testSucceedMoveEntryMismatch() throws {
         let state = DetailModel(
             address: MemoAddress(formatting: "loomings", audience: .public)!,
@@ -383,6 +383,37 @@ class Tests_Detail: XCTestCase {
             update.state.headers.title,
             "Loomings",
             "Does not change title, because addresses don't match"
+        )
+    }
+    
+    func testSucceedMergeEntry() throws {
+        let state = DetailModel(
+            address: MemoAddress(formatting: "loomings", audience: .public)!,
+            headers: WellKnownHeaders(
+                contentType: ContentType.subtext.rawValue,
+                created: Date.now,
+                modified: Date.now,
+                title: "Loomings",
+                fileExtension: ContentType.subtext.fileExtension
+            )
+        )
+        let update = DetailModel.update(
+            state: state,
+            action: .succeedMergeEntry(
+                parent: EntryLink(title: "The Lee Tide", audience: .public)!,
+                child: EntryLink(title: "Loomings", audience: .public)!
+            ),
+            environment: environment
+        )
+        XCTAssertEqual(
+            update.state.address,
+            MemoAddress(formatting: "The Lee Tide", audience: .public)!,
+            "Changes address"
+        )
+        XCTAssertEqual(
+            update.state.headers.title,
+            "The Lee Tide",
+            "Changes title"
         )
     }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_Detail.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Detail.swift
@@ -11,12 +11,12 @@ import ObservableStore
 
 class Tests_Detail: XCTestCase {
     let environment = AppEnvironment()
-
+    
     func testSetAndPresentDetail() throws {
         let state = DetailModel()
-
+        
         let modified = Date.now
-
+        
         let entry = MemoEntry(
             address: MemoAddress(formatting: "example", audience: .public)!,
             contents: Memo(
@@ -29,12 +29,12 @@ class Tests_Detail: XCTestCase {
                 body: "Example text"
             )
         )
-
+        
         let detail = EntryDetail(
             saveState: .saved,
             entry: entry
         )
-
+        
         let update = DetailModel.update(
             state: state,
             action: .setDetail(
@@ -43,7 +43,7 @@ class Tests_Detail: XCTestCase {
             ),
             environment: environment
         )
-
+        
         XCTAssertEqual(
             update.state.isLoading,
             false,
@@ -70,50 +70,13 @@ class Tests_Detail: XCTestCase {
             "Focus request is set to true"
         )
     }
-
+    
     func testUpdateDetailFocus() throws {
         let store = Store(
             state: DetailModel(),
             environment: environment
         )
-
-        let entry = MemoEntry(
-            address: MemoAddress(formatting: "example", audience: .public)!,
-            contents: Memo(
-                contentType: ContentType.subtext.rawValue,
-                created: Date.now,
-                modified: Date.now,
-                title: "Example",
-                fileExtension: ContentType.subtext.fileExtension,
-                additionalHeaders: [],
-                body: "Example"
-            )
-        )
-
-        let detail = EntryDetail(
-            saveState: .saved,
-            entry: entry
-        )
-
-        store.send(.setDetail(detail: detail, autofocus: true))
-
-        let expectation = XCTestExpectation(
-            description: "Autofocus sets editor focus"
-        )
-        DispatchQueue.main.asyncAfter(deadline: .now()) {
-            XCTAssertEqual(
-                store.state.markupEditor.focusRequest,
-                true,
-                "Autofocus sets editor focus"
-            )
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 0.2)
-    }
-
-    func testUpdateDetailBlur() throws {
-        let state = DetailModel()
-
+        
         let entry = MemoEntry(
             address: MemoAddress(formatting: "example", audience: .public)!,
             contents: Memo(
@@ -131,7 +94,44 @@ class Tests_Detail: XCTestCase {
             saveState: .saved,
             entry: entry
         )
-
+        
+        store.send(.setDetail(detail: detail, autofocus: true))
+        
+        let expectation = XCTestExpectation(
+            description: "Autofocus sets editor focus"
+        )
+        DispatchQueue.main.asyncAfter(deadline: .now()) {
+            XCTAssertEqual(
+                store.state.markupEditor.focusRequest,
+                true,
+                "Autofocus sets editor focus"
+            )
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 0.2)
+    }
+    
+    func testUpdateDetailBlur() throws {
+        let state = DetailModel()
+        
+        let entry = MemoEntry(
+            address: MemoAddress(formatting: "example", audience: .public)!,
+            contents: Memo(
+                contentType: ContentType.subtext.rawValue,
+                created: Date.now,
+                modified: Date.now,
+                title: "Example",
+                fileExtension: ContentType.subtext.fileExtension,
+                additionalHeaders: [],
+                body: "Example"
+            )
+        )
+        
+        let detail = EntryDetail(
+            saveState: .saved,
+            entry: entry
+        )
+        
         let update = DetailModel.update(
             state: state,
             action: .setDetail(
@@ -146,7 +146,7 @@ class Tests_Detail: XCTestCase {
             "Autofocus sets editor focus"
         )
     }
-
+    
     func testAutosave() throws {
         let state = DetailModel(
             address: MemoAddress(formatting: "example", audience: .public)!,
@@ -163,7 +163,7 @@ class Tests_Detail: XCTestCase {
             "Sets editor save state to saving when not already saved"
         )
     }
-
+    
     func testSaveAlreadySaved() throws {
         let state = DetailModel(
             address: MemoAddress(formatting: "example", audience: .public)!,
@@ -180,7 +180,7 @@ class Tests_Detail: XCTestCase {
             "Leaves editor save state as saved if already saved"
         )
     }
-
+    
     func testEditorSnapshotModified() throws {
         let state = DetailModel(
             address: MemoAddress(formatting: "example", audience: .public)!,
@@ -196,7 +196,7 @@ class Tests_Detail: XCTestCase {
             "Marks modified time"
         )
     }
-
+    
     func testShowRenameSheet() throws {
         let state = DetailModel()
         let link = EntryLink(title: "Loomings", audience: .public)!
@@ -208,7 +208,7 @@ class Tests_Detail: XCTestCase {
             ),
             environment: environment
         )
-
+        
         XCTAssertEqual(
             update.state.isRenameSheetPresented,
             true,
@@ -220,7 +220,7 @@ class Tests_Detail: XCTestCase {
             "slugToRename was set"
         )
     }
-
+    
     func testHideRenameSheet() throws {
         let state = DetailModel()
         let update = DetailModel.update(
@@ -228,7 +228,7 @@ class Tests_Detail: XCTestCase {
             action: .unpresentRenameSheet,
             environment: environment
         )
-
+        
         XCTAssertEqual(
             update.state.isRenameSheetPresented,
             false,
@@ -253,11 +253,136 @@ class Tests_Detail: XCTestCase {
             action: .setRenameField("Two pink faces turned in the flare of the tiny torch"),
             environment: environment
         )
-
+        
         XCTAssertEqual(
             update.state.renameField,
             "Two pink faces turned in the flare of the tiny torch",
             "Rename field set to literal text of query"
+        )
+    }
+    
+    func testSucceedMoveEntry() throws {
+        let state = DetailModel(
+            address: MemoAddress(formatting: "loomings", audience: .public)!,
+            headers: WellKnownHeaders(
+                contentType: ContentType.subtext.rawValue,
+                created: Date.now,
+                modified: Date.now,
+                title: "Loomings",
+                fileExtension: ContentType.subtext.fileExtension
+            )
+        )
+        let update = DetailModel.update(
+            state: state,
+            action: .succeedMoveEntry(
+                from: EntryLink(title: "Loomings", audience: .public)!,
+                to: EntryLink(title: "The Lee Tide", audience: .public)!
+            ),
+            environment: environment
+        )
+        XCTAssertEqual(
+            update.state.address,
+            MemoAddress(formatting: "The Lee Tide", audience: .public)!,
+            "Changes address"
+        )
+        XCTAssertEqual(
+            update.state.headers.title,
+            "The Lee Tide",
+            "Changes title"
+        )
+    }
+
+    func testSucceedMoveEntryMismatch() throws {
+        let state = DetailModel(
+            address: MemoAddress(formatting: "loomings", audience: .public)!,
+            headers: WellKnownHeaders(
+                contentType: ContentType.subtext.rawValue,
+                created: Date.now,
+                modified: Date.now,
+                title: "Loomings",
+                fileExtension: ContentType.subtext.fileExtension
+            )
+        )
+        let update = DetailModel.update(
+            state: state,
+            action: .succeedMoveEntry(
+                from: EntryLink(title: "The White Whale", audience: .public)!,
+                to: EntryLink(title: "The Lee Tide", audience: .public)!
+            ),
+            environment: environment
+        )
+        XCTAssertEqual(
+            update.state.address,
+            MemoAddress(formatting: "loomings", audience: .public)!,
+            "Does not change address, because addresses don't match"
+        )
+        XCTAssertEqual(
+            update.state.headers.title,
+            "Loomings",
+            "Does not change title, because addresses don't match"
+        )
+    }
+    
+    func testSucceedRetitleEntry() throws {
+        let state = DetailModel(
+            address: MemoAddress(formatting: "loomings", audience: .public)!,
+            headers: WellKnownHeaders(
+                contentType: ContentType.subtext.rawValue,
+                created: Date.now,
+                modified: Date.now,
+                title: "Loomings",
+                fileExtension: ContentType.subtext.fileExtension
+            )
+        )
+        let update = DetailModel.update(
+            state: state,
+            action: .succeedRetitleEntry(
+                from: EntryLink(title: "Loomings", audience: .public)!,
+                to: EntryLink(title: "LOOMINGS", audience: .public)!
+            ),
+            environment: environment
+        )
+        XCTAssertEqual(
+            update.state.address,
+            MemoAddress(formatting: "loomings", audience: .public)!,
+            "Does not change address"
+        )
+        XCTAssertEqual(
+            update.state.headers.title,
+            "LOOMINGS",
+            "Changes title"
+        )
+    }
+    
+    /// Tests against a mis-matched from/to slug
+    func testSucceedRetitleEntryMismatch() throws {
+        let state = DetailModel(
+            address: MemoAddress(formatting: "loomings", audience: .public)!,
+            headers: WellKnownHeaders(
+                contentType: ContentType.subtext.rawValue,
+                created: Date.now,
+                modified: Date.now,
+                title: "Loomings",
+                fileExtension: ContentType.subtext.fileExtension
+            )
+        )
+        let update = DetailModel.update(
+            state: state,
+            action: .succeedRetitleEntry(
+                from: EntryLink(title: "Wrong", audience: .public)!,
+                to: EntryLink(title: "WRONG", audience: .public)!
+            ),
+            environment: environment
+        )
+        XCTAssertEqual(
+            update.state.address,
+            MemoAddress(formatting: "loomings", audience: .public)!,
+            "Does not change address"
+        )
+        XCTAssertEqual(
+            update.state.headers.title,
+            "Loomings",
+            "Does not change title, because addresses don't match"
         )
     }
 }


### PR DESCRIPTION
Fixes #409

Changes:
- The logic was simply missing for updating the DetailModel after a successful move or retitle. Added appropriate logic.
- Added regression tests that make sure title/address are updated when moving/retitling/merging.