### PR TITLE
Embedded SwiftUI Transclude Blocks

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -904,6 +904,7 @@ struct AppEnvironment {
 
     var data: DataService
     var feed: FeedService
+    var slashlinks: SlashlinkLookupService
     
     var recoveryPhrase = RecoveryPhraseEnvironment()
     var addressBook: AddressBookEnvironment
@@ -962,18 +963,19 @@ struct AppEnvironment {
             migrations: Config.migrations
         )
         
-        let addresBook = AddressBookService(noosphere: noosphere, database: databaseService)
+        let addressBook = AddressBookService(noosphere: noosphere, database: databaseService)
         
         self.data = DataService(
             noosphere: noosphere,
             database: databaseService,
             local: local,
-            addressBook: addresBook
+            addressBook: addressBook
         )
         
         self.addressBook = AddressBookEnvironment(data: data)
 
         self.feed = FeedService()
+        self.slashlinks = SlashlinkLookupService(database: databaseService)
     }
 }
 

--- a/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
@@ -336,13 +336,17 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
             else {
                 return baseLayoutFragment
             }
+            
+            guard let entry = slashlinkPreviews[slashlink] else {
+                return baseLayoutFragment
+            }
 
             let layoutFragment = TranscludeBlockLayoutFragment(
                 textElement: paragraph,
                 range: paragraph.elementRange
             )
             layoutFragment.slashlink = slashlink
-            layoutFragment.entry = slashlinkPreviews[slashlink]
+            layoutFragment.entry = entry
             
             return layoutFragment
         }

--- a/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
@@ -179,7 +179,6 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
         /// which triggers an update, which triggers an event, etc.
         var isUIViewUpdating: Bool
         var representable: SubtextTextViewRepresentable
-        var renderTranscludeBlocks: Bool = false
         /// Subtext renderer instance
         var renderer: SubtextAttributedStringRenderer
         var subtext: Subtext? = nil
@@ -297,7 +296,7 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
                 range: textElement.elementRange
             )
  
-            guard renderTranscludeBlocks else {
+            guard Config.default.renderTranscludeBlocks else {
                 return baseLayoutFragment
             }
 

--- a/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
@@ -172,7 +172,7 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
                 }
                 
                 SubtextTextViewRepresentable.logger.debug("Tapped: \(slashlink)")
-                let x = onSlashlink(slashlink)
+                let _ = onSlashlink(slashlink)
                 
                 // Calling super preserves default behaviour
                 super.touchesBegan(touches, with: event)

--- a/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
@@ -69,6 +69,7 @@ struct SubtextTextModel: ModelProtocol {
         environment: Void
     ) -> Update<Self> {
         switch action {
+       
         case .requestFocus(let focus):
             var model = state
             model.isFocusChangeScheduled = false
@@ -222,6 +223,12 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
 
             // Render markup on TextStorage (which is an NSMutableString)
             self.subtext = renderer.renderAttributesOf(textStorage)
+            let links = self.subtext?.slashlinks.map { value in value.toSlashlink() }.compactMap { value in value }
+            guard let slashlinks = links else {
+                return
+            }
+            
+            self.representable.onFetchSlashlinkPreviews(slashlinks)
         }
 
         /// Handle link taps
@@ -341,6 +348,7 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
     
     var state: SubtextTextModel
     var send: (SubtextTextAction) -> Void
+    var onFetchSlashlinkPreviews: ([Slashlink]) -> Void
     /// Frame needed to determine textview height.
     /// Use `GeometryView` to find container width.
     var frame: CGRect

--- a/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
@@ -340,6 +340,9 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
             guard let entry = slashlinkPreviews[slashlink] else {
                 return baseLayoutFragment
             }
+            guard let container = textLayoutManager.textContainer else {
+                return baseLayoutFragment
+            }
 
             let layoutFragment = TranscludeBlockLayoutFragment(
                 textElement: paragraph,
@@ -347,6 +350,7 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
             )
             layoutFragment.slashlink = slashlink
             layoutFragment.entry = entry
+            layoutFragment.prepare(textContainer: container)
             
             return layoutFragment
         }

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeBlockLayoutFragment.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeBlockLayoutFragment.swift
@@ -68,12 +68,16 @@ class TranscludeBlockLayoutFragment: NSTextLayoutFragment {
     
     var hosted: UIHostingController<EmbeddedTranscludePreview>?
     
+    let MAX_HEIGHT: CGFloat = 128.0
+    
     override var leadingPadding: CGFloat { return 0 }
     override var trailingPadding: CGFloat { return 0 }
     override var topMargin: CGFloat { return 0 }
     override var bottomMargin: CGFloat { return 0 }
     
     func prepare(textContainer: NSTextContainer) {
+        let width = textContainer.size.width
+        
         guard let slashlink = slashlink else {
             TranscludeBlockLayoutFragment.logger.warning("nil slashlink provided to transclude block")
             return
@@ -84,6 +88,7 @@ class TranscludeBlockLayoutFragment: NSTextLayoutFragment {
             return
         }
         
+        // Construct view
         let v = EmbeddedTranscludePreview(
             address: MemoAddress.public(slashlink),
             excerpt: entry.excerpt
@@ -98,12 +103,9 @@ class TranscludeBlockLayoutFragment: NSTextLayoutFragment {
             return
         }
         
-        let width = textContainer.size.width
-        
         view.backgroundColor = .clear
-        mountSubview(view: view)
-        
         view.translatesAutoresizingMaskIntoConstraints = false
+        mountSubview(view: view)
         
         // First, we try and render the view at zero size
         do {
@@ -112,10 +114,8 @@ class TranscludeBlockLayoutFragment: NSTextLayoutFragment {
             view.bounds = CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: width, height: fit.height))
         }
         
-        let HEIGHT_CONSTRAINT = 128.0
-        
         // Re-layout at the frame size. Now, magically, the fit will return the minimum height needed to fit the view.
-        let fit = hosted.sizeThatFits(in: CGSize(width: width, height: HEIGHT_CONSTRAINT))
+        let fit = hosted.sizeThatFits(in: CGSize(width: width, height: MAX_HEIGHT))
         view.frame = CGRect(origin: CGPoint(x: 0, y: fit.height), size: CGSize(width: 0, height: fit.height))
         view.bounds = CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: width, height: fit.height))
         
@@ -165,7 +165,6 @@ class TranscludeBlockLayoutFragment: NSTextLayoutFragment {
         let img = view.asImage()
         unmountSubview()
         
-        // Cache for reuse in layout calculations
         return img
     }
     

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeBlockLayoutFragment.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeBlockLayoutFragment.swift
@@ -76,6 +76,9 @@ class TranscludeBlockLayoutFragment: NSTextLayoutFragment {
     var text: String?
     var height: CGFloat? = 128.0
     
+    var slashlink: Slashlink?
+    var entry: EntryStub?
+    
     override var leadingPadding: CGFloat { return 0 }
     override var trailingPadding: CGFloat { return 0 }
     override var topMargin: CGFloat { return 0 }
@@ -93,13 +96,15 @@ class TranscludeBlockLayoutFragment: NSTextLayoutFragment {
         
         let content = textContentStorage.attributedString(for: textElement)
         let rawContent = content?.string.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let slashlink = Slashlink(rawContent ?? "/fallback") else {
+        
+        guard let slashlink = slashlink else {
+            TranscludeBlockLayoutFragment.logger.warning("nil slashlink provided to transclude block")
             return
         }
         
         let v = Transclude2View(
             address: MemoAddress.public(slashlink),
-            excerpt: "Call me Ishmael.",
+            excerpt: entry?.excerpt ?? "MISSING ENTRY",
             action: { }
         )
         

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeBlockLayoutFragment.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeBlockLayoutFragment.swift
@@ -94,9 +94,6 @@ class TranscludeBlockLayoutFragment: NSTextLayoutFragment {
             return
         }
         
-        let content = textContentStorage.attributedString(for: textElement)
-        let rawContent = content?.string.trimmingCharacters(in: .whitespacesAndNewlines)
-        
         guard let slashlink = slashlink else {
             TranscludeBlockLayoutFragment.logger.warning("nil slashlink provided to transclude block")
             return

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeBlockLayoutFragment.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeBlockLayoutFragment.swift
@@ -26,23 +26,12 @@ import Cocoa
 import CoreGraphics
 
 struct EmbeddedTranscludePreview: View {
-    var label: String = "Subconscious"
+    var address: MemoAddress
+    var excerpt: String
     
     var body: some View {
-        VStack(alignment: .leading) {
-            Text("title")
-            Text(label)
-                .multilineTextAlignment(.leading)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        }
-        .padding(4)
-        .frame(maxWidth: .infinity, maxHeight: 128) // TODO: share constant for all instances of 128
-        .background(.white)
-        .overlay(
-            RoundedRectangle(cornerRadius: 4)
-                .stroke(.purple, lineWidth: 2)
-            )
-        .padding(2)
+        Transclude2View(address: address, excerpt: excerpt, action: {})
+            .padding(1)
     }
 }
 
@@ -87,22 +76,19 @@ class TranscludeBlockLayoutFragment: NSTextLayoutFragment {
     private var img: UIImage?
     
     private func render() {
-        guard let textContentStorage = self.textLayoutManager?.textContentManager as? NSTextContentStorage else {
-            return
-        }
-        guard let textElement = textElement else {
-            return
-        }
-        
         guard let slashlink = slashlink else {
             TranscludeBlockLayoutFragment.logger.warning("nil slashlink provided to transclude block")
             return
         }
         
-        let v = Transclude2View(
+        guard let entry = entry else {
+            TranscludeBlockLayoutFragment.logger.warning("nil entry provided to transclude block")
+            return
+        }
+        
+        let v = EmbeddedTranscludePreview(
             address: MemoAddress.public(slashlink),
-            excerpt: entry?.excerpt ?? "MISSING ENTRY",
-            action: { }
+            excerpt: entry.excerpt
         )
         
         // Host our SwiftUI view within a UIKit view

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeBlockLayoutFragment.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeBlockLayoutFragment.swift
@@ -5,6 +5,16 @@
 //  Created by Ben Follington on 28/2/2023.
 //
 
+/*
+ Copyright © 2022 Apple Inc.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
 import os
 import SwiftUI
 
@@ -15,16 +25,122 @@ import Cocoa
 #endif
 import CoreGraphics
 
+struct EmbeddedTranscludePreview: View {
+    var label: String = "Subconscious"
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("title")
+            Text(label)
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+        .padding(4)
+        .frame(maxWidth: .infinity, maxHeight: 128) // TODO: share constant for all instances of 128
+        .background(.white)
+        .overlay(
+            RoundedRectangle(cornerRadius: 4)
+                .stroke(.purple, lineWidth: 2)
+            )
+        .padding(2)
+    }
+}
+
+extension UIView {
+    func asImage() -> UIImage {
+        let renderer = UIGraphicsImageRenderer(bounds: bounds)
+        let img = renderer.image { rendererContext in
+            rendererContext.cgContext.saveGState()
+            
+            // SwiftUI views render upside down by default, flip them
+            let flipVertical: CGAffineTransform = CGAffineTransform(a: 1, b: 0, c: 0, d: -1, tx: 0, ty: bounds.height )
+            rendererContext.cgContext.concatenate(flipVertical)
+            
+            layer.render(in: rendererContext.cgContext)
+            
+            rendererContext.cgContext.restoreGState()
+        }
+        
+        return img
+    }
+}
+
 class TranscludeBlockLayoutFragment: NSTextLayoutFragment {
     static var logger = Logger(
         subsystem: Config.default.rdns,
         category: "editor"
     )
 
+    // Max height constraint
+    let SLASHLINK_PREVIEW_HEIGHT = 128.0
+    var text: String?
+    
     override var leadingPadding: CGFloat { return 0 }
     override var trailingPadding: CGFloat { return 0 }
     override var topMargin: CGFloat { return 0 }
     override var bottomMargin: CGFloat { return 0 }
+    
+    private var img: UIImage?
+    
+    private func render() {
+        let v = EmbeddedTranscludePreview(label: text ?? "Testing")
+        // Host our SwiftUI view within a UIKit view
+        let hosted = UIHostingController(rootView: v)
+        guard let view = hosted.view else {
+            return
+        }
+        
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        // We have to mount the view before it will actually do layout calculations
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
+            TranscludeBlockLayoutFragment.logger.warning("Could not find UIWindowScene")
+            return
+        }
+        
+        guard let rootView = scene.windows.first?.rootViewController?.view else {
+            TranscludeBlockLayoutFragment.logger.warning("Could not find rootViewController")
+            return
+        }
+        
+        rootView.addSubview(hosted.view)
+        
+        // Ideally here is where we would dynamically adjust the height of the rendered card
+        // However there doesn't seem to be a way to get the "preferred" size of the child content, it always tries to expand to fill the space provided
+        // This might be due to the underlying UIKit constraint system
+        let size = hosted.sizeThatFits(in: CGSize(width: containerWidth(), height: SLASHLINK_PREVIEW_HEIGHT))
+        hosted.view.frame = CGRect(origin: CGPoint(x: 0, y: SLASHLINK_PREVIEW_HEIGHT), size: CGSize(width: containerWidth(), height: size.height))
+        hosted.view.bounds = CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: containerWidth(), height: size.height ))
+        hosted.view.backgroundColor = .clear
+        
+        let img = view.asImage()
+        hosted.view.removeFromSuperview()
+        
+        // Cache for reuse in layout calculations
+        self.img = img
+        
+        // Reflow the document layout to include the subview dimensions
+        invalidateLayout()
+    }
+    
+    private func containerWidth() -> CGFloat {
+        return self.textLayoutManager!.textContainer!.size.width - leadingPadding - trailingPadding
+    }
+    
+    // Determines how this flows around text
+    override var layoutFragmentFrame: CGRect {
+        let parent = super.layoutFragmentFrame
+        let r = CGRect(origin: parent.origin, size: CGSize(width: parent.width, height: parent.height + (self.img?.size.height ?? 0)))
+        return r
+    }
+    
+    // Determines the full drawing bounds, should be larger than layoutFragmentFrame
+    override var renderingSurfaceBounds: CGRect {
+        let w = containerWidth()
+        
+        let size = super.renderingSurfaceBounds.union(CGRect(x: 0, y: 0, width: w, height: SLASHLINK_PREVIEW_HEIGHT))
+        return size
+    }
     
     private func withTranslation(x: CGFloat, y: CGFloat, ctx: CGContext, perform: (CGContext) -> Void) {
         ctx.translateBy(x: x, y: y)
@@ -33,12 +149,22 @@ class TranscludeBlockLayoutFragment: NSTextLayoutFragment {
     }
     
     override func draw(at renderingOrigin: CGPoint, in ctx: CGContext) {
+        render()
         ctx.saveGState()
         
-        // DEBUG: render border around entire draw surface
-        withTranslation(x: leadingPadding, y: 0, ctx: ctx) { ctx in
-            ctx.stroke(CGRect(origin: renderingSurfaceBounds.origin, size: renderingSurfaceBounds.size))
+        if let img = self.img {
+            let height = img.size.height
+            withTranslation(x: leadingPadding, y: super.layoutFragmentFrame.height, ctx: ctx) { ctx in
+                ctx.draw(img.cgImage!, in: CGRect(x: 0, y: 0, width: img.size.width, height: height))
+                // DEBUG: Render border around the cached view image
+//                ctx.stroke(CGRect(origin: renderingSurfaceBounds.origin, size: img.size))
+            }
         }
+        
+        // DEBUG: render border around entire draw surface
+//        withTranslation(x: leadingPadding, y: 0, ctx: ctx) { ctx in
+//            ctx.stroke(CGRect(origin: renderingSurfaceBounds.origin, size: renderingSurfaceBounds.size))
+//        }
         
         ctx.restoreGState()
         

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeBlockLayoutFragment.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeBlockLayoutFragment.swift
@@ -165,6 +165,8 @@ class TranscludeBlockLayoutFragment: NSTextLayoutFragment {
         let img = view.asImage()
         unmountSubview()
         
+        print("ORIGIN \(layoutFragmentFrame.origin) \(layoutFragmentFrame.size)")
+        
         return img
     }
     
@@ -200,7 +202,8 @@ class TranscludeBlockLayoutFragment: NSTextLayoutFragment {
         
         let height = img.size.height
         withTranslation(x: leadingPadding, y: super.layoutFragmentFrame.height, ctx: ctx) { ctx in
-            ctx.draw(img.cgImage!, in: CGRect(x: 0, y: 0, width: img.size.width, height: height))
+//            ctx.draw(img.cgImage!, in: CGRect(x: 0, y: 0, width: img.size.width, height: height))
+//            ctx.fill([CGRect(x: 0, y: 0, width: img.size.width, height: img.size.height)])
             // DEBUG: Render border around the cached view image
 //                ctx.stroke(CGRect(origin: renderingSurfaceBounds.origin, size: img.size))
         }

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -45,6 +45,18 @@ struct MemoEditorDetailView: View {
         )
         return false
     }
+    
+    private func onSlashlink(
+        slashlink: Slashlink
+    ) -> Bool {
+        notify(
+            .requestFindDetail(
+                slashlink: slashlink,
+                fallback: slashlink.toSlug().toTitle()
+            )
+        )
+        return false
+    }
 
     var body: some View {
         GeometryReader { geometry in
@@ -58,7 +70,8 @@ struct MemoEditorDetailView: View {
                                 tag: MemoEditorDetailSubtextTextCursor.tag
                             ),
                             frame: geometry.frame(in: .local),
-                            onLink: self.onLink
+                            onLink: self.onLink,
+                            onSlashlink: self.onSlashlink
                         )
                         .insets(
                             EdgeInsets(

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -57,6 +57,12 @@ struct MemoEditorDetailView: View {
         )
         return false
     }
+    
+    private func onFetchSlashlinkPreviews(
+        slashlinks: [Slashlink]
+    ) -> Void {
+        notify(.fetchSlashlinkPreviews(slashlinks))
+    }
 
     var body: some View {
         GeometryReader { geometry in
@@ -69,6 +75,7 @@ struct MemoEditorDetailView: View {
                                 send: store.send,
                                 tag: MemoEditorDetailSubtextTextCursor.tag
                             ),
+                            onFetchSlashlinkPreviews: self.onFetchSlashlinkPreviews,
                             frame: geometry.frame(in: .local),
                             onLink: self.onLink,
                             onSlashlink: self.onSlashlink
@@ -262,6 +269,9 @@ enum MemoEditorDetailNotification: Hashable {
     case succeedMergeEntry(parent: MemoAddress, child: MemoAddress)
     case succeedSaveEntry(address: MemoAddress, modified: Date)
     case succeedUpdateAudience(_ receipt: MoveReceipt)
+    case fetchSlashlinkPreviews([Slashlink])
+    
+
 }
 
 extension MemoEditorDetailNotification {

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -69,29 +69,47 @@ struct MemoEditorDetailView: View {
             VStack(spacing: 0) {
                 ScrollView(.vertical) {
                     VStack(spacing: 0) {
-                        SubtextTextViewRepresentable(
-                            state: store.state.editor,
-                            send: Address.forward(
-                                send: store.send,
-                                tag: MemoEditorDetailSubtextTextCursor.tag
-                            ),
-                            onFetchSlashlinkPreviews: self.onFetchSlashlinkPreviews,
-                            frame: geometry.frame(in: .local),
-                            onLink: self.onLink,
-                            onSlashlink: self.onSlashlink
-                        )
-                        .insets(
-                            EdgeInsets(
-                                top: AppTheme.padding,
-                                leading: AppTheme.padding,
-                                bottom: AppTheme.padding,
-                                trailing: AppTheme.padding
+                        ZStack(alignment: .top) {
+                            SubtextTextViewRepresentable(
+                                state: store.state.editor,
+                                send: Address.forward(
+                                    send: store.send,
+                                    tag: MemoEditorDetailSubtextTextCursor.tag
+                                ),
+                                onFetchSlashlinkPreviews: self.onFetchSlashlinkPreviews,
+                                frame: geometry.frame(in: .local),
+                                onLink: self.onLink,
+                                onSlashlink: self.onSlashlink
                             )
-                        )
-                        .frame(
-                            minHeight: UIFont.appTextMono.lineHeight * 8
-
-                        )
+                            .insets(
+                                EdgeInsets(
+                                    top: AppTheme.padding,
+                                    leading: AppTheme.padding,
+                                    bottom: AppTheme.padding,
+                                    trailing: AppTheme.padding
+                                )
+                            )
+                            .frame(
+                                minHeight: UIFont.appTextMono.lineHeight * 8
+                            )
+                            
+                            Group {
+                                Transclude2View(
+                                    address: MemoAddress.public(Slashlink("/same-ish-different-day")!),
+                                    excerpt: "Short.",
+                                    action: { }
+                                )
+                                .offset(x: -4, y:  212.6666 + 26 )
+                                
+                                Transclude2View(
+                                    address: MemoAddress.public(Slashlink("/here-is-a-possible-title")!),
+                                    excerpt: "Here is a possivle title, with more content to appear in the except!",
+                                    action: { }
+                                )
+                                .offset(x: -4, y:  45.5999 + 26 )
+                            }
+                            .padding(AppTheme.padding)
+                        }
                         ThickDividerView()
                             .padding(.bottom, AppTheme.unit4)
                         BacklinksView(

--- a/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
@@ -168,8 +168,6 @@ enum NotebookAction {
     case pushRandomDetail(autofocus: Bool)
     case failPushRandomDetail(String)
     
-    case fetchSlashlinkPreviews([Slashlink])
-    case populateSlashlinkPreviews(Dictionary<Slashlink, EntryStub>)
     
     /// Set search query
     static func setSearch(_ query: String) -> NotebookAction {
@@ -242,8 +240,6 @@ extension NotebookAction: CustomLogStringConvertible {
 extension NotebookAction {
     static func tag(_ action: MemoEditorDetailNotification) -> Self {
         switch action {
-        case .fetchSlashlinkPreviews(let slashlinks):
-            return .fetchSlashlinkPreviews(slashlinks)
         case .requestDelete(let address):
             return .deleteEntry(address)
         case let .requestDetail(detail):
@@ -533,22 +529,7 @@ struct NotebookModel: ModelProtocol {
         case .failPushRandomDetail(let error):
             logger.log("Failed to get random note: \(error)")
             return Update(state: state)
-            
-        case .fetchSlashlinkPreviews(let slashlinks):
-           let fx: Fx<NotebookAction> =
-               environment.slashlinks.listEntriesForSlashlinksAsync(slashlinks: slashlinks)
-               .catch({ err in
-                   Just([:])
-               })
-               .map { v in
-                   NotebookAction.populateSlashlinkPreviews(v)
-               }
-               .eraseToAnyPublisher()
-           
-           return Update(state: state, fx: fx)
-            
-        case .populateSlashlinkPreviews(let slashlinks):
-           return Update(state: state)
+      
         }
     }
     

--- a/xcode/Subconscious/Shared/Config.swift
+++ b/xcode/Subconscious/Shared/Config.swift
@@ -26,7 +26,7 @@ struct Config: Equatable, Codable {
         }
     }
     
-    var renderTranscludeBlocks: Bool = false
+    var renderTranscludeBlocks = false
 
     /// Standard interval at which to run long-polling services
     var pollingInterval: Double = 15

--- a/xcode/Subconscious/Shared/Config.swift
+++ b/xcode/Subconscious/Shared/Config.swift
@@ -26,7 +26,7 @@ struct Config: Equatable, Codable {
         }
     }
     
-    var renderTranscludeBlocks = false
+    var renderTranscludeBlocks = true
 
     /// Standard interval at which to run long-polling services
     var pollingInterval: Double = 15

--- a/xcode/Subconscious/Shared/Config.swift
+++ b/xcode/Subconscious/Shared/Config.swift
@@ -25,6 +25,8 @@ struct Config: Equatable, Codable {
             debug ? "did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7" : ""
         }
     }
+    
+    var renderTranscludeBlocks: Bool = false
 
     /// Standard interval at which to run long-polling services
     var pollingInterval: Double = 15

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -361,6 +361,12 @@ struct DataService {
             try database.listRecentMemos()
         }
     }
+    
+    func listEntriesForSlashlinks(slashlinks: [Slashlink]) -> AnyPublisher<[EntryStub], Error> {
+        CombineUtilities.async(qos: .default) {
+            try database.listEntriesForSlashlinks(slashlinks: slashlinks)
+        }
+    }
 
     func countMemos() throws -> Int {
         return try database.countMemos().unwrap()

--- a/xcode/Subconscious/Shared/Services/SlashlinkLookupService.swift
+++ b/xcode/Subconscious/Shared/Services/SlashlinkLookupService.swift
@@ -17,7 +17,7 @@ class SlashlinkLookupService {
         self.cache = Dictionary()
     }
     
-    func listEntriesForSlashlinks(slashlinks: [Slashlink]) throws -> [EntryStub] {
+    func listEntriesForSlashlinks(slashlinks: [Slashlink]) throws -> Dictionary<Slashlink, EntryStub> {
         // Check for cached data
         let cacheHits =
             slashlinks.map { s in
@@ -27,7 +27,7 @@ class SlashlinkLookupService {
         
         // Do we have it all? Early return
         if cacheHits.count == slashlinks.count {
-            return cacheHits
+            return cache
         }
         
         // Otherwise, only look up the cache misses
@@ -40,10 +40,10 @@ class SlashlinkLookupService {
         }
         
         // Combine the two sets of results
-        return result + cacheHits
+        return cache
     }
     
-    func listEntriesForSlashlinksAsync(slashlinks: [Slashlink]) -> AnyPublisher<[EntryStub], Error> {
+    func listEntriesForSlashlinksAsync(slashlinks: [Slashlink]) -> AnyPublisher<Dictionary<Slashlink, EntryStub>, Error> {
         CombineUtilities.async(qos: .default) {
             return try self.listEntriesForSlashlinks(slashlinks: slashlinks)
         }

--- a/xcode/Subconscious/Shared/Services/SlashlinkLookupService.swift
+++ b/xcode/Subconscious/Shared/Services/SlashlinkLookupService.swift
@@ -1,0 +1,51 @@
+//
+//  SlashlinkLookupService.swift
+//  Subconscious
+//
+//  Created by Ben Follington on 23/3/2023.
+//
+
+import Foundation
+import Combine
+
+class SlashlinkLookupService {
+    var database: DatabaseService
+    private var cache: Dictionary<Slashlink, EntryStub>
+    
+    init(database: DatabaseService) {
+        self.database = database
+        self.cache = Dictionary()
+    }
+    
+    func listEntriesForSlashlinks(slashlinks: [Slashlink]) throws -> [EntryStub] {
+        // Check for cached data
+        let cacheHits =
+            slashlinks.map { s in
+                cache[s]
+            }
+            .compactMap { value in value }
+        
+        // Do we have it all? Early return
+        if cacheHits.count == slashlinks.count {
+            return cacheHits
+        }
+        
+        // Otherwise, only look up the cache misses
+        let remainingLinks = slashlinks.filter { s in cache[s] == nil }
+        let result = try self.database.listEntriesForSlashlinks(slashlinks: remainingLinks)
+        
+        // Cache for the future
+        for link in result {
+            cache[link.address.toSlashlink()] = link
+        }
+        
+        // Combine the two sets of results
+        return result + cacheHits
+    }
+    
+    func listEntriesForSlashlinksAsync(slashlinks: [Slashlink]) -> AnyPublisher<[EntryStub], Error> {
+        CombineUtilities.async(qos: .default) {
+            return try self.listEntriesForSlashlinks(slashlinks: slashlinks)
+        }
+    }
+}

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -1865,7 +1865,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = LA8RNJ2LQP;
+				DEVELOPMENT_TEAM = UQU98W83FV;
 				ENABLE_BITCODE = NO;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1886,7 +1886,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.0.7;
-				PRODUCT_BUNDLE_IDENTIFIER = com.subconscious.Subconscious;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bfollington.Subconscious;
 				PRODUCT_NAME = Subconscious;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		B51A895B29B80F6E00BF5C8A /* FollowUserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51A895A29B80F6E00BF5C8A /* FollowUserView.swift */; };
+		B51C428929CBEEED00D88320 /* SlashlinkLookupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51C428829CBEEED00D88320 /* SlashlinkLookupService.swift */; };
+		B51C428A29CBEEED00D88320 /* SlashlinkLookupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51C428829CBEEED00D88320 /* SlashlinkLookupService.swift */; };
 		B532F8C329B1752E00CE9256 /* TranscludeBlockLayoutFragment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532F8C229B1752E00CE9256 /* TranscludeBlockLayoutFragment.swift */; };
 		B54B922828E669D6003ACA1F /* MementoGeist.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B922728E669D6003ACA1F /* MementoGeist.swift */; };
 		B550E04029AF219100050F19 /* Did.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D8D30029AF1F9B0011D820 /* Did.swift */; };
@@ -364,6 +366,7 @@
 
 /* Begin PBXFileReference section */
 		B51A895A29B80F6E00BF5C8A /* FollowUserView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FollowUserView.swift; sourceTree = "<group>"; };
+		B51C428829CBEEED00D88320 /* SlashlinkLookupService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SlashlinkLookupService.swift; sourceTree = "<group>"; };
 		B532F8C229B1752E00CE9256 /* TranscludeBlockLayoutFragment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscludeBlockLayoutFragment.swift; sourceTree = "<group>"; };
 		B54B922728E669D6003ACA1F /* MementoGeist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MementoGeist.swift; sourceTree = "<group>"; };
 		B569971429B6A0DF003204FC /* FollowUserViaQRCodeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FollowUserViaQRCodeView.swift; sourceTree = "<group>"; };
@@ -800,6 +803,7 @@
 				B8B604E529146DF6006FCB77 /* MemoryStore.swift */,
 				B8CE40E628D2707D00819064 /* QueryPromptGeist.swift */,
 				B8CA8F1F288F1875005F8802 /* RandomPromptGeist.swift */,
+				B51C428829CBEEED00D88320 /* SlashlinkLookupService.swift */,
 				B8CBAFA8299580E50079107E /* StoreProtocol.swift */,
 			);
 			path = Services;
@@ -1459,6 +1463,7 @@
 				B85EC460296F099700558761 /* ProfilePic.swift in Sources */,
 				B8EB2A1F26F27797006E97C3 /* SubconsciousApp.swift in Sources */,
 				B866868127AC4EF100A03A55 /* NSRangeUtilities.swift in Sources */,
+				B51C428929CBEEED00D88320 /* SlashlinkLookupService.swift in Sources */,
 				B824FDD126FA98F300B81BBD /* MemoEditorDetailResponse.swift in Sources */,
 				B8AE34AA276A986000777FF0 /* PlaceholderTextView.swift in Sources */,
 				B8925B3129C2320D001F9503 /* MemoDetailDescription.swift in Sources */,
@@ -1642,6 +1647,7 @@
 				B8B4251628FDE8570081B8D5 /* Memo.swift in Sources */,
 				B85EC461296F099700558761 /* ProfilePic.swift in Sources */,
 				B8EC568A26F4204F00AC64E5 /* SQLite3Database.swift in Sources */,
+				B51C428A29CBEEED00D88320 /* SlashlinkLookupService.swift in Sources */,
 				B8B4251928FDE8AA0081B8D5 /* MemoData.swift in Sources */,
 				B8A59D6A28B692900010DB2F /* StoryPrompt.swift in Sources */,
 			);


### PR DESCRIPTION
Fixes #328

- [x] Fix half-pixel trimming on X axis 
     - try wrapping swift view with padding 
- [x] Try UIKit contraint layout instead of naive for loop (https://developer.apple.com/documentation/uikit/uiview/1622623-systemlayoutsizefitting)
- [x] Fix height calculation of textarea (manually count layout fragment heights?)
- [x] Improve dataflow architecture for slashlink previews
- [x] Do not render transcludes unless lookup succeeds
- [ ] Newline handling at end of doc can introduce space between slashlink and transclude

# Current State

https://user-images.githubusercontent.com/5009316/227083975-4abdbc46-6e08-4db5-9d67-be185391a8fd.mov


