### PR TITLE
Gateway Sync Status Indicator

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -178,11 +178,11 @@ enum AppDatabaseState {
     case ready
 }
 
-enum GatewaySyncStatus {
+enum GatewaySyncStatus: Equatable {
     case initial
     case inProgress
     case success
-    case failure
+    case failure(String)
 }
 
 //  MARK: Model
@@ -760,7 +760,7 @@ struct AppModel: ModelProtocol {
         logger.log("Sphere failed to sync with gateway: \(error)")
         
         var model = state
-        model.lastGatewaySyncStatus = .failure
+        model.lastGatewaySyncStatus = .failure(error)
         
         return update(
             state: model,

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -178,6 +178,13 @@ enum AppDatabaseState {
     case ready
 }
 
+enum GatewaySyncStatus {
+    case initial
+    case inProgress
+    case success
+    case failure
+}
+
 //  MARK: Model
 struct AppModel: ModelProtocol {
     /// Is database connected and migrated?
@@ -201,6 +208,7 @@ struct AppModel: ModelProtocol {
     var gatewayURL = AppDefaults.standard.gatewayURL
     var gatewayURLTextField = AppDefaults.standard.gatewayURL
     var isGatewayURLTextFieldValid = true
+    var gatewaySyncStatus = GatewaySyncStatus.initial
     
     /// Show settings sheet?
     var isSettingsSheetPresented = false
@@ -711,6 +719,10 @@ struct AppModel: ModelProtocol {
             logger.log("No gateway configured. Skipping sync.")
             return Update(state: state)
         }
+        
+        var model = state
+        model.gatewaySyncStatus = .inProgress
+        
         logger.log("Syncing with gateway: \(gatewayURL.absoluteString)")
         let fx: Fx<AppAction> = environment.data.syncSphereWithGateway()
             .map({ version in
@@ -720,7 +732,7 @@ struct AppModel: ModelProtocol {
                 Just(AppAction.failSyncSphereWithGateway(error.localizedDescription))
             })
             .eraseToAnyPublisher()
-        return Update(state: state, fx: fx)
+        return Update(state: model, fx: fx)
     }
     
     static func succeedSyncSphereWithGateway(
@@ -729,8 +741,12 @@ struct AppModel: ModelProtocol {
         version: String
     ) -> Update<AppModel> {
         logger.log("Sphere synced with gateway @ \(version)")
+        
+        var model = state
+        model.gatewaySyncStatus = .success
+        
         return update(
-            state: state,
+            state: model,
             action: .syncSphereWithDatabase,
             environment: environment
         )
@@ -742,8 +758,12 @@ struct AppModel: ModelProtocol {
         error: String
     ) -> Update<AppModel> {
         logger.log("Sphere failed to sync with gateway: \(error)")
+        
+        var model = state
+        model.gatewaySyncStatus = .failure
+        
         return update(
-            state: state,
+            state: model,
             action: .syncSphereWithDatabase,
             environment: environment
         )

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -208,7 +208,7 @@ struct AppModel: ModelProtocol {
     var gatewayURL = AppDefaults.standard.gatewayURL
     var gatewayURLTextField = AppDefaults.standard.gatewayURL
     var isGatewayURLTextFieldValid = true
-    var gatewaySyncStatus = GatewaySyncStatus.initial
+    var lastGatewaySyncStatus = GatewaySyncStatus.initial
     
     /// Show settings sheet?
     var isSettingsSheetPresented = false
@@ -721,7 +721,7 @@ struct AppModel: ModelProtocol {
         }
         
         var model = state
-        model.gatewaySyncStatus = .inProgress
+        model.lastGatewaySyncStatus = .inProgress
         
         logger.log("Syncing with gateway: \(gatewayURL.absoluteString)")
         let fx: Fx<AppAction> = environment.data.syncSphereWithGateway()
@@ -743,7 +743,7 @@ struct AppModel: ModelProtocol {
         logger.log("Sphere synced with gateway @ \(version)")
         
         var model = state
-        model.gatewaySyncStatus = .success
+        model.lastGatewaySyncStatus = .success
         
         return update(
             state: model,
@@ -760,7 +760,7 @@ struct AppModel: ModelProtocol {
         logger.log("Sphere failed to sync with gateway: \(error)")
         
         var model = state
-        model.gatewaySyncStatus = .failure
+        model.lastGatewaySyncStatus = .failure
         
         return update(
             state: model,

--- a/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
@@ -12,13 +12,33 @@ struct GatewaySyncLabel: View {
     var status: GatewaySyncStatus
     @State var spin = false
     
+    func label(status: GatewaySyncStatus) -> String {
+        switch (status) {
+        case .initial:
+            return "Sync with Gateway"
+        case .inProgress:
+            return "Syncing..."
+        case .failure:
+            return "Sync Failed"
+        case .success:
+            return "Sync Complete"
+        }
+    }
+    
     var body: some View {
         HStack {
+            Text(label(status: status))
+                .foregroundColor(status == .failure ? .red : .accentColor)
+            
+            Spacer()
+            
             switch (status) {
             case .initial:
                 Image(systemName: "arrow.triangle.2.circlepath")
+                    .foregroundColor(.secondary)
             case .inProgress:
                 Image(systemName: "arrow.triangle.2.circlepath")
+                    .foregroundColor(.accentColor)
                     .rotationEffect(.degrees(spin ? 360 : 0))
                     .animation(Animation.linear
                         .repeatForever(autoreverses: false)
@@ -28,11 +48,12 @@ struct GatewaySyncLabel: View {
                     }
             case .success:
                 Image(systemName: "checkmark.circle")
+                    .foregroundColor(.secondary)
             case .failure:
                 Image(systemName: "exclamationmark.arrow.triangle.2.circlepath")
+                    .foregroundColor(.red)
             }
             
-            Text("Sync with Gateway")
         }
     }
 }

--- a/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
@@ -11,6 +11,8 @@ import ObservableStore
 struct SettingsView: View {
     @ObservedObject var app: Store<AppModel>
     var unknown = "Unknown"
+    
+    @State private var spin = false
 
     var body: some View {
         NavigationStack {
@@ -61,7 +63,27 @@ struct SettingsView: View {
                             app.send(.syncSphereWithGateway)
                         },
                         label: {
-                            Text("Sync with Gateway")
+                            HStack {
+                                switch (app.state.gatewaySyncStatus) {
+                                case .initial:
+                                    Image(systemName: "arrow.triangle.2.circlepath")
+                                case .inProgress:
+                                    Image(systemName: "arrow.triangle.2.circlepath")
+                                        .rotationEffect(.degrees(spin ? 360 : 0))
+                                        .animation(Animation.linear
+                                            .repeatForever(autoreverses: false)
+                                            .speed(0.4), value: spin)
+                                        .onAppear() {
+                                            self.spin = true
+                                        }
+                                case .success:
+                                    Image(systemName: "checkmark.circle")
+                                case .failure:
+                                    Image(systemName: "exclamationmark.arrow.triangle.2.circlepath")
+                                }
+                                
+                                Text("Sync with Gateway")
+                            }
                         }
                     )
                 }

--- a/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
@@ -8,6 +8,35 @@
 import SwiftUI
 import ObservableStore
 
+struct GatewaySyncLabel: View {
+    var status: GatewaySyncStatus
+    @State var spin = false
+    
+    var body: some View {
+        HStack {
+            switch (status) {
+            case .initial:
+                Image(systemName: "arrow.triangle.2.circlepath")
+            case .inProgress:
+                Image(systemName: "arrow.triangle.2.circlepath")
+                    .rotationEffect(.degrees(spin ? 360 : 0))
+                    .animation(Animation.linear
+                        .repeatForever(autoreverses: false)
+                        .speed(0.4), value: spin)
+                    .onAppear() {
+                        self.spin = true
+                    }
+            case .success:
+                Image(systemName: "checkmark.circle")
+            case .failure:
+                Image(systemName: "exclamationmark.arrow.triangle.2.circlepath")
+            }
+            
+            Text("Sync with Gateway")
+        }
+    }
+}
+
 struct SettingsView: View {
     @ObservedObject var app: Store<AppModel>
     var unknown = "Unknown"
@@ -63,27 +92,7 @@ struct SettingsView: View {
                             app.send(.syncSphereWithGateway)
                         },
                         label: {
-                            HStack {
-                                switch (app.state.gatewaySyncStatus) {
-                                case .initial:
-                                    Image(systemName: "arrow.triangle.2.circlepath")
-                                case .inProgress:
-                                    Image(systemName: "arrow.triangle.2.circlepath")
-                                        .rotationEffect(.degrees(spin ? 360 : 0))
-                                        .animation(Animation.linear
-                                            .repeatForever(autoreverses: false)
-                                            .speed(0.4), value: spin)
-                                        .onAppear() {
-                                            self.spin = true
-                                        }
-                                case .success:
-                                    Image(systemName: "checkmark.circle")
-                                case .failure:
-                                    Image(systemName: "exclamationmark.arrow.triangle.2.circlepath")
-                                }
-                                
-                                Text("Sync with Gateway")
-                            }
+                            GatewaySyncLabel(status: app.state.gatewaySyncStatus)
                         }
                     )
                 }

--- a/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
@@ -41,8 +41,6 @@ struct SettingsView: View {
     @ObservedObject var app: Store<AppModel>
     var unknown = "Unknown"
     
-    @State private var spin = false
-
     var body: some View {
         NavigationStack {
             Form {

--- a/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
@@ -92,7 +92,7 @@ struct SettingsView: View {
                             app.send(.syncSphereWithGateway)
                         },
                         label: {
-                            GatewaySyncLabel(status: app.state.gatewaySyncStatus)
+                            GatewaySyncLabel(status: app.state.lastGatewaySyncStatus)
                         }
                     )
                 }

--- a/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
@@ -27,8 +27,23 @@ struct GatewaySyncLabel: View {
     
     var body: some View {
         HStack {
-            Text(label(status: status))
-                .foregroundColor(status == .failure ? .red : .accentColor)
+            VStack(alignment: .leading) {
+                switch (status) {
+                case .failure(_):
+                    Text(label(status: status))
+                        .foregroundColor(.red)
+                default:
+                    Text(label(status: status))
+                        .foregroundColor(.accentColor)
+                }
+                
+                if case .failure(let message) = status {
+                    Text("\(message)")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+
             
             Spacer()
             


### PR DESCRIPTION
There's currently no UI feedback for the gateway sync making it hard to tell if it worked as a user. This PR tracks the status of the sync operation in the `AppModel` and uses that to display a status icon next to the sync button in the `SettingsView`.

The `.inProgress` state is animated, because it's the little things...

<img width="363" alt="Screenshot 2023-03-02 at 12 08 20 pm" src="https://user-images.githubusercontent.com/5009316/222312504-1d857020-880c-4c40-8fda-4e65f2550524.png">
<img width="364" alt="Screenshot 2023-03-02 at 12 08 05 pm" src="https://user-images.githubusercontent.com/5009316/222312510-ba735795-f22d-49d7-8d2a-0bb3db9b4219.png">

https://user-images.githubusercontent.com/5009316/222312511-cdf83d69-9451-4f4f-99f3-a09ae639ab09.mov


