### PR TITLE
Make MemoAddress an enum

### DIFF
--- a/xcode/Subconscious/Shared/Components/BacklinksView.swift
+++ b/xcode/Subconscious/Shared/Components/BacklinksView.swift
@@ -57,19 +57,15 @@ struct BacklinksView_Previews: PreviewProvider {
             BacklinksView(
                 backlinks: [
                     EntryStub(
-                        address: MemoAddress(
-                            formatting: "The Lee Shore",
-                            audience: .local
-                        )!,
+                        address: Slug(formatting: "The Lee Shore")!
+                            .toLocalMemoAddress(),
                         title: "The Lee Shore",
                         excerpt: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.",
                         modified: Date.now
                     ),
                     EntryStub(
-                        address: MemoAddress(
-                            formatting: "Loomings",
-                            audience: .public
-                        )!,
+                        address: Slug(formatting: "Loomings")!
+                            .toPublicMemoAddress(),
                         title: "Floop",
                         excerpt: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.",
                         modified: Date.now

--- a/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
@@ -44,7 +44,7 @@ struct EntryRow: View, Equatable {
                 .multilineTextAlignment(.leading)
                 .foregroundColor(Color.secondary)
             HStack(spacing: AppTheme.unit) {
-                Image(audience: entry.address.audience)
+                Image(audience: entry.address.toAudience())
                     .font(.system(size: 12))
                 Text(entry.address.slug.description)
             }
@@ -61,10 +61,8 @@ struct EntryRow_Previews: PreviewProvider {
         VStack {
             EntryRow(
                 entry: EntryStub(
-                    address: MemoAddress(
-                        slug: Slug(formatting: "Anything that can be derived should be derived")!,
-                        audience: .local
-                    ),
+                    address: Slug(formatting: "Anything that can be derived should be derived")!
+                        .toLocalMemoAddress(),
                     title: "Anything that can be derived should be derived",
                     excerpt: "Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply.",
                     modified: Date.now
@@ -72,10 +70,8 @@ struct EntryRow_Previews: PreviewProvider {
             )
             EntryRow(
                 entry: EntryStub(
-                    address: MemoAddress(
-                        slug: Slug(formatting: "Anything that can be derived should be derived")!,
-                        audience: .public
-                    ),
+                    address: Slug(formatting: "Anything that can be derived should be derived")!
+                        .toPublicMemoAddress(),
                     title: "Anything that can be derived should be derived",
                     excerpt: "Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply.",
                     modified: Date.now

--- a/xcode/Subconscious/Shared/Components/Common/LinkSuggestionLabelView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/LinkSuggestionLabelView.swift
@@ -48,11 +48,9 @@ struct LinkSuggestionLabel_Previews: PreviewProvider {
         LinkSuggestionLabelView(
             suggestion: .new(
                 EntryLink(
-                    address: MemoAddress(
-                        slug: Slug("A muse is more interesting than an oracle")!,
-                        audience: .public
-                    )
-                )
+                    title: "A muse is more interesting than an oracle",
+                    audience: .public
+                )!
             )
         )
     }

--- a/xcode/Subconscious/Shared/Components/Common/RenameSuggestionLabelView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/RenameSuggestionLabelView.swift
@@ -56,20 +56,8 @@ struct RenameSuggestionLabel_Previews: PreviewProvider {
     static var previews: some View {
         RenameSuggestionLabelView(
             suggestion: .move(
-                from: EntryLink(
-                    address: MemoAddress(
-                        formatting: "loomings",
-                        audience: .public
-                    )!,
-                    title: "Loomings"
-                ),
-                to: EntryLink(
-                    address: MemoAddress(
-                        formatting: "the-lee-shore",
-                        audience: .public
-                    )!,
-                    title: "The Lee Shore"
-                )
+                from: EntryLink(title: "Loomings", audience: .public)!,
+                to: EntryLink(title: "The Lee Shore", audience: .public)!
             )
         )
     }

--- a/xcode/Subconscious/Shared/Components/Common/SlashlinkBarView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SlashlinkBarView.swift
@@ -34,20 +34,8 @@ struct SlashlinkBarView_Previews: PreviewProvider {
     static var previews: some View {
         SlashlinkBarView(
             links: [
-                EntryLink(
-                    address: MemoAddress(
-                        formatting: "The Lee Shore",
-                        audience: .public
-                    )!,
-                    title: "The Lee Shore"
-                ),
-                EntryLink(
-                    address: MemoAddress(
-                        formatting: "Loomings",
-                        audience: .public
-                    )!,
-                    title: "loomings"
-                )
+                EntryLink(title: "Loomings", audience: .public)!,
+                EntryLink(title: "The Lee Shore", audience: .public)!
             ],
             onSelectLink: { _ in }
         )

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryComboView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryComboView.swift
@@ -92,10 +92,7 @@ struct StoryComboView_Previews: PreviewProvider {
                 prompt: "How are these similar?",
                 entryA: EntryStub(
                     MemoEntry(
-                        address: MemoAddress(
-                            slug: Slug("meme")!,
-                            audience: .local
-                        ),
+                        address: Slug("meme")!.toLocalMemoAddress(),
                         contents: Memo(
                             contentType: ContentType.subtext.rawValue,
                             created: Date.now,
@@ -113,10 +110,7 @@ struct StoryComboView_Previews: PreviewProvider {
                 ),
                 entryB: EntryStub(
                     MemoEntry(
-                        address: MemoAddress(
-                            slug: Slug("meme")!,
-                            audience: .local
-                        ),
+                        address: Slug("meme")!.toLocalMemoAddress(),
                         contents: Memo(
                             contentType: ContentType.subtext.rawValue,
                             created: Date.now,

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryPromptView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryPromptView.swift
@@ -76,10 +76,7 @@ struct StoryPromptView_Previews: PreviewProvider {
             story: StoryPrompt(
                 entry: EntryStub(
                     MemoEntry(
-                        address: MemoAddress(
-                            slug: Slug("meme")!,
-                            audience: .public
-                        ),
+                        address: Slug("meme")!.toPublicMemoAddress(),
                         contents: Memo(
                             contentType: ContentType.subtext.rawValue,
                             created: Date.now,

--- a/xcode/Subconscious/Shared/Components/Common/WikilinkBarView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/WikilinkBarView.swift
@@ -35,16 +35,12 @@ struct EntryLinkSuggestionBarView_Previews: PreviewProvider {
         WikilinkBarView(
             links: [
                 EntryLink(
-                    address: MemoAddress(
-                        formatting: "Loomings",
-                        audience: .local
-                    )!
+                    address: Slug(formatting: "Loomings")!
+                        .toLocalMemoAddress()
                 ),
                 EntryLink(
-                    address: MemoAddress(
-                        formatting: "The Lee Shore",
-                        audience: .local
-                    )!
+                    address: Slug(formatting: "The Lee Shore")!
+                        .toPublicMemoAddress()
                 )
             ],
             onSelectLink: { _ in }

--- a/xcode/Subconscious/Shared/Components/Detail/DetailKeyboardToolbarView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/DetailKeyboardToolbarView.swift
@@ -89,12 +89,9 @@ struct KeyboardToolbarView_Previews: PreviewProvider {
             suggestions: [
                 .entry(
                     EntryLink(
-                        address: MemoAddress(
-                            slug: Slug("an-organism-is-a-living-system")!,
-                            audience: .local
-                        ),
-                        title: "An organism is a living system"
-                    )
+                        title: "An organism is a living system",
+                        audience: .local
+                    )!
                 )
             ],
             onSelectLinkCompletion: { _ in },

--- a/xcode/Subconscious/Shared/Components/OmniboxView.swift
+++ b/xcode/Subconscious/Shared/Components/OmniboxView.swift
@@ -36,7 +36,7 @@ extension OmniboxView {
     init(
         address: MemoAddress?
     ) {
-        let audience = address?.audience ?? .local
+        let audience = address?.toAudience() ?? .local
         let title = address?.slug.description ?? ""
         self.init(
             icon: Image(audience: audience),

--- a/xcode/Subconscious/Shared/Components/RenameSearchView.swift
+++ b/xcode/Subconscious/Shared/Components/RenameSearchView.swift
@@ -84,6 +84,7 @@ struct RenameSearchView_Previews: PreviewProvider {
                         title: "The Street",
                         audience: .public
                     )!
+
                 )
             ],
             text: .constant(""),

--- a/xcode/Subconscious/Shared/Models/Audience.swift
+++ b/xcode/Subconscious/Shared/Models/Audience.swift
@@ -25,8 +25,6 @@ extension Audience: CustomStringConvertible {
             return "Everyone"
         }
     }
-    
-    
 }
 
 extension String {
@@ -34,3 +32,4 @@ extension String {
         Audience(rawValue: self)
     }
 }
+

--- a/xcode/Subconscious/Shared/Models/EntryLink.swift
+++ b/xcode/Subconscious/Shared/Models/EntryLink.swift
@@ -36,18 +36,6 @@ struct EntryLink:
         )
     }
     
-    /// Construct an EntryLink from a string.
-    /// Slug is generated for string using lossy approach.
-    init?(title: String, audience: Audience) {
-        let title = Self.sanitizeTitle(title)
-        guard let address = title.toMemoAddress(audience: audience) else {
-            return nil
-        }
-        self.title = title
-        self.linkableTitle = title
-        self.address = address
-    }
-    
     /// Construct an EntryLink from a slug.
     /// Title is generated using `slug.toTitle()`.
     init(address: MemoAddress, title: String? = nil) {

--- a/xcode/Subconscious/Shared/Models/MemoAddress.swift
+++ b/xcode/Subconscious/Shared/Models/MemoAddress.swift
@@ -7,41 +7,151 @@
 
 import Foundation
 
-/// An ID that is a combination of slug and local draft flag.
-struct MemoAddress: Hashable, CustomStringConvertible, Codable {
-    let slug: Slug
-    let audience: Audience
+enum MemoAddress: Hashable, Codable {
+    case local(Slug)
+    case `public`(Slug)
     
-    var description: String {
-        return "\(audience.rawValue)::\(slug)"
-    }
-    
-    init(slug: Slug, audience: Audience) {
-        self.slug = slug
-        self.audience = audience
-    }
-    
-    init?(formatting title: String, audience: Audience) {
-        guard let slug = Slug(formatting: title) else {
-            return nil
+    var slug: Slug {
+        switch self {
+        case .local(let slug):
+            return slug
+        case .public(let slug):
+            return slug
         }
-        self.slug = slug
-        self.audience = audience
-    }
-    
-    func withAudience(_ audience: Audience) -> Self {
-        MemoAddress(slug: self.slug, audience: audience)
     }
 }
 
-extension String {
-    func toMemoAddress(audience: Audience) -> MemoAddress? {
-        MemoAddress(formatting: self, audience: audience)
+extension MemoAddress: LosslessStringConvertible, Identifiable {
+    /// An address is considered to be any two strings separated by `::`
+    private static let addressRegex = /(.+)::(.+)/
+    
+    /// Initialize from a string
+    init?(_ description: String) {
+        guard
+            let match = try? Self.addressRegex.wholeMatch(in: description)
+        else {
+            return nil
+        }
+        guard let audience = Audience(rawValue: String(match.1)) else {
+            return nil
+        }
+        guard let slug = Slug(String(match.2)) else {
+            return nil
+        }
+        switch audience {
+        case .local:
+            self = .local(slug)
+        case .public:
+            self = .public(slug)
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .local(let slug):
+            return "local::\(slug)"
+        case .public(let slug):
+            return "public::\(slug)"
+        }
+    }
+    
+    var id: String { description }
+}
+
+extension MemoAddress {
+    func toEntryLink(title: String? = nil) -> EntryLink {
+        EntryLink(address: self, title: title)
+    }
+}
+
+extension MemoAddress {
+    func toLocalMemoAddress() -> Self {
+        .local(slug)
+    }
+}
+
+extension MemoAddress {
+    func toPublicMemoAddress() -> Self {
+        .public(slug)
+    }
+}
+
+extension MemoAddress {
+    // TODO: in future we will need to add an argument for the default petname
+    // when converting from local to public.
+    func withAudience(_ audience: Audience) -> Self {
+        switch audience {
+        case .local:
+            return .local(slug)
+        case .public:
+            return .public(slug)
+        }
+    }
+}
+
+extension MemoAddress {
+    func isLocal() -> Bool {
+        switch self {
+        case .local:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+extension MemoAddress {
+    func isPublic() -> Bool {
+        switch self {
+        case .public:
+            return true
+        default:
+            return false
+        }
     }
 }
 
 extension Slug {
-    func toMemoAddress(audience: Audience) -> MemoAddress {
-        MemoAddress(slug: self, audience: audience)
+    func toLocalMemoAddress() -> MemoAddress {
+        .local(self)
+    }
+    
+    func toPublicMemoAddress() -> MemoAddress {
+        .public(self)
+    }
+}
+
+extension String {
+    /// Parse MemoAddress from string
+    /// - Returns MemoAddress, if parse is successful, otherwise nil.
+    func toMemoAddress() -> MemoAddress? {
+        MemoAddress(self)
+    }
+}
+
+extension MemoAddress {
+    func toAudience() -> Audience {
+        switch self {
+        case .local:
+            return .local
+        case .public:
+            return .public
+        }
+    }
+}
+
+extension EntryLink {
+    init?(title: String, audience: Audience) {
+        guard let slug = Slug(formatting: title) else {
+            return nil
+        }
+        switch audience {
+        case .local:
+            self.init(address: MemoAddress.local(slug), title: title)
+            return
+        case .public:
+            self.init(address: MemoAddress.public(slug), title: title)
+            return
+        }
     }
 }

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -28,6 +28,12 @@ enum DataServiceError: Error, LocalizedError {
     }
 }
 
+/// Record of a successful move transaction
+struct MoveReceipt: Hashable {
+    var from: MemoAddress
+    var to: MemoAddress
+}
+
 // MARK: SERVICE
 /// Wraps both database and source-of-truth store, providing data
 /// access methods for the app.
@@ -100,10 +106,9 @@ struct DataService {
         let since = try? database.readMetadata(key: .sphereVersion)
         let changes = try noosphere.changes(since)
         for change in changes {
-            guard let address = MemoAddress(
-                formatting: change,
-                audience: .public
-            ) else {
+            guard
+                let address = Slug(formatting: change)?.toPublicMemoAddress()
+            else {
                 continue
             }
             let slashlink = address.slug.toSlashlink()
@@ -175,14 +180,14 @@ struct DataService {
                     let info = try local.info(left.slug).unwrap()
                     memo.modified = info.modified
                     try database.writeMemo(
-                        MemoAddress(slug: left.slug, audience: .local),
+                        left.slug.toLocalMemoAddress(),
                         memo: memo,
                         size: info.size
                     )
                 // .rightOnly = delete. Remove from search index
                 case .rightOnly(let right):
                     try database.removeMemo(
-                        MemoAddress(slug: right.slug, audience: .local)
+                        right.slug.toLocalMemoAddress()
                     )
                 // .same = no change. Do nothing.
                 case .same:
@@ -197,16 +202,13 @@ struct DataService {
     func readMemo(
         address: MemoAddress
     ) throws -> Memo {
-        switch address.audience {
-        case .public:
-            return try noosphere
-                .read(slashlink: address.slug.toSlashlink())
+        switch address {
+        case .public(let slug):
+            return try noosphere.read(slashlink: slug.toSlashlink())
                 .toMemo()
                 .unwrap()
-        case .local:
-            return try local
-                .read(address.slug)
-                .unwrap()
+        case .local(let slug):
+            return try local.read(slug).unwrap()
         }
     }
 
@@ -219,11 +221,11 @@ struct DataService {
         var memo = memo
         memo.modified = Date.now
 
-        switch address.audience {
-        case .public:
+        switch address {
+        case .public(let slug):
             let body = try memo.body.toData().unwrap()
             try noosphere.write(
-                slug: address.slug.description,
+                slug: slug.description,
                 contentType: memo.contentType,
                 additionalHeaders: memo.headers,
                 body: body
@@ -240,13 +242,13 @@ struct DataService {
                 value: version
             )
             return
-        case .local:
-            try local.write(address.slug, value: memo)
+        case .local(let slug):
+            try local.write(slug, value: memo)
             // Read modified/size from file system directly after writing.
             // Why: we use file system as source of truth and don't want any
             // discrepencies to sneak in (e.g. different time between write and
             // persistence on file system).
-            let info = try local.info(address.slug).unwrap()
+            let info = try local.info(slug).unwrap()
             memo.modified = info.modified
             try database.writeMemo(
                 address,
@@ -269,13 +271,13 @@ struct DataService {
     
     /// Delete entry from file system and database
     func deleteMemo(_ address: MemoAddress) throws {
-        switch address.audience {
-        case .local:
-            try local.remove(address.slug)
+        switch address {
+        case .local(let slug):
+            try local.remove(slug)
             try database.removeMemo(address)
             return
-        case .public:
-            try noosphere.remove(slug: address.slug.description)
+        case .public(let slug):
+            try noosphere.remove(slug: slug.description)
             let version = try noosphere.save()
             try database.removeMemo(address)
             try database.writeMetadatadata(key: .sphereVersion, value: version)
@@ -290,39 +292,8 @@ struct DataService {
         }
     }
     
-    /// Update audience for memo.
-    /// This moves memo from sphere to local or vise versa.
-    func updateAudience(
-        address: MemoAddress,
-        audience: Audience
-    ) throws -> MemoAddress {
-        // Exit early if no change is needed
-        guard address.audience != audience else {
-            return address
-        }
-        let memo = try readMemo(address: address)
-        let newAddress = address.withAudience(audience)
-        try writeMemo(
-            address: newAddress,
-            memo: memo
-        )
-        try deleteMemo(address)
-        return newAddress
-    }
-
-    /// Update audience for memo.
-    /// This moves memo from sphere to local or vise versa.
-    func updateAudienceAsync(
-        address: MemoAddress,
-        audience: Audience
-    ) -> AnyPublisher<MemoAddress, Error> {
-        CombineUtilities.async {
-            return try updateAudience(address: address, audience: audience)
-        }
-    }
-
     /// Move entry to a new location, updating file system and database.
-    func moveEntry(from: EntryLink, to: EntryLink) throws {
+    func moveEntry(from: EntryLink, to: EntryLink) throws -> MoveReceipt {
         guard from.address.slug != to.address.slug else {
             throw DataServiceError.fileExists(to.address.slug.description)
         }
@@ -338,6 +309,7 @@ struct DataService {
         try writeMemo(address: to.address, memo: toMemo)
         // ...Then delete old entry
         try deleteMemo(from.address)
+        return MoveReceipt(from: from.address, to: to.address)
     }
     
     /// Move entry to a new location, updating file system and database.
@@ -345,7 +317,7 @@ struct DataService {
     func moveEntryAsync(
         from: EntryLink,
         to: EntryLink
-    ) -> AnyPublisher<Void, Error> {
+    ) -> AnyPublisher<MoveReceipt, Error> {
         CombineUtilities.async {
             try moveEntry(from: from, to: to)
         }
@@ -406,7 +378,7 @@ struct DataService {
     
     func listRecentMemos() -> AnyPublisher<[EntryStub], Error> {
         CombineUtilities.async(qos: .default) {
-            database.listRecentMemos()
+            try database.listRecentMemos()
         }
     }
 
@@ -466,14 +438,14 @@ struct DataService {
     
     /// Check if a given address exists
     func exists(_ address: MemoAddress) -> Bool {
-        switch address.audience {
-        case .public:
+        switch address {
+        case .public(let slug):
             let version = noosphere.getFileVersion(
-                slashlink: address.slug.toSlashlink()
+                slashlink: slug.toSlashlink()
             )
             return version != nil
-        case .local:
-            let info = local.info(address.slug)
+        case .local(let slug):
+            let info = local.info(slug)
             return info != nil
         }
     }
@@ -486,11 +458,11 @@ struct DataService {
     ) -> MemoAddress? {
         // If slug exists in default sphere, return that.
         if noosphere.getFileVersion(slashlink: slug.toSlashlink()) != nil {
-            return MemoAddress(slug: slug, audience: .public)
+            return slug.toPublicMemoAddress()
         }
         // Otherwise if slug exists on local, return that.
         if local.info(slug) != nil {
-            return MemoAddress(slug: slug, audience: .local)
+            return slug.toLocalMemoAddress()
         }
         return nil
     }
@@ -518,9 +490,9 @@ struct DataService {
             )
         )
 
-        let slashlink = address.slug.toSlashlink()
-        switch address.audience {
-        case .public:
+        switch address {
+        case .public(let slug):
+            let slashlink = slug.toSlashlink()
             do {
                 let memo = try noosphere.read(slashlink: slashlink)
                     .toMemo()
@@ -537,7 +509,8 @@ struct DataService {
                 logger.debug("Sphere file does not exist: \(slashlink). Returning new draft.")
                 return draft
             }
-        case .local:
+        case .local(let slug):
+            let slashlink = slug.toSlashlink()
             // Retreive top entry from file system to ensure it is fresh.
             // If no file exists, return a draft, using fallback for title.
             guard let memo = local.read(address.slug) else {

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -780,7 +780,7 @@ final class DatabaseService {
         
         return try? database.execute(
             sql: """
-            SELECT slug, audience, modified, title, excerpt
+            SELECT id, modified, title, excerpt
             FROM memo_search
             WHERE memo_search MATCH ?
             ORDER BY RANDOM()

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		B87288DC299AB01800EF7E07 /* Noosphere.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87288DB299AB01800EF7E07 /* Noosphere.swift */; };
 		B87288DE299AB02400EF7E07 /* SphereFS.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87288DD299AB02400EF7E07 /* SphereFS.swift */; };
 		B87288E0299B05B500EF7E07 /* Tests_DataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87288DF299B05B500EF7E07 /* Tests_DataService.swift */; };
+		B886A9B829A7E41700BFF9A2 /* Tests_MemoAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = B886A9B729A7E41700BFF9A2 /* Tests_MemoAddress.swift */; };
 		B8879EA026F90C5100A0B4FF /* NotebookNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8879E9F26F90C5100A0B4FF /* NotebookNavigationView.swift */; };
 		B8879EA126F90C5100A0B4FF /* NotebookNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8879E9F26F90C5100A0B4FF /* NotebookNavigationView.swift */; };
 		B8879EA626F9348600A0B4FF /* SubURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8879EA526F9348600A0B4FF /* SubURL.swift */; };
@@ -418,6 +419,7 @@
 		B87288DB299AB01800EF7E07 /* Noosphere.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Noosphere.swift; sourceTree = "<group>"; };
 		B87288DD299AB02400EF7E07 /* SphereFS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SphereFS.swift; sourceTree = "<group>"; };
 		B87288DF299B05B500EF7E07 /* Tests_DataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_DataService.swift; sourceTree = "<group>"; };
+		B886A9B729A7E41700BFF9A2 /* Tests_MemoAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_MemoAddress.swift; sourceTree = "<group>"; };
 		B8879E9F26F90C5100A0B4FF /* NotebookNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotebookNavigationView.swift; sourceTree = "<group>"; };
 		B8879EA526F9348600A0B4FF /* SubURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubURL.swift; sourceTree = "<group>"; };
 		B8879EA826F93EBF00A0B4FF /* BacklinksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BacklinksView.swift; sourceTree = "<group>"; };
@@ -624,6 +626,7 @@
 				B831BDB62824DA9700C4CE92 /* Tests_Tape.swift */,
 				B84AD8E72811C827006B3153 /* Tests_URLComponentsUtilities.swift */,
 				B8D328B929A69D2D00850A37 /* Tests_URLUtilities.swift */,
+				B886A9B729A7E41700BFF9A2 /* Tests_MemoAddress.swift */,
 			);
 			path = SubconsciousTests;
 			sourceTree = "<group>";
@@ -1244,6 +1247,7 @@
 				B84AD8E82811C827006B3153 /* Tests_URLComponentsUtilities.swift in Sources */,
 				B87288E0299B05B500EF7E07 /* Tests_DataService.swift in Sources */,
 				B8AAAADB28CBDED800DBC8A9 /* Tests_Search.swift in Sources */,
+				B886A9B829A7E41700BFF9A2 /* Tests_MemoAddress.swift in Sources */,
 				B809AFF428D8E7BC00D0589A /* Tests_MarkupText.swift in Sources */,
 				B85D5E3D28BE4B2C00EE0078 /* Tests_NotebookUpdate.swift in Sources */,
 				B8682DCD2804C379001CD8DD /* Tests_CollectionUtilities.swift in Sources */,

--- a/xcode/Subconscious/SubconsciousTests/Tests_DataService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DataService.swift
@@ -78,7 +78,7 @@ final class Tests_DataService: XCTestCase {
         let tmp = try createTmpDir()
         let data = try createDataService(tmp: tmp)
         
-        let address = MemoAddress(formatting: "Test", audience: .public)!
+        let address = Slug(formatting: "Test")!.toPublicMemoAddress()
         let memoIn = Memo(
             contentType: ContentType.subtext.rawValue,
             created: Date.now,
@@ -104,7 +104,7 @@ final class Tests_DataService: XCTestCase {
         let tmp = try createTmpDir()
         let data = try createDataService(tmp: tmp)
 
-        let address = MemoAddress(formatting: "Test", audience: .public)!
+        let address = Slug(formatting: "Test")!.toPublicMemoAddress()
         
         XCTAssertThrowsError(try data.readMemo(address: address))
     }
@@ -113,7 +113,7 @@ final class Tests_DataService: XCTestCase {
         let tmp = try createTmpDir()
         let data = try createDataService(tmp: tmp)
         
-        let address = MemoAddress(formatting: "Test", audience: .public)!
+        let address = Slug(formatting: "Test")!.toPublicMemoAddress()
         let memoIn = Memo(
             contentType: ContentType.subtext.rawValue,
             created: Date.now,
@@ -142,7 +142,7 @@ final class Tests_DataService: XCTestCase {
         let tmp = try createTmpDir()
         let data = try createDataService(tmp: tmp)
         
-        let address = MemoAddress(formatting: "Test", audience: .public)!
+        let address = Slug(formatting: "Test")!.toPublicMemoAddress()
         let memo = Memo(
             contentType: ContentType.subtext.rawValue,
             created: Date.now,
@@ -179,10 +179,10 @@ final class Tests_DataService: XCTestCase {
         let versionX = try data.noosphere.version()
         print("!!! X", versionX)
 
-        let addressA = MemoAddress(formatting: "a", audience: .public)!
-        let addressB = MemoAddress(formatting: "b", audience: .public)!
-        let addressC = MemoAddress(formatting: "c", audience: .public)!
-        let addressD = MemoAddress(formatting: "d", audience: .public)!
+        let addressA = Slug(formatting: "a")!.toPublicMemoAddress()
+        let addressB = Slug(formatting: "b")!.toPublicMemoAddress()
+        let addressC = Slug(formatting: "c")!.toPublicMemoAddress()
+        let addressD = Slug(formatting: "d")!.toPublicMemoAddress()
         
         let memo = Memo(
             contentType: ContentType.subtext.rawValue,

--- a/xcode/Subconscious/SubconsciousTests/Tests_Detail.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Detail.swift
@@ -199,9 +199,7 @@ class Tests_Detail: XCTestCase {
     
     func testShowRenameSheet() throws {
         let state = DetailModel()
-        let link = Slug(formatting: "Loomings")!
-            .toPublicMemoAddress()
-            .toEntryLink()
+        let link = EntryLink(title: "Loomings", audience: .public)!
         let update = DetailModel.update(
             state: state,
             action: .presentRenameSheet(

--- a/xcode/Subconscious/SubconsciousTests/Tests_Detail.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Detail.swift
@@ -407,9 +407,7 @@ class Tests_Detail: XCTestCase {
             )
         )
 
-        let parentLink = Slug(formatting: "The Lee Tide")!
-            .toPublicMemoAddress()
-            .toEntryLink(title: "The Lee Tide")
+        let parentLink = EntryLink(title: "The Lee Tide", audience: .public)!
 
         let update = DetailModel.update(
             state: state,

--- a/xcode/Subconscious/SubconsciousTests/Tests_Detail.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Detail.swift
@@ -312,12 +312,8 @@ class Tests_Detail: XCTestCase {
         let update = DetailModel.update(
             state: state,
             action: .succeedMoveEntry(
-                from: Slug(formatting: "The White Whale")!
-                    .toPublicMemoAddress()
-                    .toEntryLink(),
-                to: Slug(formatting: "The Lee Tide")!
-                    .toPublicMemoAddress()
-                    .toEntryLink()
+                from: EntryLink(title: "The White Whale", audience: .public)!,
+                to: EntryLink(title: "The Lee Tide", audience: .public)!
             ),
             environment: environment
         )

--- a/xcode/Subconscious/SubconsciousTests/Tests_Detail.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Detail.swift
@@ -243,9 +243,10 @@ class Tests_Detail: XCTestCase {
     
     func testRenameField() throws {
         let state = DetailModel(
-            entryToRename: Slug(formatting: "Dawson spoke and there was music")!
-                .toPublicMemoAddress()
-                .toEntryLink()
+            entryToRename: EntryLink(
+                title: "Dawson spoke and there was music",
+                audience: .public
+            )!
         )
         let update = DetailModel.update(
             state: state,

--- a/xcode/Subconscious/SubconsciousTests/Tests_Detail.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Detail.swift
@@ -262,12 +262,8 @@ class Tests_Detail: XCTestCase {
     }
     
     func testSucceedMoveEntry() throws {
-        let from = Slug(formatting: "loomings")!
-            .toPublicMemoAddress()
-            .toEntryLink()
-        let to = Slug(formatting: "The lee tide")!
-            .toPublicMemoAddress()
-            .toEntryLink(title: "The Lee Tide")
+        let from = EntryLink(title: "Loomings", audience: .public)!
+        let to = EntryLink(title: "The Lee Tide", audience: .public)!
         let state = DetailModel(
             address: from.address,
             headers: WellKnownHeaders(

--- a/xcode/Subconscious/SubconsciousTests/Tests_Detail.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Detail.swift
@@ -377,12 +377,8 @@ class Tests_Detail: XCTestCase {
         let update = DetailModel.update(
             state: state,
             action: .succeedRetitleEntry(
-                from: Slug(formatting: "wrong")!
-                    .toPublicMemoAddress()
-                    .toEntryLink(title: "Wrong"),
-                to: Slug(formatting: "wrong")!
-                    .toPublicMemoAddress()
-                    .toEntryLink(title: "WRONG")
+                from: EntryLink(title: "Wrong", audience: .public)!,
+                to: EntryLink(title: "WRONG", audience: .public)!
             ),
             environment: environment
         )

--- a/xcode/Subconscious/SubconsciousTests/Tests_EntryLink.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_EntryLink.swift
@@ -9,41 +9,6 @@ import XCTest
 @testable import Subconscious
 
 class Tests_EntryLink: XCTestCase {
-    func testTitle() throws {
-        guard let link = EntryLink(
-            title: "RAND Corporation",
-            audience: .public
-        ) else {
-            XCTFail("Expected title to parse to slug successfully")
-            return
-        }
-        XCTAssertEqual(
-            link.title,
-            "RAND Corporation",
-            "Title matches title given"
-        )
-        XCTAssertEqual(
-            String(link.address.slug),
-            "rand-corporation",
-            "Title is slugified correctly"
-        )
-    }
-
-    func testDeepTitle() throws {
-        guard let link = EntryLink(
-            title: "A deep title/With children",
-            audience: .public
-        ) else {
-            XCTFail("Expected title to parse to slug successfully")
-            return
-        }
-        XCTAssertEqual(
-            String(link.address.slug),
-            "a-deep-title/with-children",
-            "Title with slashes is converted to deep slug"
-        )
-    }
-
     func testSanitizeTitle() throws {
         let title = EntryLink.sanitizeTitle("  RAND\nCorporation  ")
         XCTAssertEqual(
@@ -54,30 +19,21 @@ class Tests_EntryLink: XCTestCase {
     }
 
     func testSanitizesTitle() throws {
-        guard let link = EntryLink(
-            title: "  RAND\nCorporation    ",
-            audience: .local
-        ) else {
-            XCTFail("Expected title to parse to slug successfully")
-            return
-        }
+        let link = EntryLink(
+            address: MemoAddress.local(Slug(formatting: "rand-corporation")!),
+            title: "  RAND\nCorporation    "
+        )
         XCTAssertEqual(
             link.title,
             "RAND Corporation",
             "Title is santized"
         )
-        XCTAssertEqual(
-            String(link.address.slug),
-            "rand-corporation",
-            "Title is slugified correctly"
-        )
     }
 
     func testSanitizesLinkableTitle() throws {
-        let text = "  RAND\nCorporation    "
         let link = EntryLink(
-            address: MemoAddress(formatting: text, audience: .local)!,
-            title: text
+            address: MemoAddress.local(Slug(formatting: "rand-corporation")!),
+            title: "  RAND\nCorporation    "
         )
         XCTAssertEqual(
             link.title,
@@ -98,7 +54,7 @@ class Tests_EntryLink: XCTestCase {
 
     func testSanitizesNonLinkableTitle() throws {
         let link = EntryLink(
-            address: MemoAddress(formatting: "something", audience: .local)!,
+            address: MemoAddress.local(Slug(formatting: "something")!),
             title: "  Something else    "
         )
         XCTAssertEqual(
@@ -117,26 +73,20 @@ class Tests_EntryLink: XCTestCase {
     /// the various sanitization steps don't somehow change the title.
     func testLeavesLinkableTitleFormattingAlone() throws {
         let stringDate = "2022-10-10 10:45:35"
-        guard let address = MemoAddress(
-            formatting: stringDate,
-            audience: .public
-        ) else {
-            XCTFail("Expected slug")
-            return
-        }
+
         let link = EntryLink(
-            address: address,
+            address: MemoAddress.local(Slug(formatting: stringDate)!),
             title: stringDate
         )
+
         XCTAssertEqual(link.linkableTitle, stringDate)
         XCTAssertEqual(link.title, stringDate)
     }
 
-    func testSlugOnlyEntryLinkToLinkableSentence() throws {
-        guard let address = MemoAddress(
-            formatting: "rand",
-            audience: .public
-        ) else {
+    func testSlugOnlyEntryLinkToLinkableTitle() throws {
+        guard
+            let address = Slug(formatting: "rand")?.toPublicMemoAddress()
+        else {
             XCTFail("Expected slug")
             return
         }
@@ -145,39 +95,6 @@ class Tests_EntryLink: XCTestCase {
             title,
             "Rand",
             "Title is derived by sentence-ifying slug when constructed without title"
-        )
-    }
-
-    func testWikilinkMarkupWithTitleMatchingSlug() throws {
-        guard let link = EntryLink(title: "RAND", audience: .public) else {
-            XCTFail("Expected title to parse to slug successfully")
-            return
-        }
-        let title = link.linkableTitle
-        XCTAssertEqual(
-            title,
-            "RAND",
-            "Title is used for wikilink text when slugified title matches slug"
-        )
-    }
-
-    func testWikilinkMarkupWithTitleNotMatchingSlug() throws {
-        guard let address = MemoAddress(
-            formatting: "rand",
-            audience: .public
-        ) else {
-            XCTFail("Expected slug")
-            return
-        }
-        let link = EntryLink(
-            address: address,
-            title: "RAND Corporation"
-        )
-        let title = link.linkableTitle
-        XCTAssertEqual(
-            title,
-            "Rand",
-            "Sentence-ified slug is used for wikilink text when slugified title does not match slug"
         )
     }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_MemoAddress.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_MemoAddress.swift
@@ -1,0 +1,57 @@
+//
+//  Tests_MemoAddress.swift
+//  SubconsciousTests
+//
+//  Created by Gordon Brander on 2/23/23.
+//
+
+import XCTest
+@testable import Subconscious
+
+final class Tests_MemoAddress: XCTestCase {
+    func testMemoAddressParseA() throws {
+        guard let address = MemoAddress("local::slug") else {
+            XCTFail("Failed to parse valid address string")
+            return
+        }
+        switch address {
+        case .local:
+            break
+        default:
+            XCTFail("Parsed type incorrectly")
+        }
+        XCTAssertEqual(address.slug, Slug("slug")!)
+    }
+    
+    func testMemoAddressParseB() throws {
+        guard let address = MemoAddress("public::slug") else {
+            XCTFail("Failed to parse valid address string")
+            return
+        }
+        switch address {
+        case .public:
+            break
+        default:
+            XCTFail("Parsed type incorrectly")
+        }
+        XCTAssertEqual(address.slug, Slug("slug")!)
+    }
+    
+    func testMemoAddressParseBadAddress() throws {
+        XCTAssertNil(MemoAddress("badwrong::slug"))
+        XCTAssertNil(MemoAddress("::slug"))
+        XCTAssertNil(MemoAddress("nope::slug"))
+        XCTAssertNil(MemoAddress("localbadwrong::slug"))
+        XCTAssertNil(MemoAddress("publicbadwrong::slug"))
+        XCTAssertNil(MemoAddress("xpublicx::slug"))
+        XCTAssertNil(MemoAddress(" public::slug"))
+        XCTAssertNil(MemoAddress(" local ::slug"))
+        XCTAssertNil(MemoAddress(":: slug"))
+        XCTAssertNil(MemoAddress("public:: slug"))
+        XCTAssertNil(MemoAddress("local:: slug"))
+        XCTAssertNil(MemoAddress("local::"))
+        XCTAssertNil(MemoAddress("local::/slug"))
+        XCTAssertNil(MemoAddress("local::slug/"))
+        XCTAssertNil(MemoAddress("local::/slug/"))
+    }
+}

--- a/xcode/Subconscious/SubconsciousTests/Tests_MemoAddress.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_MemoAddress.swift
@@ -54,4 +54,39 @@ final class Tests_MemoAddress: XCTestCase {
         XCTAssertNil(MemoAddress("local::slug/"))
         XCTAssertNil(MemoAddress("local::/slug/"))
     }
+    
+    func testEntryLinkExtensionTitle() throws {
+        guard let link = EntryLink(
+            title: "RAND Corporation",
+            audience: .public
+        ) else {
+            XCTFail("Expected title to parse to slug successfully")
+            return
+        }
+        XCTAssertEqual(
+            link.title,
+            "RAND Corporation",
+            "Title matches title given"
+        )
+        XCTAssertEqual(
+            String(link.address.slug),
+            "rand-corporation",
+            "Title is slugified correctly"
+        )
+    }
+
+    func testEntryLinkExtensionDeepTitle() throws {
+        guard let link = EntryLink(
+            title: "A deep title/With children",
+            audience: .public
+        ) else {
+            XCTFail("Expected title to parse to slug successfully")
+            return
+        }
+        XCTAssertEqual(
+            String(link.address.slug),
+            "a-deep-title/with-children",
+            "Title with slashes is converted to deep slug"
+        )
+    }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_NotebookUpdate.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_NotebookUpdate.swift
@@ -28,9 +28,9 @@ class Tests_NotebookUpdate: XCTestCase {
     }
 
     func testDeleteEntry() throws {
-        let a = MemoAddress(formatting: "A", audience: .public)!
-        let b = MemoAddress(formatting: "B", audience: .local)!
-        let c = MemoAddress(formatting: "C", audience: .local)!
+        let a = Slug(formatting: "A")!.toPublicMemoAddress()
+        let b = Slug(formatting: "B")!.toLocalMemoAddress()
+        let c = Slug(formatting: "C")!.toLocalMemoAddress()
         let state = NotebookModel(
             recent: [
                 EntryStub(

--- a/xcode/Subconscious/SubconsciousTests/Tests_Search.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Search.swift
@@ -84,10 +84,9 @@ class Tests_Search: XCTestCase {
             state: state,
             action: .activateSuggestion(
                 Suggestion.entry(
-                    EntryLink(
-                        title: "Red and orange and purple",
-                        audience: .local
-                    )!
+                    Slug(formatting: "Red and orange and purple")!
+                        .toLocalMemoAddress()
+                        .toEntryLink()
                 )
             ),
             environment: environment

--- a/xcode/Subconscious/SubconsciousTests/Tests_Search.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Search.swift
@@ -84,9 +84,10 @@ class Tests_Search: XCTestCase {
             state: state,
             action: .activateSuggestion(
                 Suggestion.entry(
-                    Slug(formatting: "Red and orange and purple")!
-                        .toLocalMemoAddress()
-                        .toEntryLink()
+                    EntryLink(
+                        title: "Red and orange and purple",
+                        audience: .local
+                    )!
                 )
             ),
             environment: environment


### PR DESCRIPTION
Previously MemoAddress was a struct containing an enum. This PR changes it to be an enum.

### Rationale

A local address should never have a petname, while a public address may have a petname (fully qualified e.g. @gordon/foo) or not (relative e.g. /foo).

Making the ID type itself an enum will alow us to smoothly evolve to a world where public posts can have fully qualified slashlinks.