### PR TITLE
Merge .pbxproj with union strategy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Always merge Xcode project files with union strategy.
+# This reduces the amount of conflicts we get when
+# merging different branches that touch this file.
+# See https://roadfiresoftware.com/2015/09/automatically-resolving-git-merge-conflicts-in-xcodes-project-pbxproj/
+*.pbxproj merge=union


### PR DESCRIPTION
This reduces the number of conflicts we get in pbxproj (Xcode project file) when merging multiple branches that touch the file.

Xcode project file merge conflicts are a perennial issue. In general, what you want is a union strategy for merging Xcode project files (keep both).

See https://roadfiresoftware.com/2015/09/automatically-resolving-git-merge-conflicts-in-xcodes-project-pbxproj/