### PR TITLE
Selectively re-render text in range

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
@@ -198,19 +198,8 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
           range: NSRange,
           changeInLength: Int
         ) {
-            SubtextTextViewRepresentable.logger.debug(
-              "textStorage: render markup attributes"
-            )
-            textStorage.setAttributes(
-                [:],
-                range: NSRange(
-                    textStorage.string.startIndex...,
-                    in: textStorage.string
-                )
-            )
-
-            // Render markup on TextStorage (which is an NSMutableString)
-            self.subtext = Subtext.renderAttributesOf(textStorage, url: SubtextTextViewRepresentable.toSubURL)
+            SubtextTextViewRepresentable.logger.debug("textStorage: render markup attributes")
+            self.subtext = Subtext.renderAttributesOf(textStorage, inRange: range, url: SubtextTextViewRepresentable.toSubURL)
         }
 
 
@@ -300,7 +289,7 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
             guard let paragraph = textElement as? NSTextParagraph else {
                 return baseLayoutFragment
             }
-
+            
             // Only render transcludes for a single slashlink in a single block
             guard let _ = subtext?
                 .block(forParagraph: paragraph)?

--- a/xcode/Subconscious/Shared/Library/NSRangeUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/NSRangeUtilities.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 extension NSRange {
     /// Determine if an NSRange is a valid range for a given string.
@@ -13,4 +14,27 @@ extension NSRange {
         let range = Range(self, in: string)
         return range != nil
     }
+}
+
+
+// https://gist.github.com/krzyzanowskim/057676af670f06fa6061473ac28a6c58
+extension NSRange {
+
+    static let notFound = NSRange(location: NSNotFound, length: 0)
+
+    var isEmpty: Bool {
+        length == 0
+    }
+
+    init(_ textRange: NSTextRange, in textContentManager: NSTextContentManager) {
+        let offset = textContentManager.offset(from: textContentManager.documentRange.location, to: textRange.location)
+        let length = textContentManager.offset(from: textRange.location, to: textRange.endLocation)
+        self.init(location: offset, length: length)
+    }
+
+    init(_ textLocation: NSTextLocation, in textContentManager: NSTextContentManager) {
+        let offset = textContentManager.offset(from: textContentManager.documentRange.location, to: textLocation)
+        self.init(location: offset, length: 0)
+    }
+
 }

--- a/xcode/Subconscious/Shared/Parsers/Subtext.swift
+++ b/xcode/Subconscious/Shared/Parsers/Subtext.swift
@@ -722,3 +722,21 @@ extension Subtext {
         return shortlinkFor(index: range.lowerBound)
     }
 }
+
+extension Subtext {
+    func block(forParagraph: NSTextParagraph) -> Block? {
+        return blocks.last { b in
+            guard let contentRange = forParagraph.paragraphContentRange else {
+                return false
+            }
+            guard let tcm = forParagraph.textContentManager else {
+                return false
+            }
+            
+            guard let range: Range<String.Index> = Range(NSRange(contentRange, in: tcm), in: base) else {
+                return false
+            }
+            return b.body().range.overlaps(range)
+        }
+    }
+}

--- a/xcode/Subconscious/Shared/Parsers/Subtext.swift
+++ b/xcode/Subconscious/Shared/Parsers/Subtext.swift
@@ -734,10 +734,10 @@ extension Subtext {
             guard let tcm = forParagraph.textContentManager else {
                 return false
             }
-            
             guard let range: Range<String.Index> = Range(NSRange(contentRange, in: tcm), in: base) else {
                 return false
             }
+            
             return b.body().range.overlaps(range)
         }
     }

--- a/xcode/Subconscious/Shared/Parsers/Subtext.swift
+++ b/xcode/Subconscious/Shared/Parsers/Subtext.swift
@@ -456,7 +456,7 @@ extension Subtext {
     static func renderAttributesOf(
         _ attributedString: NSMutableAttributedString,
         url: (String, String) -> URL?
-    ) {
+    ) -> Subtext {
         let dom = Subtext(markup: attributedString.string)
         
         // Get range of all text, using new Swift NSRange constructor
@@ -493,6 +493,8 @@ extension Subtext {
         for block in dom.blocks {
             renderBlockAttributesOf(attributedString, block: block, url: url)
         }
+        
+        return dom
     }
     
     /// Read markup in NSMutableAttributedString, and render as attributes.


### PR DESCRIPTION
Extends #432 

With some range-hackery we can actually still pull-off per-paragraph rendering of attributes.

# Known Issues
- [ ] Pasting several blocks erases the formatting from the earlier blocks