### PR TITLE
Improve omnibox with 3p @handles, animations, untitled state

### DIFF
--- a/xcode/Subconscious/Shared/Components/Detail/Detail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/Detail.swift
@@ -1490,6 +1490,7 @@ struct DetailModel: ModelProtocol {
                 ],
                 environment: environment
             )
+            .animation(.default)
         }
         
         let entry = state.snapshotEntry()

--- a/xcode/Subconscious/Shared/Components/OmniboxView.swift
+++ b/xcode/Subconscious/Shared/Components/OmniboxView.swift
@@ -8,27 +8,32 @@
 import SwiftUI
 
 struct OmniboxView: View {
-    var icon: Image
-    var title: String
+    var address: MemoAddress?
+    var defaultAudience: Audience
 
     var body: some View {
         HStack(spacing: 8) {
-            icon
+            Image(audience: address?.toAudience() ?? defaultAudience)
                 .resizable()
                 .frame(width: 17, height: 17)
-                .foregroundColor(.accentColor)
-            HStack(spacing: 0) {
-                Spacer()
-                Text(verbatim: title)
-                    .font(.callout)
-                    .foregroundColor(.accentColor)
-                Spacer()
+            Spacer(minLength: AppTheme.unit)
+            if let slashlink = address?.toSlashlink() {
+                OmniboxSlashlinkView(
+                    petname: slashlink.petnamePart,
+                    slug: slashlink.slugPart
+                )
+            } else {
+                Text("Untitled")
+                    .foregroundColor(Color.secondary)
             }
+            Spacer(minLength: AppTheme.unit)
         }
+        .transition(.opacity)
+        .foregroundColor(.accentColor)
+        .font(.callout)
         .padding(.leading, 8)
         .padding(.trailing, 12)
         .frame(height: 34)
-        .clipShape(Capsule())
         .overlay(
             RoundedRectangle(cornerRadius: AppTheme.cornerRadius)
                 .stroke(Color.separator, lineWidth: 0.5)
@@ -37,30 +42,80 @@ struct OmniboxView: View {
     }
 }
 
-extension OmniboxView {
-    init(
-        address: MemoAddress?,
-        defaultAudience: Audience
-    ) {
-        let audience = address?.toAudience() ?? defaultAudience
-        let title = address?.slug.description ?? ""
-        self.init(
-            icon: Image(audience: audience),
-            title: title
-        )
+/// Helper view that knows how to format slashlinks with or without petname.
+struct OmniboxSlashlinkView: View {
+    var petname: String?
+    var slug: String
+    
+    var body: some View {
+        HStack(spacing: 0) {
+            if let petname = petname {
+                Text(verbatim: "@\(petname)").fontWeight(.medium)
+                Text(verbatim: "/\(slug)")
+            } else {
+                Text(verbatim: slug)
+            }
+        }
+        .lineLimit(1)
     }
 }
 
 struct OmniboxView_Previews: PreviewProvider {
+    struct TappableOmniboxTestView: View {
+        var addresses: [MemoAddress] = [
+            MemoAddress.public(Slashlink("@ksr/red-mars")!),
+            MemoAddress.public(Slashlink("@ksr/green-mars")!),
+            MemoAddress.public(Slashlink("@ksr/blue-mars")!),
+            MemoAddress.local(Slug("mars")!),
+            MemoAddress.local(Slug("a-very-long-note-title-that-goes-on-and-on")!),
+            MemoAddress.public(Slashlink("@ksr/a-very-long-note-title-that-goes-on-and-on")!)
+        ]
+        
+        @State private var address: MemoAddress? = nil
+        var defaultAudience = Audience.local
+
+        var body: some View {
+            OmniboxView(address: address, defaultAudience: defaultAudience)
+                .onTapGesture {
+                    withAnimation {
+                        self.address = addresses.randomElement()
+                    }
+                }
+        }
+    }
+
     static var previews: some View {
         VStack {
+            VStack {
+                Text("Tap me")
+                TappableOmniboxTestView()
+            }
+            Divider()
             OmniboxView(
-                icon: Image(systemName: "network"),
-                title: "Permissionless creation is where value comes from"
+                address: .public(Slashlink("@here/red-mars")!),
+                defaultAudience: .local
             )
             OmniboxView(
-                icon: Image(systemName: "network"),
-                title: "X"
+                address: .public(Slashlink("@here/red-mars-very-long-slug")!),
+                defaultAudience: .local
+            )
+            OmniboxView(
+                address: .public(Slashlink("/red-mars")!),
+                defaultAudience: .local
+            )
+            OmniboxView(
+                address: .local(Slug("red-mars")!),
+                defaultAudience: .local
+            )
+            OmniboxView(
+                address: .local(Slug("red-mars")!),
+                defaultAudience: .local
+            )
+            OmniboxView(
+                defaultAudience: .local
+            )
+            OmniboxView(
+                defaultAudience: .public
             )
             OmniboxView(
                 address: .local(Slug("red-mars")!),


### PR DESCRIPTION
Fixes #437. 

This PR introduces improvements to Omnibox:

- Displays specially formatted `@handles/slashlinks` when petname present
- Animates changes to location with fade animation
- Introduces an untitled state for empty notes