### PR TITLE
Restore full-document attribute rendering

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
@@ -165,7 +165,14 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
     }
 
     //  MARK: Coordinator
-    class Coordinator: NSObject, UITextViewDelegate, NSTextContentStorageDelegate, NSTextStorageDelegate, NSTextContentManagerDelegate, NSTextLayoutManagerDelegate {
+    class Coordinator:
+        NSObject,
+        UITextViewDelegate,
+        NSTextContentStorageDelegate,
+        NSTextStorageDelegate,
+        NSTextContentManagerDelegate,
+        NSTextLayoutManagerDelegate
+    {
         /// Is event happening during updateUIView?
         /// Used to avoid setting properties in events during view updates, as
         /// that would cause feedback cycles where an update triggers an event,

--- a/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
@@ -208,13 +208,6 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
             SubtextTextViewRepresentable.logger.debug(
               "textStorage: render markup attributes"
             )
-            textStorage.setAttributes(
-                [:],
-                range: NSRange(
-                    textStorage.string.startIndex...,
-                    in: textStorage.string
-                )
-            )
 
             // Render markup on TextStorage (which is an NSMutableString)
             self.subtext = Subtext.renderAttributesOf(textStorage, url: SubtextTextViewRepresentable.toSubURL)

--- a/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
@@ -482,10 +482,19 @@ extension Subtext {
             guard let contentRange = forParagraph.paragraphContentRange else {
                 return false
             }
-            guard let tcm = forParagraph.textContentManager else {
+            guard let textContentStorage = forParagraph.textContentManager as? NSTextContentStorage else {
                 return false
             }
-            guard let range: Range<String.Index> = Range(NSRange(contentRange, in: tcm), in: base) else {
+            
+            // Is this instance of Subtext actually working on the same text that the paragraph belongs to?
+            guard let underlyingString = textContentStorage.attributedString?.string else {
+                return false
+            }
+            guard underlyingString == base else {
+                return false
+            }
+            
+            guard let range: Range<String.Index> = Range(NSRange(contentRange, in: textContentStorage), in: base) else {
                 return false
             }
             

--- a/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
@@ -482,3 +482,21 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
         return view
     }
 }
+
+extension Subtext {
+    func block(forParagraph: NSTextParagraph) -> Block? {
+        return blocks.last { b in
+            guard let contentRange = forParagraph.paragraphContentRange else {
+                return false
+            }
+            guard let tcm = forParagraph.textContentManager else {
+                return false
+            }
+            guard let range: Range<String.Index> = Range(NSRange(contentRange, in: tcm), in: base) else {
+                return false
+            }
+            
+            return b.body().range.overlaps(range)
+        }
+    }
+}

--- a/xcode/Subconscious/Shared/Library/NSRangeUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/NSRangeUtilities.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 extension NSRange {
     /// Determine if an NSRange is a valid range for a given string.
@@ -13,4 +14,27 @@ extension NSRange {
         let range = Range(self, in: string)
         return range != nil
     }
+}
+
+
+// https://gist.github.com/krzyzanowskim/057676af670f06fa6061473ac28a6c58
+extension NSRange {
+
+    static let notFound = NSRange(location: NSNotFound, length: 0)
+
+    var isEmpty: Bool {
+        length == 0
+    }
+
+    init(_ textRange: NSTextRange, in textContentManager: NSTextContentManager) {
+        let offset = textContentManager.offset(from: textContentManager.documentRange.location, to: textRange.location)
+        let length = textContentManager.offset(from: textRange.location, to: textRange.endLocation)
+        self.init(location: offset, length: length)
+    }
+
+    init(_ textLocation: NSTextLocation, in textContentManager: NSTextContentManager) {
+        let offset = textContentManager.offset(from: textContentManager.documentRange.location, to: textLocation)
+        self.init(location: offset, length: 0)
+    }
+
 }

--- a/xcode/Subconscious/Shared/Library/NSRangeUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/NSRangeUtilities.swift
@@ -16,25 +16,12 @@ extension NSRange {
     }
 }
 
-
-// https://gist.github.com/krzyzanowskim/057676af670f06fa6061473ac28a6c58
 extension NSRange {
-
-    static let notFound = NSRange(location: NSNotFound, length: 0)
-
-    var isEmpty: Bool {
-        length == 0
-    }
-
     init(_ textRange: NSTextRange, in textContentManager: NSTextContentManager) {
-        let offset = textContentManager.offset(from: textContentManager.documentRange.location, to: textRange.location)
+        let docRange = textContentManager.documentRange
+        let location = textContentManager.offset(from: docRange.location, to: textRange.location)
         let length = textContentManager.offset(from: textRange.location, to: textRange.endLocation)
-        self.init(location: offset, length: length)
+        
+        self.init(location: location, length: length)
     }
-
-    init(_ textLocation: NSTextLocation, in textContentManager: NSTextContentManager) {
-        let offset = textContentManager.offset(from: textContentManager.documentRange.location, to: textLocation)
-        self.init(location: offset, length: 0)
-    }
-
 }

--- a/xcode/Subconscious/Shared/Parsers/Subtext.swift
+++ b/xcode/Subconscious/Shared/Parsers/Subtext.swift
@@ -722,3 +722,21 @@ extension Subtext {
         return shortlinkFor(index: range.lowerBound)
     }
 }
+
+extension Subtext {
+    func block(forParagraph: NSTextParagraph) -> Block? {
+        return blocks.last { b in
+            guard let contentRange = forParagraph.paragraphContentRange else {
+                return false
+            }
+            guard let tcm = forParagraph.textContentManager else {
+                return false
+            }
+            
+            guard let range: Range<String.Index> = Range(NSRange(contentRange, in: tcm), in: base) else {
+                return false
+            }
+            return b.body().range.overlaps(range)
+        }
+    }
+}

--- a/xcode/Subconscious/Shared/Parsers/Subtext.swift
+++ b/xcode/Subconscious/Shared/Parsers/Subtext.swift
@@ -734,10 +734,10 @@ extension Subtext {
             guard let tcm = forParagraph.textContentManager else {
                 return false
             }
-            
             guard let range: Range<String.Index> = Range(NSRange(contentRange, in: tcm), in: base) else {
                 return false
             }
+            
             return b.body().range.overlaps(range)
         }
     }

--- a/xcode/Subconscious/Shared/Parsers/Subtext.swift
+++ b/xcode/Subconscious/Shared/Parsers/Subtext.swift
@@ -456,7 +456,7 @@ extension Subtext {
     static func renderAttributesOf(
         _ attributedString: NSMutableAttributedString,
         url: (String, String) -> URL?
-    ) {
+    ) -> Subtext {
         let dom = Subtext(markup: attributedString.string)
         
         // Get range of all text, using new Swift NSRange constructor
@@ -493,6 +493,8 @@ extension Subtext {
         for block in dom.blocks {
             renderBlockAttributesOf(attributedString, block: block, url: url)
         }
+        
+        return dom
     }
     
     /// Read markup in NSMutableAttributedString, and render as attributes.

--- a/xcode/Subconscious/Shared/Parsers/Subtext.swift
+++ b/xcode/Subconscious/Shared/Parsers/Subtext.swift
@@ -8,7 +8,6 @@
 import Foundation
 import SwiftUI
 
-
 struct Subtext: Hashable, Equatable, LosslessStringConvertible {
     let base: Substring
     let blocks: [Block]
@@ -466,6 +465,9 @@ extension Subtext {
             dom.base.startIndex...,
             in: dom.base
         )
+        
+        // Clear all attributes before rendering
+        attributedString.setAttributes([:], range: baseNSRange)
         
         // Set default font for entire string
         attributedString.addAttribute(

--- a/xcode/Subconscious/Shared/Parsers/Subtext.swift
+++ b/xcode/Subconscious/Shared/Parsers/Subtext.swift
@@ -724,21 +724,3 @@ extension Subtext {
         return shortlinkFor(index: range.lowerBound)
     }
 }
-
-extension Subtext {
-    func block(forParagraph: NSTextParagraph) -> Block? {
-        return blocks.last { b in
-            guard let contentRange = forParagraph.paragraphContentRange else {
-                return false
-            }
-            guard let tcm = forParagraph.textContentManager else {
-                return false
-            }
-            guard let range: Range<String.Index> = Range(NSRange(contentRange, in: tcm), in: base) else {
-                return false
-            }
-            
-            return b.body().range.overlaps(range)
-        }
-    }
-}


### PR DESCRIPTION
This renders attributes directly to TextStorage (like we used to but with TK2) to resolve #431

- [x] Restore old functionality
- [x] Remove per-fragment rendering (otherwise we're doing it twice)

I've also put together a proof-of-concept for how we could do per-paragraph rendering in #433 