### PR TITLE
Noosphere Address Book FFI Stub

### DIFF
--- a/xcode/Subconscious/Shared/AppTheme.swift
+++ b/xcode/Subconscious/Shared/AppTheme.swift
@@ -76,6 +76,9 @@ extension Color {
     static let secondaryBackground = SwiftUI.Color(
         uiColor: UIColor.secondarySystemBackground
     )
+    static let formFieldBackground = SwiftUI.Color(
+        uiColor: UIColor.secondarySystemGroupedBackground
+    )
     static let backgroundPressed = SwiftUI.Color(UIColor.systemFill)
     static let inputBackground = SwiftUI.Color(uiColor: .secondarySystemFill)
     static let primaryButtonBackground = Color.accentColor.opacity(0.2)

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookEntryView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookEntryView.swift
@@ -24,6 +24,7 @@ struct AddressBookEntryView: View {
                     .foregroundColor(.secondary)
                     .font(.caption.monospaced())
             }
+            Spacer()
         }
     }
 }
@@ -33,7 +34,7 @@ struct AddressBookEntryView_Previews: PreviewProvider {
         AddressBookEntryView(
             pfp: Image("pfp-dog"),
             petname: Petname("name")!,
-            did: Did("did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!
+            did: Did("did:key:z6x")!
         )
     }
 }

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
@@ -29,14 +29,27 @@ class PlaceholderSphereIdentityProvider: SphereIdentityProtocol {
     }
 }
 
+struct FollowUserFormModel: Equatable {
+    var did: FormField<String, Did> = FormField(value: "", validate: Self.validateDid)
+    var petname: FormField<String, Petname> = FormField(value: "", validate: Self.validatePetname)
+    
+    static func validateDid(key: String) -> Did? {
+        Did(key)
+    }
+
+    static func validatePetname(petname: String) -> Petname? {
+        Petname(petname)
+    }
+}
+
 struct PetnameFieldCursor: CursorProtocol {
     static func get(state: AddressBookModel) -> FormField<String, Petname> {
-        state.petnameField
+        state.followUserForm.petname
     }
     
     static func set(state: AddressBookModel, inner: FormField<String, Petname>) -> AddressBookModel {
         var model = state
-        model.petnameField = inner
+        model.followUserForm.petname = inner
         return model
     }
     
@@ -47,12 +60,12 @@ struct PetnameFieldCursor: CursorProtocol {
 
 struct DidFieldCursor: CursorProtocol {
     static func get(state: AddressBookModel) -> FormField<String, Did> {
-        state.didField
+        state.followUserForm.did
     }
     
     static func set(state: AddressBookModel, inner: FormField<String, Did>) -> AddressBookModel {
         var model = state
-        model.didField = inner
+        model.followUserForm.did = inner
         return model
     }
     
@@ -83,16 +96,7 @@ struct AddressBookModel: ModelProtocol {
     var follows: [AddressBookEntry] = []
     
     var followUserFormIsPresented = false
-    var didField: FormField<String, Did> = FormField(value: "", validate: Self.validateDid)
-    var petnameField: FormField<String, Petname> = FormField(value: "", validate: Self.validatePetname)
-    
-    static func validateDid(key: String) -> Did? {
-        Did(key)
-    }
-
-    static func validatePetname(petname: String) -> Petname? {
-        Petname(petname)
-    }
+    var followUserForm = FollowUserFormModel()
     
     var failFollowErrorMessage: String? = nil
     var failUnfollowErrorMessage: String? = nil
@@ -115,13 +119,13 @@ struct AddressBookModel: ModelProtocol {
             model.followUserFormIsPresented = isPresented
             if isPresented {
                 // Reset form when opened
-                model.didField = FormField.update(
-                    state: model.didField,
+                model.followUserForm.did = FormField.update(
+                    state: model.followUserForm.did,
                     action: .reset,
                     environment: FormFieldEnvironment()
                 ).state
-                model.petnameField = FormField.update(
-                    state: model.petnameField,
+                model.followUserForm.petname = FormField.update(
+                    state: model.followUserForm.petname,
                     action: .reset,
                     environment: FormFieldEnvironment()
                 ).state
@@ -162,21 +166,21 @@ struct AddressBookModel: ModelProtocol {
         case .requestFollow:
             var model = state
             // Show errors on any untouched fields, hints at why you cannot submit
-            model.didField = FormField.update(
-                state: model.didField,
+            model.followUserForm.did = FormField.update(
+                state: model.followUserForm.did,
                 action: .touch(focused: false),
                 environment: FormFieldEnvironment()
             ).state
-            model.petnameField = FormField.update(
-                state: model.petnameField,
+            model.followUserForm.petname = FormField.update(
+                state: model.followUserForm.petname,
                 action: .touch(focused: false),
                 environment: FormFieldEnvironment()
             ).state
             
-            guard let did = state.didField.validated else {
+            guard let did = state.followUserForm.did.validated else {
                 return Update(state: model)
             }
-            guard let petname = state.petnameField.validated else {
+            guard let petname = state.followUserForm.petname.validated else {
                 return Update(state: model)
             }
             // Guard against duplicates

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
@@ -26,8 +26,9 @@ struct FormField<I : Equatable, O>: Equatable {
         Self(value: input, validate: validate, touched: touched)
     }
     
-    func touch() -> Self {
-        Self(value: value, validate: validate, touched: true)
+    /// Only marked as touched when field _loses_ focus
+    func touch(focused: Bool = false) -> Self {
+        Self(value: value, validate: validate, touched: focused ? touched : true)
     }
     
     var validated: O? {
@@ -132,12 +133,8 @@ struct AddressBookModel: ModelProtocol {
             return Update(state: model)
             
         case .touchDidField(let focused):
-            guard !focused else {
-                return Update(state: state)
-            }
-            
             var model = state
-            model.followUserForm.did = state.followUserForm.did.touch()
+            model.followUserForm.did = state.followUserForm.did.touch(focused: focused)
             return Update(state: model)
             
         case .setDidField(input: let input):
@@ -146,12 +143,8 @@ struct AddressBookModel: ModelProtocol {
             return Update(state: model)
             
         case .touchPetnameField(let focused):
-            guard !focused else {
-                return Update(state: state)
-            }
-            
             var model = state
-            model.followUserForm.petname = state.followUserForm.petname.touch()
+            model.followUserForm.petname = state.followUserForm.petname.touch(focused: focused)
             return Update(state: model)
             
         case .setPetnameField(input: let input):

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
@@ -187,7 +187,8 @@ struct AddressBookModel: ModelProtocol {
                 return Update(state: state)
             }
             
-            let fx: Fx<AddressBookAction> = environment.data.addressBook
+            let fx: Fx<AddressBookAction> =
+                environment.data.addressBook
                 .setPetnameAsync(did: did, petname: petname)
                 .map({ _ in
                     AddressBookAction.succeedFollow(did: did, petname: petname)
@@ -216,7 +217,8 @@ struct AddressBookModel: ModelProtocol {
             return Update(state: model)
             
         case .requestUnfollow(petname: let petname):
-            let fx: Fx<AddressBookAction> = environment.data.addressBook
+            let fx: Fx<AddressBookAction> =
+                environment.data.addressBook
                 .unsetPetnameAsync(petname: petname)
                 .map({ _ in
                     AddressBookAction.succeedUnfollow(petname: petname)

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
@@ -49,6 +49,7 @@ struct FollowUserForm: Equatable {
         Petname(petname)
     }
 }
+
 struct AddressBookEntry: Equatable {
     var pfp: Image
     var petname: Petname
@@ -77,6 +78,8 @@ enum AddressBookAction: Hashable {
     case requestUnfollow(petname: Petname)
     case failUnfollow(error: String)
     case succeedUnfollow(petname: Petname)
+    
+    case presentFollowUserForm(_ isPresented: Bool)
     case setDidField(input: String)
     case setPetnameField(input: String)
 }
@@ -86,6 +89,7 @@ struct AddressBookModel: ModelProtocol {
     var did: Did? = nil
     var follows: [AddressBookEntry] = []
     
+    var followUserFormIsPresented = false
     var followUserForm: FollowUserForm = FollowUserForm()
     
     var failFollowErrorMessage: String? = nil
@@ -102,6 +106,11 @@ struct AddressBookModel: ModelProtocol {
         environment: AddressBookEnvironment
     ) -> Update<AddressBookModel> {
         switch action {
+            
+        case .presentFollowUserForm(let isPresented):
+            var model = state
+            model.followUserFormIsPresented = isPresented
+            return Update(state: model)
             
         case .setDidField(input: let input):
             var model = state
@@ -160,6 +169,7 @@ struct AddressBookModel: ModelProtocol {
             let entry = AddressBookEntry(pfp: Image("sub_logo_dark"), petname: petname, did: did)
             
             var model = state
+            model.followUserFormIsPresented = false
             model.follows.append(entry)
             return Update(state: model)
             

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
@@ -198,12 +198,12 @@ struct AddressBookModel: ModelProtocol {
             // Show errors on any untouched fields, hints at why you cannot submit
             model.followUserForm.did = FormField.update(
                 state: model.followUserForm.did,
-                action: .touch(focused: false),
+                action: .markAsTouched,
                 environment: FormFieldEnvironment()
             ).state
             model.followUserForm.petname = FormField.update(
                 state: model.followUserForm.petname,
-                action: .touch(focused: false),
+                action: .markAsTouched,
                 environment: FormFieldEnvironment()
             ).state
             

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
@@ -90,7 +90,7 @@ struct AddressBookModel: ModelProtocol {
     var did: Did? = nil
     var follows: [AddressBookEntry] = []
     
-    var followUserFormIsPresented = false
+    var isFollowUserFormPresented = false
     var followUserForm = FollowUserFormModel()
     
     var failFollowErrorMessage: String? = nil
@@ -116,7 +116,7 @@ struct AddressBookModel: ModelProtocol {
         case .presentFollowUserForm(let isPresented):
             var model = state
             
-            model.followUserFormIsPresented = isPresented
+            model.isFollowUserFormPresented = isPresented
             if isPresented {
                 // Reset form when opened
                 model.followUserForm.did = FormField.update(
@@ -211,7 +211,7 @@ struct AddressBookModel: ModelProtocol {
             let entry = AddressBookEntry(pfp: Image("sub_logo_dark"), petname: petname, did: did)
             
             var model = state
-            model.followUserFormIsPresented = false
+            model.isFollowUserFormPresented = false
             model.follows.append(entry)
             return Update(state: model)
             

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
@@ -18,16 +18,9 @@ struct AddressBookEntry: Equatable {
 }
 
 struct AddressBookEnvironment {
-    var noosphere: SphereIdentityProtocol
     var data: DataService
 }
 
-// Used for SwiftUI Previews, also useful for testing
-class PlaceholderSphereIdentityProvider: SphereIdentityProtocol {
-    func identity() throws -> String {
-        "did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7"
-    }
-}
 
 struct FollowUserFormModel: Equatable {
     var did: FormField<String, Did> = FormField(value: "", validate: Self.validateDid)
@@ -160,7 +153,7 @@ struct AddressBookModel: ModelProtocol {
             
             if isPresented {
                 do {
-                    model.did = try Did(environment.noosphere.identity())
+                    model.did = try Did(environment.data.noosphere.identity())
                 } catch {
                     model.did = nil
                 }

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
@@ -37,7 +37,7 @@ struct AddressBookView: View {
                                 .frame(maxWidth: .infinity)
                                 .swipeActions {
                                     Button("Unfollow", role: .destructive) {
-                                        send(.unfollow(did: user.did))
+                                        send(.requestUnfollow(petname: user.petname))
                                     }
                                 }
                             }
@@ -76,8 +76,8 @@ struct AddressBookView: View {
 }
 
 struct AddressBook_Previews: PreviewProvider {
-    struct TestView: View {
-        @StateObject private var store = Store(
+    static var previews: some View {
+        AddressBookView(
             state: AddressBookModel(
                 follows: [
                     AddressBookEntry(pfp: Image("pfp-dog"), petname: Petname("ben")!, did: Did(  "did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!),
@@ -85,19 +85,7 @@ struct AddressBook_Previews: PreviewProvider {
                     AddressBookEntry(pfp: Image("sub_logo_dark"), petname: Petname("alice")!, did: Did("did:key:z6MjmBJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!)
                 ]
             ),
-            action: .present(true),
-            environment: AddressBookEnvironment(noosphere: PlaceholderSphereIdentityProvider())
+            send: { action in }
         )
-
-        var body: some View {
-            AddressBookView(
-                state: store.state,
-                send: store.send
-            )
-        }
-    }
-
-    static var previews: some View {
-        TestView()
     }
 }

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
@@ -66,7 +66,7 @@ struct AddressBookView: View {
             .navigationTitle("Address Book")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Close") {
+                    Button("Close", role: .cancel) {
                         AddressBookModel.logger.debug("Close Address Book")
                         send(.present(false))
                     }

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
@@ -60,9 +60,9 @@ struct AddressBookView: View {
                     }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    NavigationLink(
-                        destination: {
-                            FollowUserView(state: state, send: send)
+                    Button(
+                        action: {
+                            send(.presentFollowUserForm(true))
                         },
                         label: {
                             Image(systemName: "person.badge.plus")
@@ -71,12 +71,28 @@ struct AddressBookView: View {
                 }
             }
             .navigationBarTitleDisplayMode(.inline)
+            .sheet(
+                isPresented: Binding(
+                    get: { state.followUserFormIsPresented },
+                    send: send,
+                    tag: AddressBookAction.presentFollowUserForm
+                )
+            ) {
+                FollowUserView(state: state, send: send)
+            }
         }
     }
 }
 
 struct AddressBook_Previews: PreviewProvider {
     static var previews: some View {
+        AddressBookView(
+            state: AddressBookModel(
+                follows: [],
+                followUserFormIsPresented: true
+            ),
+            send: { action in }
+        )
         AddressBookView(
             state: AddressBookModel(
                 follows: [

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
@@ -85,7 +85,7 @@ struct AddressBookView: View {
             .navigationBarTitleDisplayMode(.inline)
             .sheet(
                 isPresented: Binding(
-                    get: { state.followUserFormIsPresented },
+                    get: { state.isFollowUserFormPresented },
                     send: send,
                     tag: AddressBookAction.presentFollowUserForm
                 )
@@ -105,7 +105,7 @@ struct AddressBook_Previews: PreviewProvider {
                     AddressBookEntry(pfp: Image("sub_logo_light"), petname: Petname("bob")!, did: Did("did:key:z6MkmBJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!),
                     AddressBookEntry(pfp: Image("sub_logo_dark"), petname: Petname("alice")!, did: Did("did:key:z6MjmBJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!)
                 ],
-                followUserFormIsPresented: false // Toggle to test sheet
+                isFollowUserFormPresented: false // Toggle to test sheet
             ),
             send: { action in }
         )

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
@@ -44,12 +44,24 @@ struct AddressBookView: View {
                         }
                     }
                 }
+                // Basic error visibility
+                if let msg = state.failUnfollowErrorMessage {
+                    HStack {
+                        Image(systemName: "exclamationmark.circle")
+                            .frame(width: 24, height: 22)
+                            .padding(.horizontal, 8)
+                            .foregroundColor(.red)
+                            .background(Color.clear)
+                        Text(msg)
+                            .foregroundColor(.red)
+                    }
+                }
+                
                 if let did = state.did {
                     Section(header: Text("My DID")) {
                         DidView(did: did)
                     }
                 }
-                
             }
             .navigationTitle("Address Book")
             .toolbar {

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
@@ -88,18 +88,12 @@ struct AddressBook_Previews: PreviewProvider {
     static var previews: some View {
         AddressBookView(
             state: AddressBookModel(
-                follows: [],
-                followUserFormIsPresented: true
-            ),
-            send: { action in }
-        )
-        AddressBookView(
-            state: AddressBookModel(
                 follows: [
                     AddressBookEntry(pfp: Image("pfp-dog"), petname: Petname("ben")!, did: Did(  "did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!),
                     AddressBookEntry(pfp: Image("sub_logo_light"), petname: Petname("bob")!, did: Did("did:key:z6MkmBJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!),
                     AddressBookEntry(pfp: Image("sub_logo_dark"), petname: Petname("alice")!, did: Did("did:key:z6MjmBJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!)
-                ]
+                ],
+                followUserFormIsPresented: false // Toggle to test sheet
             ),
             send: { action in }
         )

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
@@ -36,7 +36,7 @@ struct AddressBookView: View {
                                 )
                                 .frame(maxWidth: .infinity)
                                 .swipeActions {
-                                    Button("Unfollow", role: .destructive) {
+                                    Button("Unfollow") {
                                         send(.requestUnfollow(petname: user.petname))
                                     }
                                 }

--- a/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
@@ -36,6 +36,7 @@ struct FollowUserView: View {
                                 caption: "e.g. did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7",
                                 hasError: form.did.hasError
                             )
+                            .formField()
                             .lineLimit(1)
                             .textInputAutocapitalization(.never)
                             .disableAutocorrection(true)
@@ -57,6 +58,7 @@ struct FollowUserView: View {
                                 caption: "Lowercase letters, numbers and dashes only.",
                                 hasError: form.petname.hasError
                             )
+                            .formField()
                             .lineLimit(1)
                             .textInputAutocapitalization(.never)
                             .disableAutocorrection(true)

--- a/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
@@ -14,17 +14,6 @@ struct FollowUserView: View {
     
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
     
-    @State var did: String = ""
-    @State var petname: String = ""
-    
-    func validateDid(key: String) -> Did? {
-        Did(key)
-    }
-    
-    func validatePetname(petname: String) -> Petname? {
-        Petname(petname)
-    }
-    
     var body: some View {
         NavigationStack {
             Form {
@@ -34,9 +23,13 @@ struct FollowUserView: View {
                             .foregroundColor(.accentColor)
                         ValidatedTextField(
                             placeholder: "DID",
-                            text: $did,
+                            text: Binding(
+                                get: { state.followUserForm.did.value },
+                                send: send,
+                                tag: AddressBookAction.setDidField
+                            ),
                             caption: "e.g. did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7",
-                            isValid: validateDid(key: did) != nil || did.count  == 0 // Prevent initial error
+                            isValid: state.followUserForm.did.isValid
                         )
                         .lineLimit(1)
                         .textInputAutocapitalization(.never)
@@ -48,9 +41,13 @@ struct FollowUserView: View {
                             .foregroundColor(.accentColor)
                         ValidatedTextField(
                             placeholder: "Petname",
-                            text: $petname,
+                            text: Binding(
+                                get: { state.followUserForm.petname.value },
+                                send: send,
+                                tag: AddressBookAction.setPetnameField
+                            ),
                             caption: "Lowercase letters, numbers and dashes only.",
-                            isValid: validatePetname(petname: petname) != nil || petname.count == 0
+                            isValid: state.followUserForm.petname.isValid
                         )
                         .lineLimit(1)
                         .textInputAutocapitalization(.never)
@@ -62,16 +59,7 @@ struct FollowUserView: View {
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") {
-                        guard let did = validateDid(key: did) else {
-                            return
-                        }
-                        
-                        guard let petname = validatePetname(petname: petname) else {
-                            return
-                        }
-                        
-                        send(.requestFollow(did: did, petname: petname))
-                        presentationMode.wrappedValue.dismiss()
+                        send(.requestFollow)
                     }
                 }
             }

--- a/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
@@ -10,6 +10,9 @@ import ObservableStore
 
 struct FollowUserView: View {
     var state: AddressBookModel
+    var form: FollowUserFormModel {
+        get { state.followUserForm }
+    }
     var send: (AddressBookAction) -> Void
     
     var body: some View {
@@ -23,7 +26,7 @@ struct FollowUserView: View {
                             ValidatedTextField(
                                 placeholder: "DID",
                                 text: Binding(
-                                    get: { state.didField.value },
+                                    get: { form.did.value },
                                     send: send,
                                     tag: { v in .didField(.setValue(input: v))}
                                 ),
@@ -31,7 +34,7 @@ struct FollowUserView: View {
                                     send(.didField(.touch(focused: focused)))
                                 },
                                 caption: "e.g. did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7",
-                                hasError: state.didField.hasError
+                                hasError: form.did.hasError
                             )
                             .lineLimit(1)
                             .textInputAutocapitalization(.never)
@@ -44,7 +47,7 @@ struct FollowUserView: View {
                             ValidatedTextField(
                                 placeholder: "Petname",
                                 text: Binding(
-                                    get: { state.petnameField.value },
+                                    get: { form.petname.value },
                                     send: send,
                                     tag: { v in .petnameField(.setValue(input: v))}
                                 ),
@@ -52,7 +55,7 @@ struct FollowUserView: View {
                                     send(.petnameField(.touch(focused: focused)))
                                 },
                                 caption: "Lowercase letters, numbers and dashes only.",
-                                hasError: state.petnameField.hasError
+                                hasError: form.petname.hasError
                             )
                             .lineLimit(1)
                             .textInputAutocapitalization(.never)

--- a/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
@@ -12,46 +12,60 @@ struct FollowUserView: View {
     var state: AddressBookModel
     var send: (AddressBookAction) -> Void
     
-    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
-    
     var body: some View {
         NavigationStack {
-            Form {
-                Section(header: Text("User To Follow")) {
-                    HStack(alignment: .top) {
-                        Image(systemName: "key")
-                            .foregroundColor(.accentColor)
-                        ValidatedTextField(
-                            placeholder: "DID",
-                            text: Binding(
-                                get: { state.followUserForm.did.value },
-                                send: send,
-                                tag: AddressBookAction.setDidField
-                            ),
-                            caption: "e.g. did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7",
-                            isValid: state.followUserForm.did.isValid
-                        )
-                        .lineLimit(1)
-                        .textInputAutocapitalization(.never)
-                        .disableAutocorrection(true)
+            VStack {
+                Form {
+                    Section(header: Text("User To Follow")) {
+                        HStack(alignment: .top) {
+                            Image(systemName: "key")
+                                .foregroundColor(.accentColor)
+                            ValidatedTextField(
+                                placeholder: "DID",
+                                text: Binding(
+                                    get: { state.followUserForm.did.value },
+                                    send: send,
+                                    tag: AddressBookAction.setDidField
+                                ),
+                                onFocusChanged: { focused in send(.touchDidField(focused: focused)) },
+                                caption: "e.g. did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7",
+                                hasError: state.followUserForm.did.hasError
+                            )
+                            .lineLimit(1)
+                            .textInputAutocapitalization(.never)
+                            .disableAutocorrection(true)
+                        }
+                        
+                        HStack(alignment: .top) {
+                            Image(systemName: "at")
+                                .foregroundColor(.accentColor)
+                            ValidatedTextField(
+                                placeholder: "Petname",
+                                text: Binding(
+                                    get: { state.followUserForm.petname.value },
+                                    send: send,
+                                    tag: AddressBookAction.setPetnameField
+                                ),
+                                onFocusChanged: { focused in send(.touchPetnameField(focused: focused))},
+                                caption: "Lowercase letters, numbers and dashes only.",
+                                hasError: state.followUserForm.petname.hasError
+                            )
+                            .lineLimit(1)
+                            .textInputAutocapitalization(.never)
+                            .disableAutocorrection(true)
+                        }
                     }
                     
-                    HStack(alignment: .top) {
-                        Image(systemName: "at")
-                            .foregroundColor(.accentColor)
-                        ValidatedTextField(
-                            placeholder: "Petname",
-                            text: Binding(
-                                get: { state.followUserForm.petname.value },
-                                send: send,
-                                tag: AddressBookAction.setPetnameField
-                            ),
-                            caption: "Lowercase letters, numbers and dashes only.",
-                            isValid: state.followUserForm.petname.isValid
-                        )
-                        .lineLimit(1)
-                        .textInputAutocapitalization(.never)
-                        .disableAutocorrection(true)
+                    if let msg = state.failFollowErrorMessage {
+                        HStack {
+                            Image(systemName: "exclamationmark.circle")
+                                .frame(width: 24, height: 22)
+                                .padding(.horizontal, 8)
+                                .foregroundColor(.red)
+                                .background(Color.clear)
+                            Text(msg)
+                                .foregroundColor(.red)
+                        }
                     }
                 }
             }
@@ -60,6 +74,11 @@ struct FollowUserView: View {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") {
                         send(.requestFollow)
+                    }
+                }
+                ToolbarItem(placement: .navigation) {
+                    Button("Cancel") {
+                        send(.presentFollowUserForm(false))
                     }
                 }
             }

--- a/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
@@ -85,7 +85,7 @@ struct FollowUserView: View {
                     }
                 }
                 ToolbarItem(placement: .navigation) {
-                    Button("Cancel") {
+                    Button("Cancel", role: .cancel) {
                         send(.presentFollowUserForm(false))
                     }
                 }

--- a/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
@@ -23,15 +23,15 @@ struct FollowUserView: View {
                             ValidatedTextField(
                                 placeholder: "DID",
                                 text: Binding(
-                                    get: { state.followUserForm.did.value },
+                                    get: { state.didField.value },
                                     send: send,
-                                    tag: AddressBookAction.setDidField
+                                    tag: { v in .didField(.setValue(input: v))}
                                 ),
                                 onFocusChanged: { focused in
-                                    send(.touchDidField(focused: focused))
+                                    send(.didField(.touch(focused: focused)))
                                 },
                                 caption: "e.g. did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7",
-                                hasError: state.followUserForm.did.hasError
+                                hasError: state.didField.hasError
                             )
                             .lineLimit(1)
                             .textInputAutocapitalization(.never)
@@ -44,15 +44,15 @@ struct FollowUserView: View {
                             ValidatedTextField(
                                 placeholder: "Petname",
                                 text: Binding(
-                                    get: { state.followUserForm.petname.value },
+                                    get: { state.petnameField.value },
                                     send: send,
-                                    tag: AddressBookAction.setPetnameField
+                                    tag: { v in .petnameField(.setValue(input: v))}
                                 ),
                                 onFocusChanged: { focused in
-                                    send(.touchPetnameField(focused: focused))
+                                    send(.petnameField(.touch(focused: focused)))
                                 },
                                 caption: "Lowercase letters, numbers and dashes only.",
-                                hasError: state.followUserForm.petname.hasError
+                                hasError: state.petnameField.hasError
                             )
                             .lineLimit(1)
                             .textInputAutocapitalization(.never)

--- a/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
@@ -63,6 +63,7 @@ struct FollowUserView: View {
                         }
                     }
                     
+                    // Basic error visibility
                     if let msg = state.failFollowErrorMessage {
                         HStack {
                             Image(systemName: "exclamationmark.circle")

--- a/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
@@ -31,7 +31,7 @@ struct FollowUserView: View {
                                     tag: { v in .didField(.setValue(input: v))}
                                 ),
                                 onFocusChanged: { focused in
-                                    send(.didField(.touch(focused: focused)))
+                                    send(.didField(.focusChange(focused: focused)))
                                 },
                                 caption: "e.g. did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7",
                                 hasError: form.did.hasError
@@ -52,7 +52,7 @@ struct FollowUserView: View {
                                     tag: { v in .petnameField(.setValue(input: v))}
                                 ),
                                 onFocusChanged: { focused in
-                                    send(.petnameField(.touch(focused: focused)))
+                                    send(.petnameField(.focusChange(focused: focused)))
                                 },
                                 caption: "Lowercase letters, numbers and dashes only.",
                                 hasError: form.petname.hasError

--- a/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
@@ -27,7 +27,9 @@ struct FollowUserView: View {
                                     send: send,
                                     tag: AddressBookAction.setDidField
                                 ),
-                                onFocusChanged: { focused in send(.touchDidField(focused: focused)) },
+                                onFocusChanged: { focused in
+                                    send(.touchDidField(focused: focused))
+                                },
                                 caption: "e.g. did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7",
                                 hasError: state.followUserForm.did.hasError
                             )
@@ -46,7 +48,9 @@ struct FollowUserView: View {
                                     send: send,
                                     tag: AddressBookAction.setPetnameField
                                 ),
-                                onFocusChanged: { focused in send(.touchPetnameField(focused: focused))},
+                                onFocusChanged: { focused in
+                                    send(.touchPetnameField(focused: focused))
+                                },
                                 caption: "Lowercase letters, numbers and dashes only.",
                                 hasError: state.followUserForm.petname.hasError
                             )

--- a/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
@@ -70,7 +70,7 @@ struct FollowUserView: View {
                             return
                         }
                         
-                        send(.follow(did: did, petname: petname))
+                        send(.requestFollow(did: did, petname: petname))
                         presentationMode.wrappedValue.dismiss()
                     }
                 }
@@ -81,21 +81,10 @@ struct FollowUserView: View {
 }
 
 struct FollowUserView_Previews: PreviewProvider {
-    struct TestView: View {
-        @StateObject private var store = Store(
-            state: AddressBookModel(),
-            environment: AddressBookEnvironment(noosphere: PlaceholderSphereIdentityProvider())
-        )
-
-        var body: some View {
-            FollowUserView(
-                state: store.state,
-                send: store.send
-            )
-        }
-    }
-
     static var previews: some View {
-        TestView()
+        FollowUserView(
+            state: AddressBookModel(),
+            send: { action in }
+        )
     }
 }

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -962,10 +962,13 @@ struct AppEnvironment {
             migrations: Config.migrations
         )
         
+        let addresBook = AddressBookService(noosphere: noosphere)
+        
         self.data = DataService(
             noosphere: noosphere,
             database: databaseService,
-            local: local
+            local: local,
+            addressBook: addresBook
         )
         
         self.addressBook = AddressBookEnvironment(noosphere: noosphere, data: data)

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -971,7 +971,7 @@ struct AppEnvironment {
             addressBook: addresBook
         )
         
-        self.addressBook = AddressBookEnvironment(noosphere: noosphere, data: data)
+        self.addressBook = AddressBookEnvironment(data: data)
 
         self.feed = FeedService()
     }

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -968,7 +968,7 @@ struct AppEnvironment {
             local: local
         )
         
-        self.addressBook = AddressBookEnvironment(noosphere: noosphere)
+        self.addressBook = AddressBookEnvironment(noosphere: noosphere, data: data)
 
         self.feed = FeedService()
     }

--- a/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
@@ -17,6 +17,14 @@ struct ValidatedTextField: View {
     var hasError: Bool = false
     @FocusState var focused: Bool
     
+    var backgroundColor = Color.background
+    
+    /// When appearing in a form the background colour of a should change
+    func formField() -> Self {
+        var this = self
+        this.backgroundColor = Color.formFieldBackground
+        return this
+    }
     
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.unit2) {
@@ -32,7 +40,7 @@ struct ValidatedTextField: View {
                             .frame(width: 24, height: 22)
                             .padding(.horizontal, 8)
                             .foregroundColor(.red)
-                            .background(Color.clear)
+                            .background(backgroundColor)
                     }
                     .padding(.trailing, 1)
                     .opacity(hasError ? 1 : 0)
@@ -79,6 +87,25 @@ struct ValidatedTextField_Previews: PreviewProvider {
                 hasError: true
             )
             .textFieldStyle(.roundedBorder)
+            
+            
+            Spacer()
+            
+            Form {
+                ValidatedTextField(
+                    placeholder: "nickname",
+                    text: .constant(""),
+                    caption: "Lowercase letters and numbers only."
+                )
+                .formField()
+                ValidatedTextField(
+                    placeholder: "nickname",
+                    text: .constant(""),
+                    caption: "Lowercase letters and numbers only.",
+                    hasError: true
+                )
+                .formField()
+            }
         }
         .padding()
     }

--- a/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct ValidatedTextField: View {
     var placeholder: String
     @Binding var text: String
+    var onFocusChanged: ((Bool) -> Void)?
     var caption: String
     var hasError: Bool = false
     
@@ -19,7 +20,10 @@ struct ValidatedTextField: View {
             HStack {
                 TextField(
                     placeholder,
-                    text: $text
+                    text: $text,
+                    onEditingChanged: { focused in
+                        onFocusChanged?(focused)
+                    }
                 )
                 .overlay(alignment: .trailing) {
                     VStack {

--- a/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
@@ -12,8 +12,8 @@ struct ValidatedTextField: View {
     var placeholder: String
     @Binding var text: String
     var caption: String
-    var isValid: Bool = true
-
+    var hasError: Bool = false
+    
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.unit2) {
             HStack {
@@ -30,15 +30,15 @@ struct ValidatedTextField: View {
                             .background(Color.clear)
                     }
                     .padding(.trailing, 1)
-                    .opacity(isValid ? 0 : 1)
-                    .animation(.default, value: isValid)
+                    .opacity(hasError ? 1 : 0)
+                    .animation(.default, value: hasError)
                 }
             }
             Text(caption)
                 .foregroundColor(
-                    isValid ? Color.secondary : Color.red
+                    hasError ? Color.red : Color.secondary
                 )
-                .animation(.default, value: isValid)
+                .animation(.default, value: hasError)
                 .font(.caption)
         }
     }
@@ -56,7 +56,7 @@ struct ValidatedTextField_Previews: PreviewProvider {
                 placeholder: "nickname",
                 text: .constant(""),
                 caption: "Lowercase letters and numbers only.",
-                isValid: false
+                hasError: true
             )
             ValidatedTextField(
                 placeholder: "nickname",
@@ -68,7 +68,7 @@ struct ValidatedTextField_Previews: PreviewProvider {
                 placeholder: "nickname",
                 text: .constant("A very long run of text to test how this interacts with the icon"),
                 caption: "Lowercase letters and numbers only.",
-                isValid: false
+                hasError: true
             )
             .textFieldStyle(.roundedBorder)
         }

--- a/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
@@ -12,7 +12,7 @@ import Combine
 struct ValidatedTextField: View {
     var placeholder: String
     @Binding var text: String
-    var onFocusChanged: ((Bool) -> Void)?
+    var onFocusChanged: (Bool) -> Void = { _ in}
     var caption: String
     var hasError: Bool = false
     @FocusState var focused: Bool
@@ -39,7 +39,7 @@ struct ValidatedTextField: View {
                     .animation(.default, value: hasError)
                 }
                 .onChange(of: focused) { focused in
-                    onFocusChanged?(focused)
+                    onFocusChanged(focused)
                 }
             }
             Text(caption)

--- a/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
@@ -38,8 +38,7 @@ struct ValidatedTextField: View {
                     .opacity(hasError ? 1 : 0)
                     .animation(.default, value: hasError)
                 }
-                // This works but it's incredibly chatty on every keystroke
-                .onReceive(Just(focused)) { focused in
+                .onChange(of: focused) { focused in
                     onFocusChanged?(focused)
                 }
             }

--- a/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Combine
 
 /// A text field that comes with help text and a validation flag
 struct ValidatedTextField: View {
@@ -14,17 +15,17 @@ struct ValidatedTextField: View {
     var onFocusChanged: ((Bool) -> Void)?
     var caption: String
     var hasError: Bool = false
+    @FocusState var focused: Bool
+    
     
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.unit2) {
             HStack {
                 TextField(
                     placeholder,
-                    text: $text,
-                    onEditingChanged: { focused in
-                        onFocusChanged?(focused)
-                    }
+                    text: $text
                 )
+                .focused($focused)
                 .overlay(alignment: .trailing) {
                     VStack {
                         Image(systemName: "exclamationmark.circle")
@@ -36,6 +37,10 @@ struct ValidatedTextField: View {
                     .padding(.trailing, 1)
                     .opacity(hasError ? 1 : 0)
                     .animation(.default, value: hasError)
+                }
+                // This works but it's incredibly chatty on every keystroke
+                .onReceive(Just(focused)) { focused in
+                    onFocusChanged?(focused)
                 }
             }
             Text(caption)

--- a/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
@@ -27,7 +27,7 @@ struct ValidatedTextField: View {
                             .frame(width: 24, height: 22)
                             .padding(.horizontal, 8)
                             .foregroundColor(.red)
-                            .background(Color.background)
+                            .background(Color.clear)
                     }
                     .padding(.trailing, 1)
                     .opacity(isValid ? 0 : 1)

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeView.swift
@@ -36,7 +36,7 @@ struct TranscludeView: View {
 struct TranscludeView_Previews: PreviewProvider {
     static var previews: some View {
         TranscludeView(
-            pfp: Image("dog-pfp"),
+            pfp: Image("pfp-dog"),
             petname: "@doge",
             slashlink: "/thoughts",
             excerpt: "Thoughts of Doge. Food food park park park run run play run fetch ball run water shlorp shlorp shlorp dog bork bork bork home sleep sleep dream sleep"

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
@@ -24,7 +24,7 @@ struct FirstRunProfileView: View {
                             tag: AppAction.setNicknameTextField
                         ),
                         caption: "Lowercase letters, numbers and dashes only.",
-                        isValid: app.state.isNicknameTextFieldValid
+                        hasError: !app.state.isNicknameTextFieldValid
                     )
                     .textFieldStyle(.roundedBorder)
                     .textInputAutocapitalization(.never)

--- a/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
@@ -21,7 +21,7 @@ struct GatewayURLSettingsView: View {
                     tag: AppAction.setGatewayURLTextField
                 ),
                 caption: "The URL of your preferred Noosphere gateway",
-                isValid: app.state.isGatewayURLTextFieldValid
+                hasError: !app.state.isGatewayURLTextFieldValid
             )
             .autocapitalization(.none)
             .autocorrectionDisabled(true)

--- a/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
@@ -23,6 +23,7 @@ struct GatewayURLSettingsView: View {
                 caption: "The URL of your preferred Noosphere gateway",
                 hasError: !app.state.isGatewayURLTextFieldValid
             )
+            .formField()
             .autocapitalization(.none)
             .autocorrectionDisabled(true)
             .keyboardType(.URL)

--- a/xcode/Subconscious/Shared/Components/Settings/ProfileSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/ProfileSettingsView.swift
@@ -24,6 +24,7 @@ struct ProfileSettingsView: View {
                     caption: "Lowercase letters, numbers, and dashes only",
                     hasError: !app.state.isNicknameTextFieldValid
                 )
+                .formField()
                 .disableAutocorrection(true)
                 .autocapitalization(.none)
             }

--- a/xcode/Subconscious/Shared/Components/Settings/ProfileSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/ProfileSettingsView.swift
@@ -22,7 +22,7 @@ struct ProfileSettingsView: View {
                         tag: AppAction.setNicknameTextField
                     ),
                     caption: "Lowercase letters, numbers, and dashes only",
-                    isValid: app.state.isNicknameTextFieldValid
+                    hasError: !app.state.isNicknameTextFieldValid
                 )
                 .disableAutocorrection(true)
                 .autocapitalization(.none)

--- a/xcode/Subconscious/Shared/Models/FormField.swift
+++ b/xcode/Subconscious/Shared/Models/FormField.swift
@@ -1,0 +1,100 @@
+//
+//  FormField.swift
+//  Subconscious (iOS)
+//
+//  Created by Ben Follington on 11/3/2023.
+//
+
+import os
+import Foundation
+import SwiftUI
+import ObservableStore
+import Combine
+
+typealias FormFieldValidator<Input, Output> = (Input) -> Output?
+
+enum FormFieldAction<Input: Equatable> {
+    case reset
+    case touch(focused: Bool)
+    case setValue(input: Input)
+}
+
+struct FormFieldEnvironment {}
+
+struct FormField<Input: Equatable, Output>: Equatable, ModelProtocol {
+    static func == (lhs: FormField<Input, Output>, rhs: FormField<Input, Output>) -> Bool {
+        return (
+            lhs.value == rhs.value &&
+            lhs.touched == rhs.touched &&
+            lhs.isValid == rhs.isValid
+        )
+    }
+    
+    var value: Input
+    var defaultValue: Input
+    /// Should be a pure, static function
+    var validate: FormFieldValidator<Input, Output>
+    var touched: Bool
+    
+    init(value: Input, defaultValue: Input, escaping validate: @escaping FormFieldValidator<Input, Output>) {
+        self.value = value
+        self.defaultValue = defaultValue
+        self.validate = validate
+        self.touched = false
+    }
+    
+    init(value: Input, validate: @escaping FormFieldValidator<Input, Output>) {
+        self.value = value
+        self.defaultValue = value
+        self.validate = validate
+        self.touched = false
+    }
+    
+    /// Attempt to validate the input and produce the backing type
+    var validated: Output? {
+        get {
+            validate(value)
+        }
+    }
+    /// Is the current value valid?
+    var isValid: Bool {
+        get {
+            validated != nil
+        }
+    }
+    /// Should this field visually display an error?
+    var hasError: Bool {
+        get {
+            !isValid && touched
+        }
+    }
+    
+    static func update(
+        state: Self,
+        action: FormFieldAction<Input>,
+        environment: FormFieldEnvironment
+    ) -> Update<Self> {
+        switch action {
+        case .reset:
+            var model = state
+            model.touched = false
+            model.value = state.defaultValue
+            return Update(state: model)
+            
+        case .touch(let focused):
+            var model = state
+            // Only mark as touched when the field loses focus
+            // This avoids telling the user that a field is invalid
+            // before they've even type in it.
+            model.touched = focused ? state.touched : true
+            return Update(state: model)
+            
+        case .setValue(input: let input):
+            var model = state
+            model.value = input
+            // Only mark as touched if the value changed
+            model.touched = state.touched || input != state.value
+            return Update(state: model)
+        }
+    }
+}

--- a/xcode/Subconscious/Shared/Models/FormField.swift
+++ b/xcode/Subconscious/Shared/Models/FormField.swift
@@ -40,7 +40,7 @@ struct FormField<Input: Equatable, Output>: Equatable, ModelProtocol {
     var touched: Bool
     var hasBeenFocusedAtLeastOnce: Bool
     
-    init(value: Input, defaultValue: Input, escaping validate: @escaping FormFieldValidator<Input, Output>) {
+    init(value: Input, defaultValue: Input, validate: @escaping FormFieldValidator<Input, Output>) {
         self.value = value
         self.defaultValue = defaultValue
         self.validate = validate

--- a/xcode/Subconscious/Shared/Services/AddressBookService.swift
+++ b/xcode/Subconscious/Shared/Services/AddressBookService.swift
@@ -38,7 +38,7 @@ class AddressBookService {
                             // TODO: hardcoded pfp
                             return AddressBookEntry(pfp: Image("pfp-dog"), petname: f, did: did)
                         }
-                        .compactMap { $0 }
+                        .compactMap { value in value }
                 })
                 .collect()
                 .eraseToAnyPublisher()

--- a/xcode/Subconscious/Shared/Services/AddressBookService.swift
+++ b/xcode/Subconscious/Shared/Services/AddressBookService.swift
@@ -55,49 +55,49 @@ class AddressBookService {
     }
     
     func getPetname(petname: Petname) throws -> Did? {
-      return try Did(noosphere.getPetname(petname: petname.verbatim))
+        return try Did(noosphere.getPetname(petname: petname.verbatim))
     }
 
     func getPetnameAsync(petname: Petname) -> AnyPublisher<Did?, Error> {
-      CombineUtilities.async(qos: .utility) {
+        CombineUtilities.async(qos: .utility) {
           return try self.getPetname(petname: petname)
-      }
+        }
     }
 
     func setPetname(did: Did, petname: Petname) throws {
-      try noosphere.setPetname(did: did.did, petname: petname.verbatim)
+        try noosphere.setPetname(did: did.did, petname: petname.verbatim)
     }
 
     func setPetnameAsync(did: Did, petname: Petname) -> AnyPublisher<Void, Error> {
-      CombineUtilities.async(qos: .utility) {
+        CombineUtilities.async(qos: .utility) {
           try self.setPetname(did: did, petname: petname)
-      }
+        }
     }
 
     func unsetPetname(petname: Petname) throws {
-      try noosphere.unsetPetname(petname: petname.verbatim)
+        try noosphere.unsetPetname(petname: petname.verbatim)
     }
 
     func unsetPetnameAsync(petname: Petname) -> AnyPublisher<Void, Error> {
-      CombineUtilities.async(qos: .utility) {
+        CombineUtilities.async(qos: .utility) {
           try self.unsetPetname(petname: petname)
-      }
+        }
     }
 
     func listPetnames() throws -> [Petname] {
-      return try noosphere.listPetnames()
-          .map { name in Petname(name) }
-          .compactMap { $0 }
+        return try noosphere.listPetnames()
+            .map { name in Petname(name) }
+            .compactMap { $0 }
     }
 
     func listPetnamesAsync() -> AnyPublisher<[Petname], Error> {
-      CombineUtilities.async(qos: .utility) {
+        CombineUtilities.async(qos: .utility) {
           return try self.listPetnames()
-      }
+        }
     }
 
     func getPetnameChanges(sinceCid: String) throws -> [String] {
-      return try noosphere.getPetnameChanges(sinceCid: sinceCid)
+        return try noosphere.getPetnameChanges(sinceCid: sinceCid)
     }
       
     func getPetnameChangesAsync(sinceCid: String) -> AnyPublisher<[String], Error> {

--- a/xcode/Subconscious/Shared/Services/AddressBookService.swift
+++ b/xcode/Subconscious/Shared/Services/AddressBookService.swift
@@ -1,0 +1,108 @@
+//
+//  AddressBookService.swift
+//  Subconscious
+//
+//  Created by Ben Follington on 14/3/2023.
+//
+
+import Foundation
+import Combine
+// temp
+import SwiftUI
+
+class AddressBookService {
+    private(set) var noosphere: NoosphereService
+    private var addressBook: [AddressBookEntry]?
+    
+    init(noosphere: NoosphereService) {
+        self.noosphere = noosphere
+        self.addressBook = nil
+    }
+    
+    /// Get the full list of entries in the address book.
+    /// This is cached after the first use unless requested using refetch.
+    /// If an error occurs producing the entries the resulting list will be empty.
+    func listEntries(refetch: Bool = false) -> AnyPublisher<[AddressBookEntry], Never> {
+        if let entries = addressBook {
+            if !refetch {
+                return Just(entries).eraseToAnyPublisher()
+            }
+        }
+        
+        return self.listPetnamesAsync()
+            .flatMap { follows in
+                return Publishers.MergeMany(follows.map { f in
+                    return self.getPetnameAsync(petname: f)
+                        .map { did -> AddressBookEntry? in
+                            guard let did = did else { return nil }
+                            // TODO: hardcoded dog-pfp
+                            return AddressBookEntry(pfp: Image("dog-pfp"), petname: f, did: did)
+                        }
+                        .compactMap { $0 }
+                })
+                .collect()
+                .eraseToAnyPublisher()
+            }
+            .catch { err in
+                Just([])
+            }
+            .map { entries in
+                // Here be dragons (mutation) to cache the result
+                self.addressBook = entries
+                return entries
+            }
+            .eraseToAnyPublisher()
+    }
+    
+    func getPetname(petname: Petname) throws -> Did? {
+      return try Did(noosphere.getPetname(petname: petname.verbatim))
+    }
+
+    func getPetnameAsync(petname: Petname) -> AnyPublisher<Did?, Error> {
+      CombineUtilities.async(qos: .utility) {
+          return try self.getPetname(petname: petname)
+      }
+    }
+
+    func setPetname(did: Did, petname: Petname) throws {
+      try noosphere.setPetname(did: did.did, petname: petname.verbatim)
+    }
+
+    func setPetnameAsync(did: Did, petname: Petname) -> AnyPublisher<Void, Error> {
+      CombineUtilities.async(qos: .utility) {
+          try self.setPetname(did: did, petname: petname)
+      }
+    }
+
+    func unsetPetname(petname: Petname) throws {
+      try noosphere.unsetPetname(petname: petname.verbatim)
+    }
+
+    func unsetPetnameAsync(petname: Petname) -> AnyPublisher<Void, Error> {
+      CombineUtilities.async(qos: .utility) {
+          try self.unsetPetname(petname: petname)
+      }
+    }
+
+    func listPetnames() throws -> [Petname] {
+      return try noosphere.listPetnames()
+          .map { name in Petname(name) }
+          .compactMap { $0 }
+    }
+
+    func listPetnamesAsync() -> AnyPublisher<[Petname], Error> {
+      CombineUtilities.async(qos: .utility) {
+          return try self.listPetnames()
+      }
+    }
+
+    func getPetnameChanges(sinceCid: String) throws -> [String] {
+      return try noosphere.getPetnameChanges(sinceCid: sinceCid)
+    }
+      
+    func getPetnameChangesAsync(sinceCid: String) -> AnyPublisher<[String], Error> {
+        CombineUtilities.async(qos: .utility) {
+            return try self.getPetnameChanges(sinceCid: sinceCid)
+        }
+    }
+}

--- a/xcode/Subconscious/Shared/Services/AddressBookService.swift
+++ b/xcode/Subconscious/Shared/Services/AddressBookService.swift
@@ -35,8 +35,8 @@ class AddressBookService {
                     return self.getPetnameAsync(petname: f)
                         .map { did -> AddressBookEntry? in
                             guard let did = did else { return nil }
-                            // TODO: hardcoded dog-pfp
-                            return AddressBookEntry(pfp: Image("dog-pfp"), petname: f, did: did)
+                            // TODO: hardcoded pfp
+                            return AddressBookEntry(pfp: Image("pfp-dog"), petname: f, did: did)
                         }
                         .compactMap { $0 }
                 })

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -38,6 +38,7 @@ struct MoveReceipt: Hashable {
 /// Wraps both database and source-of-truth store, providing data
 /// access methods for the app.
 struct DataService {
+    var addressBook: AddressBookService
     var noosphere: NoosphereService
     var database: DatabaseService
     var local: HeaderSubtextMemoStore
@@ -46,11 +47,13 @@ struct DataService {
     init(
         noosphere: NoosphereService,
         database: DatabaseService,
-        local: HeaderSubtextMemoStore
+        local: HeaderSubtextMemoStore,
+        addressBook: AddressBookService
     ) {
         self.database = database
         self.noosphere = noosphere
         self.local = local
+        self.addressBook = addressBook
         self.logger = Logger(
             subsystem: Config.default.rdns,
             category: "DataService"
@@ -553,68 +556,6 @@ struct DataService {
     func readRandomEntryLinkAsync() -> AnyPublisher<EntryLink, Error> {
         CombineUtilities.async(qos: .default) {
             try readRandomEntryLink()
-        }
-    }
-  
-    func getPetname(petname: Petname) throws -> Did? {
-        return try Did(noosphere.getPetname(petname: petname.verbatim))
-    }
-    
-    func getPetnameAsync(petname: Petname) -> AnyPublisher<Did?, Error> {
-        CombineUtilities.async(qos: .utility) {
-            return try getPetname(petname: petname)
-        }
-    }
-    
-    func setPetname(did: Did, petname: Petname) throws {
-        try noosphere.setPetname(did: did.did, petname: petname.verbatim)
-    }
-    
-    func setPetnameAsync(did: Did, petname: Petname) -> AnyPublisher<Void, Error> {
-        CombineUtilities.async(qos: .utility) {
-            try setPetname(did: did, petname: petname)
-        }
-    }
-    
-    func unsetPetname(petname: Petname) throws {
-        try noosphere.unsetPetname(petname: petname.verbatim)
-    }
-    
-    func unsetPetnameAsync(petname: Petname) -> AnyPublisher<Void, Error> {
-        CombineUtilities.async(qos: .utility) {
-            try unsetPetname(petname: petname)
-        }
-    }
-    
-    func resolvePetname(petname: Petname) throws -> String {
-        return try noosphere.resolvePetname(petname: petname.verbatim)
-    }
-    
-    func resolvePetnameAsync(petname: Petname) -> AnyPublisher<String, Error> {
-        CombineUtilities.async(qos: .utility) {
-            return try resolvePetname(petname: petname)
-        }
-    }
-    
-    func listPetnames() throws -> [Petname] {
-        return try noosphere.listPetnames()
-            .map { name in Petname(name) }
-            .compactMap { $0 }
-    }
-    
-    func listPetnamesAsync() -> AnyPublisher<[Petname], Error> {
-        CombineUtilities.async(qos: .utility) {
-            return try listPetnames()
-        }
-    }
-    
-    func getPetnameChanges(sinceCid: String) throws -> [String] {
-        return try noosphere.getPetnameChanges(sinceCid: sinceCid)
-    }
-    
-    func getPetnameChangesAsync(sinceCid: String) -> AnyPublisher<[String], Error> {
-        CombineUtilities.async(qos: .utility) {
-            return try getPetnameChanges(sinceCid: sinceCid)
         }
     }
 }

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -555,4 +555,44 @@ struct DataService {
             try readRandomEntryLink()
         }
     }
+  
+    func getPetname(petname: Petname) throws {
+        try noosphere.getPetname(petname: petname.verbatim)
+    }
+    
+    func getPetnameAsync(petname: Petname) -> AnyPublisher<Void, Error> {
+        CombineUtilities.async(qos: .utility) {
+            try getPetname(petname: petname)
+        }
+    }
+    
+    func setPetname(did: Did, petname: Petname) throws {
+        try noosphere.setPetname(did: did.did, petname: petname.verbatim)
+    }
+    
+    func setPetnameAsync(did: Did, petname: Petname) -> AnyPublisher<Void, Error> {
+        CombineUtilities.async(qos: .utility) {
+            try setPetname(did: did, petname: petname)
+        }
+    }
+    
+    func unsetPetname(petname: Petname) throws {
+        try noosphere.unsetPetname(petname: petname.verbatim)
+    }
+    
+    func unsetPetnameAsync(petname: Petname) -> AnyPublisher<Void, Error> {
+        CombineUtilities.async(qos: .utility) {
+            try unsetPetname(petname: petname)
+        }
+    }
+    
+    func resolvePetname(petname: Petname) throws {
+        try noosphere.resolvePetname(petname: petname.verbatim)
+    }
+    
+    func resolvePetnameAsync(petname: Petname) -> AnyPublisher<Void, Error> {
+        CombineUtilities.async(qos: .utility) {
+            try unsetPetname(petname: petname)
+        }
+    }
 }

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -556,13 +556,13 @@ struct DataService {
         }
     }
   
-    func getPetname(petname: Petname) throws {
-        try noosphere.getPetname(petname: petname.verbatim)
+    func getPetname(petname: Petname) throws -> Did? {
+        return try Did(noosphere.getPetname(petname: petname.verbatim))
     }
     
-    func getPetnameAsync(petname: Petname) -> AnyPublisher<Void, Error> {
+    func getPetnameAsync(petname: Petname) -> AnyPublisher<Did?, Error> {
         CombineUtilities.async(qos: .utility) {
-            try getPetname(petname: petname)
+            return try getPetname(petname: petname)
         }
     }
     
@@ -586,13 +586,35 @@ struct DataService {
         }
     }
     
-    func resolvePetname(petname: Petname) throws {
-        try noosphere.resolvePetname(petname: petname.verbatim)
+    func resolvePetname(petname: Petname) throws -> String {
+        return try noosphere.resolvePetname(petname: petname.verbatim)
     }
     
-    func resolvePetnameAsync(petname: Petname) -> AnyPublisher<Void, Error> {
+    func resolvePetnameAsync(petname: Petname) -> AnyPublisher<String, Error> {
         CombineUtilities.async(qos: .utility) {
-            try unsetPetname(petname: petname)
+            return try resolvePetname(petname: petname)
+        }
+    }
+    
+    func listPetnames() throws -> [Petname] {
+        return try noosphere.listPetnames()
+            .map { name in Petname(name) }
+            .compactMap { $0 }
+    }
+    
+    func listPetnamesAsync() -> AnyPublisher<[Petname], Error> {
+        CombineUtilities.async(qos: .utility) {
+            return try listPetnames()
+        }
+    }
+    
+    func getPetnameChanges(sinceCid: String) throws -> [String] {
+        return try noosphere.getPetnameChanges(sinceCid: sinceCid)
+    }
+    
+    func getPetnameChangesAsync(sinceCid: String) -> AnyPublisher<[String], Error> {
+        CombineUtilities.async(qos: .utility) {
+            return try getPetnameChanges(sinceCid: sinceCid)
         }
     }
 }

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -241,7 +241,7 @@ final class NoosphereService: SphereProtocol, SphereIdentityProtocol {
     }
     
     // TODO: Do these belong on NoosphereService?
-    func getPetname(petname: String) throws {
+    func getPetname(petname: String) throws -> String {
         try queue.sync {
             try self.sphere().getPetname(petname: petname)
         }
@@ -259,9 +259,21 @@ final class NoosphereService: SphereProtocol, SphereIdentityProtocol {
         }
     }
     
-    func resolvePetname(petname: String) throws {
+    func resolvePetname(petname: String) throws -> String {
         try queue.sync {
             try self.sphere().resolvePetname(petname: petname)
+        }
+    }
+    
+    func listPetnames() throws -> [String] {
+        try queue.sync {
+            try self.sphere().listPetnames()
+        }
+    }
+    
+    func getPetnameChanges(sinceCid: String) throws -> [String] {
+        try queue.sync {
+            try self.sphere().getPetnameChanges(sinceCid: sinceCid)
         }
     }
 }

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -240,7 +240,6 @@ final class NoosphereService: SphereProtocol, SphereIdentityProtocol {
         }
     }
     
-    // TODO: Do these belong on NoosphereService?
     func getPetname(petname: String) throws -> String {
         try queue.sync {
             try self.sphere().getPetname(petname: petname)

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -239,4 +239,29 @@ final class NoosphereService: SphereProtocol, SphereIdentityProtocol {
             try self.sphere().changes(since)
         }
     }
+    
+    // TODO: Do these belong on NoosphereService?
+    func getPetname(petname: String) throws {
+        try queue.sync {
+            try self.sphere().getPetname(petname: petname)
+        }
+    }
+    
+    func setPetname(did: String, petname: String) throws {
+        try queue.sync {
+            try self.sphere().setPetname(did: did, petname: petname)
+        }
+    }
+    
+    func unsetPetname(petname: String) throws {
+        try queue.sync {
+            try self.sphere().unsetPetname(petname: petname)
+        }
+    }
+    
+    func resolvePetname(petname: String) throws {
+        try queue.sync {
+            try self.sphere().resolvePetname(petname: petname)
+        }
+    }
 }

--- a/xcode/Subconscious/Shared/Services/Noosphere/SphereFS.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/SphereFS.swift
@@ -265,36 +265,71 @@ public final class SphereFS: SphereProtocol {
     }
     
     // TODO: Do these belong on SphereFS?
-    public func getPetname(petname: String) throws {
-        throw NoosphereError.foreignError("Not Implemented")
+    public func getPetname(petname: String) throws -> String {
+        throw NoosphereError.foreignError("Not Implemented: getPetname")
         
-//        try Noosphere.callWithError { error in
-//            ns_sphere_petname_get(noosphere.noosphere, identity, petname)
-//        }
+//        return try Noosphere.callWithError(
+//            ns_sphere_petname_get,
+//            noosphere.noosphere,
+//            sphere,
+//            petname
+//        )
     }
     
     public func setPetname(did: String, petname: String) throws {
-        throw NoosphereError.foreignError("Not Implemented")
+        throw NoosphereError.foreignError("Not Implemented: setPetname")
         
-//        try Noosphere.callWithError { error in
-//            ns_sphere_petname_set(noosphere.noosphere, identity, petname, did)
-//        }
+//        return try Noosphere.callWithError(
+//            ns_sphere_petname_set,
+//            noosphere.noosphere,
+//            sphere,
+//            petname,
+//            did
+//        )
     }
     
     public func unsetPetname(petname: String) throws {
-        throw NoosphereError.foreignError("Not Implemented")
+        throw NoosphereError.foreignError("Not Implemented: unsetPetname")
         
-//        try Noosphere.callWithError { error in
-//            ns_sphere_petname_set(noosphere.noosphere, identity, petname, nil)
-//        }
+//        return try Noosphere.callWithError(
+//            ns_sphere_petname_set,
+//            noosphere.noosphere,
+//            sphere,
+//            petname,
+//            nil
+//        )
     }
     
-    public func resolvePetname(petname: String) throws {
-        throw NoosphereError.foreignError("Not Implemented")
+    public func resolvePetname(petname: String) throws -> String {
+        throw NoosphereError.foreignError("Not Implemented: resolvePetname")
         
-//        try Noosphere.callWithError { error in
-//            ns_sphere_petname_resolve(noosphere.noosphere, identity, petname)
-//        }
+//        return try Noosphere.callWithError(
+//            ns_sphere_petname_resolve,
+//            noosphere.noosphere,
+//            sphere,
+//            petname
+//        )
+    }
+    
+    public func listPetnames() throws -> [String] {
+        throw NoosphereError.foreignError("Not Implemented: listPetnames")
+        
+//        return try Noosphere.callWithError(
+//            ns_sphere_petname_list,
+//            noosphere.noosphere,
+//            sphere
+//        )
+    }
+    
+    public func getPetnameChanges(sinceCid: String) throws -> [String] {
+        throw NoosphereError.foreignError("Not Implemented: getPetnameChanges")
+        
+//        return try Noosphere.callWithError(
+//            ns_sphere_petname_list,
+//            noosphere.noosphere,
+//            sphere,
+//            sinceCid
+//        )
     }
     
     /// Save outstanding writes and return new Sphere version

--- a/xcode/Subconscious/Shared/Services/Noosphere/SphereFS.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/SphereFS.swift
@@ -264,7 +264,6 @@ public final class SphereFS: SphereProtocol {
         })
     }
     
-    // TODO: Do these belong on SphereFS?
     public func getPetname(petname: String) throws -> String {
         throw NoosphereError.foreignError("Not Implemented: getPetname")
         

--- a/xcode/Subconscious/Shared/Services/Noosphere/SphereFS.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/SphereFS.swift
@@ -264,6 +264,39 @@ public final class SphereFS: SphereProtocol {
         })
     }
     
+    // TODO: Do these belong on SphereFS?
+    public func getPetname(petname: String) throws {
+        throw NoosphereError.foreignError("Not Implemented")
+        
+//        try Noosphere.callWithError { error in
+//            ns_sphere_petname_get(noosphere.noosphere, identity, petname)
+//        }
+    }
+    
+    public func setPetname(did: String, petname: String) throws {
+        throw NoosphereError.foreignError("Not Implemented")
+        
+//        try Noosphere.callWithError { error in
+//            ns_sphere_petname_set(noosphere.noosphere, identity, petname, did)
+//        }
+    }
+    
+    public func unsetPetname(petname: String) throws {
+        throw NoosphereError.foreignError("Not Implemented")
+        
+//        try Noosphere.callWithError { error in
+//            ns_sphere_petname_set(noosphere.noosphere, identity, petname, nil)
+//        }
+    }
+    
+    public func resolvePetname(petname: String) throws {
+        throw NoosphereError.foreignError("Not Implemented")
+        
+//        try Noosphere.callWithError { error in
+//            ns_sphere_petname_resolve(noosphere.noosphere, identity, petname)
+//        }
+    }
+    
     /// Save outstanding writes and return new Sphere version
     @discardableResult public func save() throws -> String {
         try Noosphere.callWithError(

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		B58FE48E28DEDAEA00E000CC /* StoryComboView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58FE48D28DEDAEA00E000CC /* StoryComboView.swift */; };
 		B59D556329BBFF56007915E2 /* FormField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59D556229BBFF56007915E2 /* FormField.swift */; };
 		B5D8D2FF29AF1DBB0011D820 /* Test_Did.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D8D2FE29AF1DBB0011D820 /* Test_Did.swift */; };
+		B5F6ADC929C02F4A00690DE4 /* AddressBookService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F6ADC829C02F4A00690DE4 /* AddressBookService.swift */; };
 		B80057EB27DC355E002C0129 /* SubconsciousTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80057EA27DC355E002C0129 /* SubconsciousTests.swift */; };
 		B80057F427DC35BE002C0129 /* Tests_Slug.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80057F327DC35BE002C0129 /* Tests_Slug.swift */; };
 		B800ABE8297DE7D20024D1FD /* DataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B800ABE7297DE7D20024D1FD /* DataService.swift */; };
@@ -368,6 +369,7 @@
 		B59D556229BBFF56007915E2 /* FormField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormField.swift; sourceTree = "<group>"; };
 		B5D8D2FE29AF1DBB0011D820 /* Test_Did.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_Did.swift; sourceTree = "<group>"; };
 		B5D8D30029AF1F9B0011D820 /* Did.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Did.swift; sourceTree = "<group>"; };
+		B5F6ADC829C02F4A00690DE4 /* AddressBookService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookService.swift; sourceTree = "<group>"; };
 		B80057E827DC355E002C0129 /* SubconsciousTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SubconsciousTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B80057EA27DC355E002C0129 /* SubconsciousTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubconsciousTests.swift; sourceTree = "<group>"; };
 		B80057F327DC35BE002C0129 /* Tests_Slug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_Slug.swift; sourceTree = "<group>"; };
@@ -761,6 +763,7 @@
 			isa = PBXGroup;
 			children = (
 				B87288DA299AB00700EF7E07 /* Noosphere */,
+				B5F6ADC829C02F4A00690DE4 /* AddressBookService.swift */,
 				B8E00A2929928DD2003B40C1 /* AppDefaults.swift */,
 				B58FE48928DED93F00E000CC /* ComboGeist.swift */,
 				B82C3A5226F528B000833CC8 /* DatabaseService.swift */,
@@ -1419,6 +1422,7 @@
 				B822F18D27C9C0AB00943C6B /* CountChip.swift in Sources */,
 				B87288DE299AB02400EF7E07 /* SphereFS.swift in Sources */,
 				B8879EAC26F944DA00A0B4FF /* Detail.swift in Sources */,
+				B5F6ADC929C02F4A00690DE4 /* AddressBookService.swift in Sources */,
 				B8A1621429B2AB3A008322EB /* CloseButtonView.swift in Sources */,
 				B82C3A7626F6B5BF00833CC8 /* StringUtilities.swift in Sources */,
 				B85BF47827BC2B4700F55730 /* DetailToolbarContent.swift in Sources */,

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		B59D556329BBFF56007915E2 /* FormField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59D556229BBFF56007915E2 /* FormField.swift */; };
 		B5D8D2FF29AF1DBB0011D820 /* Test_Did.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D8D2FE29AF1DBB0011D820 /* Test_Did.swift */; };
 		B5F6ADC929C02F4A00690DE4 /* AddressBookService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F6ADC829C02F4A00690DE4 /* AddressBookService.swift */; };
+		B5F6ADCC29C1323900690DE4 /* Tests_FormField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F6ADCB29C1323900690DE4 /* Tests_FormField.swift */; };
 		B80057EB27DC355E002C0129 /* SubconsciousTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80057EA27DC355E002C0129 /* SubconsciousTests.swift */; };
 		B80057F427DC35BE002C0129 /* Tests_Slug.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80057F327DC35BE002C0129 /* Tests_Slug.swift */; };
 		B800ABE8297DE7D20024D1FD /* DataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B800ABE7297DE7D20024D1FD /* DataService.swift */; };
@@ -370,6 +371,7 @@
 		B5D8D2FE29AF1DBB0011D820 /* Test_Did.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_Did.swift; sourceTree = "<group>"; };
 		B5D8D30029AF1F9B0011D820 /* Did.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Did.swift; sourceTree = "<group>"; };
 		B5F6ADC829C02F4A00690DE4 /* AddressBookService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookService.swift; sourceTree = "<group>"; };
+		B5F6ADCB29C1323900690DE4 /* Tests_FormField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_FormField.swift; sourceTree = "<group>"; };
 		B80057E827DC355E002C0129 /* SubconsciousTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SubconsciousTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B80057EA27DC355E002C0129 /* SubconsciousTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubconsciousTests.swift; sourceTree = "<group>"; };
 		B80057F327DC35BE002C0129 /* Tests_Slug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_Slug.swift; sourceTree = "<group>"; };
@@ -658,6 +660,7 @@
 				B84AD8DE280F3659006B3153 /* Tests_EntryLink.swift */,
 				B85D5E3E28BE4B4600EE0078 /* Tests_FeedUpdate.swift */,
 				B8B3194E2909F36800A1E62A /* Tests_FileFingerprint.swift */,
+				B5F6ADCB29C1323900690DE4 /* Tests_FormField.swift */,
 				B831BDBB2825A4E700C4CE92 /* Tests_Header.swift */,
 				B809AFF328D8E7BC00D0589A /* Tests_MarkupText.swift */,
 				B80CC804299D14C900C4D7C0 /* Tests_Memo.swift */,
@@ -1335,6 +1338,7 @@
 				B88CC95B284FF64300994928 /* Tests_OrderedCollectionUtilities.swift in Sources */,
 				B80057F427DC35BE002C0129 /* Tests_Slug.swift in Sources */,
 				B5D8D2FF29AF1DBB0011D820 /* Test_Did.swift in Sources */,
+				B5F6ADCC29C1323900690DE4 /* Tests_FormField.swift in Sources */,
 				B8D328B529A640F200850A37 /* Tests_RecoveryPhrase.swift in Sources */,
 				B831BDBC2825A4E700C4CE92 /* Tests_Header.swift in Sources */,
 				B85D5E3F28BE4B4600EE0078 /* Tests_FeedUpdate.swift in Sources */,

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		B58FE48A28DED93F00E000CC /* ComboGeist.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58FE48928DED93F00E000CC /* ComboGeist.swift */; };
 		B58FE48C28DED9B600E000CC /* StoryCombo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58FE48B28DED9B600E000CC /* StoryCombo.swift */; };
 		B58FE48E28DEDAEA00E000CC /* StoryComboView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58FE48D28DEDAEA00E000CC /* StoryComboView.swift */; };
+		B59D556329BBFF56007915E2 /* FormField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59D556229BBFF56007915E2 /* FormField.swift */; };
 		B5D8D2FF29AF1DBB0011D820 /* Test_Did.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D8D2FE29AF1DBB0011D820 /* Test_Did.swift */; };
 		B80057EB27DC355E002C0129 /* SubconsciousTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80057EA27DC355E002C0129 /* SubconsciousTests.swift */; };
 		B80057F427DC35BE002C0129 /* Tests_Slug.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80057F327DC35BE002C0129 /* Tests_Slug.swift */; };
@@ -364,6 +365,7 @@
 		B58FE48928DED93F00E000CC /* ComboGeist.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComboGeist.swift; sourceTree = "<group>"; };
 		B58FE48B28DED9B600E000CC /* StoryCombo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryCombo.swift; sourceTree = "<group>"; };
 		B58FE48D28DEDAEA00E000CC /* StoryComboView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryComboView.swift; sourceTree = "<group>"; };
+		B59D556229BBFF56007915E2 /* FormField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormField.swift; sourceTree = "<group>"; };
 		B5D8D2FE29AF1DBB0011D820 /* Test_Did.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_Did.swift; sourceTree = "<group>"; };
 		B5D8D30029AF1F9B0011D820 /* Did.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Did.swift; sourceTree = "<group>"; };
 		B80057E827DC355E002C0129 /* SubconsciousTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SubconsciousTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -856,6 +858,7 @@
 				B8A59D6828B692900010DB2F /* StoryPrompt.swift */,
 				B8B54F3C271F7C6B00B9B507 /* Suggestion.swift */,
 				B8CBAFAF2996A7D50079107E /* UnqualifiedLink.swift */,
+				B59D556229BBFF56007915E2 /* FormField.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1443,6 +1446,7 @@
 				B82BB7FB2821DA61000C9FCC /* Parser.swift in Sources */,
 				B8249DA027E2668500BCDFBA /* PinTrailingBottom.swift in Sources */,
 				B85EC466296F0D0A00558761 /* ProfilePicMd.swift in Sources */,
+				B59D556329BBFF56007915E2 /* FormField.swift in Sources */,
 				B81A535C27275138001A6268 /* Tape.swift in Sources */,
 				B8B3EE7B297AFB9100779B7F /* TextFieldLabel.swift in Sources */,
 				B8B3194D2909E81D00A1E62A /* FileInfo.swift in Sources */,

--- a/xcode/Subconscious/SubconsciousTests/Tests_DataService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DataService.swift
@@ -61,11 +61,13 @@ final class Tests_DataService: XCTestCase {
         )
         
         let local = HeaderSubtextMemoStore(store: files)
+        let addressBook = AddressBookService(noosphere: noosphere)
         
         return DataService(
             noosphere: noosphere,
             database: database,
-            local: local
+            local: local,
+            addressBook: addressBook
         )
     }
     
@@ -221,11 +223,13 @@ final class Tests_DataService: XCTestCase {
                 gatewayURL: URL(string: "http://unavailable-gateway.fakewebsite"),
                 sphereIdentity: sphereIdentity
             )
+            let addressBook = AddressBookService(noosphere: noosphere)
 
             let data = DataService(
                 noosphere: noosphere,
                 database: database,
-                local: local
+                local: local,
+                addressBook: addressBook
             )
             
             versionX = try data.noosphere.version()
@@ -257,11 +261,13 @@ final class Tests_DataService: XCTestCase {
             gatewayURL: URL(string: "http://unavailable-gateway.fakewebsite"),
             sphereIdentity: sphereIdentity
         )
+        let addressBook = AddressBookService(noosphere: noosphere)
 
         let data = DataService(
             noosphere: noosphere,
             database: database,
-            local: local
+            local: local,
+            addressBook: addressBook
         )
         let versionY = try data.noosphere.version()
         

--- a/xcode/Subconscious/SubconsciousTests/Tests_FormField.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_FormField.swift
@@ -1,0 +1,128 @@
+//
+//  Tests_FormField.swift
+//  SubconsciousTests
+//
+//  Created by Ben Follington on 15/3/2023.
+//
+
+
+import XCTest
+import ObservableStore
+@testable import Subconscious
+
+class Tests_FormField: XCTestCase {
+    static func validateStringIsHello(input: String) -> String? {
+        if input == "hello" {
+            return input
+        }
+        
+        return nil
+    }
+    
+    let environment = FormFieldEnvironment()
+    
+    func testDetectsFirstFocus() throws {
+        let state = FormField(value: "", validate: Self.validateStringIsHello)
+        let update = FormField.update(state: state, action: .focusChange(focused: true), environment: environment)
+        
+        XCTAssertEqual(
+            update.state.hasBeenFocusedAtLeastOnce,
+            true,
+            "Tracks first focus correctly"
+        )
+        
+        XCTAssertEqual(
+            update.state.touched,
+            false,
+            "Does not set touched on initial focus"
+        )
+    }
+    
+    func testDetectsTouchedOnUnfocus() throws {
+        let state = FormField(value: "", validate: Self.validateStringIsHello)
+        var update = FormField.update(state: state, action: .focusChange(focused: true), environment: environment)
+        update = FormField.update(state: update.state, action: .focusChange(focused: false), environment: environment)
+        
+        XCTAssertEqual(
+            update.state.hasBeenFocusedAtLeastOnce,
+            true,
+            "Tracks first focus correctly"
+        )
+        
+        XCTAssertEqual(
+            update.state.touched,
+            true,
+            "Sets touched after focus then unfocus"
+        )
+    }
+    
+    func testOnlyDetectsTouchedAfterInitialFocus() throws {
+        let state = FormField(value: "", validate: Self.validateStringIsHello)
+        let update = FormField.update(state: state, action: .focusChange(focused: false), environment: environment)
+        
+        XCTAssertEqual(
+            update.state.touched,
+            false,
+            "Does not set touched unless field has been focused once"
+        )
+    }
+    
+    func testMultipleInputUpdates() throws {
+        let state = FormField(value: "DEFAULT", validate: Self.validateStringIsHello)
+        
+        var update = FormField.update(state: state, action: .setValue(input: "Zorpo"), environment: environment)
+        
+        XCTAssertEqual(update.state.value, "Zorpo", "Value is updated")
+        
+        update = FormField.update(state: update.state, action: .setValue(input: "Cronkulus"), environment: environment)
+        
+        XCTAssertEqual(update.state.value, "Cronkulus", "Value is updated")
+    }
+    
+    func testResetField() throws {
+        let state = FormField(value: "DEFAULT", validate: Self.validateStringIsHello)
+        
+        XCTAssertEqual(state.defaultValue, "DEFAULT", "Records default value")
+        
+        var update = FormField.update(state: state, action: .markAsTouched, environment: environment)
+        
+        XCTAssertEqual(update.state.touched, true, "Manually marked as touched")
+        
+        update = FormField.update(state: update.state, action: .setValue(input: "something else!"), environment: environment)
+        
+        XCTAssertEqual(update.state.defaultValue, "DEFAULT", "Preserves default value")
+        XCTAssertEqual(update.state.value, "something else!", "Updates input value")
+        
+        update = FormField.update(state: update.state, action: .reset, environment: environment)
+        
+        XCTAssertEqual(update.state.value, state.defaultValue, "Resets input value")
+        XCTAssertEqual(update.state.defaultValue, state.defaultValue, "Preserves default value")
+        XCTAssertEqual(update.state.touched, state.touched, "Resets touched status")
+    }
+    
+    func testValidation() throws {
+        let state = FormField(value: "DEFAULT", validate: Self.validateStringIsHello)
+        
+        XCTAssertEqual(state.validated, nil, "Validated output is nil")
+        XCTAssertEqual(state.isValid, false, "Validator fails")
+        XCTAssertEqual(state.hasError, false, "No error is displayed")
+        
+        var update = FormField.update(state: state, action: .markAsTouched, environment: environment)
+        
+        XCTAssertEqual(update.state.validated, nil, "Validated output is nil")
+        XCTAssertEqual(update.state.isValid, false, "Validator fails")
+        XCTAssertEqual(update.state.hasError, true, "Error message is displayed")
+        
+        update = FormField.update(state: update.state, action: .setValue(input: "hello"), environment: environment)
+        
+        XCTAssertEqual(update.state.validated, "hello", "Validated output returned")
+        XCTAssertEqual(update.state.isValid, true, "Validator passes")
+        XCTAssertEqual(update.state.hasError, false, "No error message is displayed")
+        
+        update = FormField.update(state: update.state, action: .reset, environment: environment)
+        
+        XCTAssertEqual(state.validated, nil, "Validated output is nil")
+        XCTAssertEqual(state.isValid, false, "Validator fails")
+        XCTAssertEqual(state.hasError, false, "No error is displayed")
+    }
+}


### PR DESCRIPTION
Resolves #443

This PR integrates the Address Book UI from #420 with the underlying persistence layer via Noosphere.

- [x] Implement actions for NS operations
- [x] Stub methods out
- [x] Model lifecycle including failure and success paths
- [x] Implement cache for address book
- [x] Tests for `FormField` model
- [x] Tests for `AddressBookModel` and/or `AddressBookService`
- [x] Switch the `Follow User` navigation to a `.sheet` instead (we can control presentation from the store directly)
    - Right now we dismiss the form on submission but we need to keep it open to show errors
- [x] Display errors in UI on fail to follow and fail to unfollow

**Note**: Swipe to unfollow can remove the entry from the UI without mutating the underlying store