### PR TITLE
Replace FAB Orb Shader with Gradient

### DIFF
--- a/xcode/Subconscious/Shared/AppTheme.swift
+++ b/xcode/Subconscious/Shared/AppTheme.swift
@@ -95,19 +95,19 @@ extension Color {
     
     // MARK: Brand colours
     // Brand Mark
-    static let brandMarkPink = Color(uiColor: UIColor(red: 255/255, green: 163/255, blue: 186/255, alpha: 1)) // #FFA3BA
-    static let brandMarkViolet = Color(uiColor: UIColor(red: 197/255, green: 112/255, blue: 219/255, alpha: 1)) // #C570DB
-    static let brandMarkCyan = Color(uiColor: UIColor(red: 48/255, green: 255/255, blue: 233/255, alpha: 1)) // #30FFE9
-    static let brandMarkRed = Color(uiColor: UIColor(red: 255/255, green: 94/255, blue: 135/255, alpha: 1)) // #FF5E87
-    static let brandMarkPurple = Color(uiColor: UIColor(red: 132/255, green: 42/255, blue: 156/255, alpha: 1)) // #842A9C
+    static let brandMarkPink = Color(red: 255/255, green: 163/255, blue: 186/255, opacity: 1) // #FFA3BA
+    static let brandMarkViolet = Color(red: 197/255, green: 112/255, blue: 219/255, opacity: 1) // #C570DB
+    static let brandMarkCyan = Color(red: 48/255, green: 255/255, blue: 233/255, opacity: 1) // #30FFE9
+    static let brandMarkRed = Color(red: 255/255, green: 94/255, blue: 135/255, opacity: 1) // #FF5E87
+    static let brandMarkPurple = Color(red: 132/255, green: 42/255, blue: 156/255, opacity: 1) // #842A9C
     
     // BG
-    static let brandBgBlush = Color(uiColor: UIColor(red: 237/255, green: 207/255, blue: 234/255, alpha: 1)) // #EDCFEA
-    static let brandBgGrey = Color(uiColor: UIColor(red: 223/255, green: 219/255, blue: 235/255, alpha: 1)) // #DFDBEB
-    static let brandBgTan = Color(uiColor: UIColor(red: 235/255, green: 235/255, blue: 218/255, alpha: 1)) // #EBEBDA
-    static let brandBgPurple = Color(uiColor: UIColor(red: 71/255, green: 30/255, blue: 68/255, alpha: 1)) // #471E44
-    static let brandBgBlack = Color(uiColor: UIColor(red: 35/255, green: 31/255, blue: 32/255, alpha: 1)) // #231F20
-    static let brandBgSlate = Color(uiColor: UIColor(red: 57/255, green: 50/255, blue: 84/255, alpha: 1)) // #393254
+    static let brandBgBlush = Color(red: 237/255, green: 207/255, blue: 234/255, opacity: 1) // #EDCFEA
+    static let brandBgGrey = Color(red: 223/255, green: 219/255, blue: 235/255, opacity: 1) // #DFDBEB
+    static let brandBgTan = Color(red: 235/255, green: 235/255, blue: 218/255, opacity: 1) // #EBEBDA
+    static let brandBgPurple = Color(red: 71/255, green: 30/255, blue: 68/255, opacity: 1) // #471E44
+    static let brandBgBlack = Color(red: 35/255, green: 31/255, blue: 32/255, opacity: 1) // #231F20
+    static let brandBgSlate = Color(red: 57/255, green: 50/255, blue: 84/255, opacity: 1) // #393254
     
     // Eyeballed to match brandmark
     static let brandLightMarkGradient = [

--- a/xcode/Subconscious/Shared/AppTheme.swift
+++ b/xcode/Subconscious/Shared/AppTheme.swift
@@ -92,4 +92,32 @@ extension Color {
     static let fabTextPressed = fabText.opacity(0.5)
     static let fabTextDisabled = fabText.opacity(0.3)
     static let scrim = SwiftUI.Color(UIColor.tertiarySystemFill)
+    
+    // Mark
+    static let brandMarkPink = Color(uiColor: UIColor(red: 255/255, green: 163/255, blue: 186/255, alpha: 1)) // #FFA3BA
+    static let brandMarkViolet = Color(uiColor: UIColor(red: 197/255, green: 112/255, blue: 219/255, alpha: 1)) // #C570DB
+    static let brandMarkCyan = Color(uiColor: UIColor(red: 48/255, green: 255/255, blue: 233/255, alpha: 1)) // #30FFE9
+    static let brandMarkRed = Color(uiColor: UIColor(red: 255/255, green: 94/255, blue: 135/255, alpha: 1)) // #FF5E87
+    static let brandMarkPurple = Color(uiColor: UIColor(red: 132/255, green: 42/255, blue: 156/255, alpha: 1)) // #842A9C
+    
+    // BG
+    static let brandBgBlush = Color(uiColor: UIColor(red: 237/255, green: 207/255, blue: 234/255, alpha: 1)) // #EDCFEA
+    static let brandBgGrey = Color(uiColor: UIColor(red: 223/255, green: 219/255, blue: 235/255, alpha: 1)) // #DFDBEB
+    static let brandBgTan = Color(uiColor: UIColor(red: 235/255, green: 235/255, blue: 218/255, alpha: 1)) // #EBEBDA
+    static let brandBgPurple = Color(uiColor: UIColor(red: 71/255, green: 30/255, blue: 68/255, alpha: 1)) // #471E44
+    static let brandBgBlack = Color(uiColor: UIColor(red: 35/255, green: 31/255, blue: 32/255, alpha: 1)) // #231F20
+    static let brandBgSlate = Color(uiColor: UIColor(red: 57/255, green: 50/255, blue: 84/255, alpha: 1)) // #393254
+    
+    static let brandLightMarkGradient = [
+        Gradient.Stop(color: Color.brandMarkPink, location: 0),
+        Gradient.Stop(color: Color.brandMarkViolet, location: 0.50),
+        Gradient.Stop(color: Color.brandMarkViolet, location: 0.60),
+        Gradient.Stop(color: Color.brandMarkCyan, location: 0.95)
+    ]
+    static let brandDarkMarkGradient = [
+        Gradient.Stop(color: Color.brandMarkRed, location: 0),
+        Gradient.Stop(color: Color.brandMarkPurple, location: 0.50),
+        Gradient.Stop(color: Color.brandMarkPurple, location: 0.60),
+        Gradient.Stop(color: Color.brandMarkCyan, location: 0.95)
+    ]
 }

--- a/xcode/Subconscious/Shared/AppTheme.swift
+++ b/xcode/Subconscious/Shared/AppTheme.swift
@@ -93,7 +93,8 @@ extension Color {
     static let fabTextDisabled = fabText.opacity(0.3)
     static let scrim = SwiftUI.Color(UIColor.tertiarySystemFill)
     
-    // Mark
+    // MARK: Brand colours
+    // Brand Mark
     static let brandMarkPink = Color(uiColor: UIColor(red: 255/255, green: 163/255, blue: 186/255, alpha: 1)) // #FFA3BA
     static let brandMarkViolet = Color(uiColor: UIColor(red: 197/255, green: 112/255, blue: 219/255, alpha: 1)) // #C570DB
     static let brandMarkCyan = Color(uiColor: UIColor(red: 48/255, green: 255/255, blue: 233/255, alpha: 1)) // #30FFE9
@@ -108,16 +109,35 @@ extension Color {
     static let brandBgBlack = Color(uiColor: UIColor(red: 35/255, green: 31/255, blue: 32/255, alpha: 1)) // #231F20
     static let brandBgSlate = Color(uiColor: UIColor(red: 57/255, green: 50/255, blue: 84/255, alpha: 1)) // #393254
     
+    // Eyeballed to match brandmark
     static let brandLightMarkGradient = [
         Gradient.Stop(color: Color.brandMarkPink, location: 0),
         Gradient.Stop(color: Color.brandMarkViolet, location: 0.50),
         Gradient.Stop(color: Color.brandMarkViolet, location: 0.60),
         Gradient.Stop(color: Color.brandMarkCyan, location: 0.95)
     ]
+    
+    // Eyeballed to match brandmark
     static let brandDarkMarkGradient = [
         Gradient.Stop(color: Color.brandMarkRed, location: 0),
         Gradient.Stop(color: Color.brandMarkPurple, location: 0.50),
         Gradient.Stop(color: Color.brandMarkPurple, location: 0.60),
         Gradient.Stop(color: Color.brandMarkCyan, location: 0.95)
     ]
+    
+    static func brandGradient(_ colorScheme: ColorScheme) -> [Gradient.Stop] {
+        colorScheme == .dark ? Color.brandDarkMarkGradient : Color.brandLightMarkGradient
+    }
+    
+    static func brandInnerShadow(_ colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? Color.brandMarkPurple : Color.brandMarkPink
+    }
+    
+    static func brandText(_ colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? Color.white : Color.brandBgSlate
+    }
+    
+    static func brandDropShadow(_ colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? Color.brandMarkPink : Color.brandMarkPurple
+    }
 }

--- a/xcode/Subconscious/Shared/Components/Common/FAB.swift
+++ b/xcode/Subconscious/Shared/Components/Common/FAB.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import SwiftSubsurface
 
 /// Wraps
 struct FABView: View {
@@ -21,9 +20,7 @@ struct FABView: View {
             }
         )
         .buttonStyle(
-            FABButtonStyle(
-                orbShaderEnabled: Config.default.orbShaderEnabled
-            )
+            FABButtonStyle()
         )
     }
 }
@@ -31,56 +28,38 @@ struct FABView: View {
 struct FABButtonStyle: ButtonStyle {
     @Environment(\.isEnabled) private var isEnabled
     @Environment(\.colorScheme) var colorScheme
-    var orbShaderEnabled: Bool
-    
 
     func makeBody(configuration: Configuration) -> some View {
         ZStack {
-            if orbShaderEnabled {
-                SubsurfaceView(speed: 0.05, density: 0.75, corner_radius: 64)
-                    .clipped()
-                    .clipShape(Circle())
-                    .frame(
-                        width: AppTheme.fabSize,
-                        height: AppTheme.fabSize,
-                        alignment: .center
+            Circle()
+                .foregroundStyle(
+                    .radialGradient(
+                        stops: Color.brandGradient(colorScheme),
+                        center: .init(x: 0.5, y: 0.25), // Calculated from brandmark
+                        startRadius: 0,
+                        endRadius: AppTheme.fabSize * 0.75 // Calculated from brandmark
                     )
                     .shadow(
-                        radius: 8,
-                        x: 0,
-                        y: 4
-                    )
-            } else {
-                Circle()
-                    .foregroundStyle(
-                        .radialGradient(
-                            stops: Color.brandGradient(colorScheme),
-                            center: .init(x: 0.5, y: 0.25), // Calculated from brandmark
-                            startRadius: 0,
-                            endRadius: AppTheme.fabSize * 0.75 // Calculated from brandmark
-                        )
-                        .shadow(
-                            // Eyeballed from brandmark
-                            .inner(
-                                color: Color.brandInnerShadow(colorScheme).opacity(0.5),
-                                radius: 5,
-                                x: 0,
-                                y: 0
-                            )
+                        // Eyeballed from brandmark
+                        .inner(
+                            color: Color.brandInnerShadow(colorScheme).opacity(0.5),
+                            radius: 5,
+                            x: 0,
+                            y: 0
                         )
                     )
-                    .frame(
-                        width: AppTheme.fabSize,
-                        height: AppTheme.fabSize,
-                        alignment: .center
-                    )
-                    .shadow(
-                        color: Color.brandDropShadow(colorScheme).opacity(0.5),
-                        radius: 8,
-                        x: 0,
-                        y: 4
-                    )
-            }
+                )
+                .frame(
+                    width: AppTheme.fabSize,
+                    height: AppTheme.fabSize,
+                    alignment: .center
+                )
+                .shadow(
+                    color: Color.brandDropShadow(colorScheme).opacity(0.5),
+                    radius: 8,
+                    x: 0,
+                    y: 4
+                )
             configuration.label
                 .foregroundColor(
                     isEnabled ? Color.brandText(colorScheme) : Color.fabTextDisabled

--- a/xcode/Subconscious/Shared/Components/Common/FAB.swift
+++ b/xcode/Subconscious/Shared/Components/Common/FAB.swift
@@ -33,21 +33,6 @@ struct FABButtonStyle: ButtonStyle {
     @Environment(\.colorScheme) var colorScheme
     var orbShaderEnabled: Bool
     
-    private func brandGradient() -> [Gradient.Stop] {
-        return colorScheme == .dark ? Color.brandDarkMarkGradient : Color.brandLightMarkGradient
-    }
-    
-    private func brandInnerShadow() -> Color {
-        return colorScheme == .dark ? Color.brandMarkPurple : Color.brandMarkPink
-    }
-    
-    private func brandText() -> Color {
-        return colorScheme == .dark ? Color.white : Color.brandBgSlate
-    }
-    
-    private func brandDropShadow() -> Color {
-        return colorScheme == .dark ? Color.brandMarkPink : Color.brandMarkPurple
-    }
 
     func makeBody(configuration: Configuration) -> some View {
         ZStack {
@@ -69,12 +54,20 @@ struct FABButtonStyle: ButtonStyle {
                 Circle()
                     .foregroundStyle(
                         .radialGradient(
-                            stops: brandGradient(),
-                            center: .init(x: 0.5, y: 0.25),
+                            stops: Color.brandGradient(colorScheme),
+                            center: .init(x: 0.5, y: 0.25), // Calculated from brandmark
                             startRadius: 0,
-                            endRadius: AppTheme.fabSize * 0.75
+                            endRadius: AppTheme.fabSize * 0.75 // Calculated from brandmark
                         )
-                        .shadow(.inner(color: brandInnerShadow().opacity(0.5), radius: 5, x: 0, y: 0))
+                        .shadow(
+                            // Eyeballed from brandmark
+                            .inner(
+                                color: Color.brandInnerShadow(colorScheme).opacity(0.5),
+                                radius: 5,
+                                x: 0,
+                                y: 0
+                            )
+                        )
                     )
                     .frame(
                         width: AppTheme.fabSize,
@@ -82,7 +75,7 @@ struct FABButtonStyle: ButtonStyle {
                         alignment: .center
                     )
                     .shadow(
-                        color: brandDropShadow().opacity(0.5),
+                        color: Color.brandDropShadow(colorScheme).opacity(0.5),
                         radius: 8,
                         x: 0,
                         y: 4
@@ -90,7 +83,7 @@ struct FABButtonStyle: ButtonStyle {
             }
             configuration.label
                 .foregroundColor(
-                    isEnabled ? brandText() : Color.fabTextDisabled
+                    isEnabled ? Color.brandText(colorScheme) : Color.fabTextDisabled
                 )
                 .contentShape(
                     Circle()

--- a/xcode/Subconscious/Shared/Components/Common/FAB.swift
+++ b/xcode/Subconscious/Shared/Components/Common/FAB.swift
@@ -30,7 +30,24 @@ struct FABView: View {
 
 struct FABButtonStyle: ButtonStyle {
     @Environment(\.isEnabled) private var isEnabled
+    @Environment(\.colorScheme) var colorScheme
     var orbShaderEnabled: Bool
+    
+    private func brandGradient() -> [Gradient.Stop] {
+        return colorScheme == .dark ? Color.brandDarkMarkGradient : Color.brandLightMarkGradient
+    }
+    
+    private func brandInnerShadow() -> Color {
+        return colorScheme == .dark ? Color.brandMarkPurple : Color.brandMarkPink
+    }
+    
+    private func brandText() -> Color {
+        return colorScheme == .dark ? Color.white : Color.brandBgSlate
+    }
+    
+    private func brandDropShadow() -> Color {
+        return colorScheme == .dark ? Color.brandMarkPink : Color.brandMarkPurple
+    }
 
     func makeBody(configuration: Configuration) -> some View {
         ZStack {
@@ -50,13 +67,22 @@ struct FABButtonStyle: ButtonStyle {
                     )
             } else {
                 Circle()
-                    .foregroundColor(Color.fabBackground)
+                    .foregroundStyle(
+                        .radialGradient(
+                            stops: brandGradient(),
+                            center: .init(x: 0.5, y: 0.25),
+                            startRadius: 0,
+                            endRadius: AppTheme.fabSize * 0.75
+                        )
+                        .shadow(.inner(color: brandInnerShadow().opacity(0.5), radius: 5, x: 0, y: 0))
+                    )
                     .frame(
                         width: AppTheme.fabSize,
                         height: AppTheme.fabSize,
                         alignment: .center
                     )
                     .shadow(
+                        color: brandDropShadow().opacity(0.5),
                         radius: 8,
                         x: 0,
                         y: 4
@@ -64,7 +90,7 @@ struct FABButtonStyle: ButtonStyle {
             }
             configuration.label
                 .foregroundColor(
-                    isEnabled ? Color.fabText : Color.fabTextDisabled
+                    isEnabled ? brandText() : Color.fabTextDisabled
                 )
                 .contentShape(
                     Circle()

--- a/xcode/Subconscious/Shared/Components/Common/FAB.swift
+++ b/xcode/Subconscious/Shared/Components/Common/FAB.swift
@@ -87,3 +87,9 @@ struct FABButtonStyle: ButtonStyle {
         )
     }
 }
+
+struct FAB_Previews: PreviewProvider {
+    static var previews: some View {
+        FABView() { }
+    }
+}

--- a/xcode/Subconscious/Shared/Config.swift
+++ b/xcode/Subconscious/Shared/Config.swift
@@ -21,7 +21,7 @@ struct Config: Equatable, Codable {
     var pollingInterval: Double = 15
 
     /// Subsurface "orb" shader on main FAB
-    var orbShaderEnabled = true
+    var orbShaderEnabled = false
 
     var untitled = "Untitled"
 

--- a/xcode/Subconscious/Shared/Config.swift
+++ b/xcode/Subconscious/Shared/Config.swift
@@ -20,9 +20,6 @@ struct Config: Equatable, Codable {
     /// Standard interval at which to run long-polling services
     var pollingInterval: Double = 15
 
-    /// Subsurface "orb" shader on main FAB
-    var orbShaderEnabled = false
-
     var untitled = "Untitled"
 
     /// Toggle random suggestion feature


### PR DESCRIPTION
Fixes #376 (by removing the shader). Confirmed that this works on iOS 16.3.1 on-device.

This PR replaces the old FAB button style with one based on the Subconscious brand mark. All colours and styles were referenced directly from our brand [styleguide](https://drive.google.com/drive/u/4/folders/1kZJ5svfLPBWSXVY9YWbexdclIYJi-QS9) including colour names etc.

## Dark Preview
<img width="130" alt="image" src="https://user-images.githubusercontent.com/5009316/224201544-b0426ba0-4bde-4663-89ec-c91b64c1a9cc.png">

## Light Preview
<img width="122" alt="image" src="https://user-images.githubusercontent.com/5009316/224201565-5604d113-5a3b-43c9-b40b-a457db415a00.png">

