### PR TITLE
Integrate Address Book API

### DIFF
--- a/xcode/Subconscious/Shared/AppTheme.swift
+++ b/xcode/Subconscious/Shared/AppTheme.swift
@@ -34,6 +34,9 @@ extension AppTheme {
     static let minTouchSize: CGFloat = 44
     static let cornerRadius: Double = 8
     static let cornerRadiusLg: Double = 16
+    
+    static let brandMarkLight = Image("sub_logo_light")
+    static let brandMarkDark = Image("sub_logo_dark")
 }
 
 //  MARK: UIFonts

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
@@ -70,7 +70,7 @@ struct DidFieldCursor: CursorProtocol {
 enum AddressBookAction {
     case present(_ isPresented: Bool)
     
-    case refetch
+    case refreshEntries(forceRefetchFromNoosphere: Bool = false)
     case populate([AddressBookEntry])
     
     case requestFollow
@@ -130,11 +130,15 @@ struct AddressBookModel: ModelProtocol {
                 }
             }
             
-            return update(state: model, action: .refetch, environment: environment)
+            return update(
+                state: model,
+                action: .refreshEntries(forceRefetchFromNoosphere: false),
+                environment: environment
+            )
             
-        case .refetch:
+        case .refreshEntries(let forceRefreshFromNoosphere):
             let fx: Fx<AddressBookAction> =
-                environment.data.addressBook.listEntries(refetch: true)
+                environment.data.addressBook.listEntries(refetch: forceRefreshFromNoosphere)
                 .map({ follows in
                     AddressBookAction.populate(follows)
                 })
@@ -218,7 +222,11 @@ struct AddressBookModel: ModelProtocol {
             model.isFollowUserFormPresented = false
             model.follows.append(entry)
             
-            return update(state: model, action: .refetch, environment: environment)
+            return update(
+                state: model,
+                action: .refreshEntries(forceRefetchFromNoosphere: true),
+                environment: environment
+            )
             
         case .failFollow(error: let error):
             var model = state
@@ -265,7 +273,11 @@ struct AddressBookModel: ModelProtocol {
             model.follows.removeAll { f in
                 f.petname == petname
             }
-            return update(state: model, action: .refetch, environment: environment)
+            return update(
+                state: model,
+                action: .refreshEntries(forceRefetchFromNoosphere: true),
+                environment: environment
+            )
             
         case .failUnfollow(error: let error):
             var model = state

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
@@ -200,6 +200,14 @@ struct AddressBookModel: ModelProtocol {
                 return Update(state: state)
             }
             
+            guard !state.follows.contains(where: { f in f.did == did }) else {
+                return update(
+                    state: state,
+                    action: .failFollow(error: "Already following user"),
+                    environment: environment
+                )
+            }
+            
             let fx: Fx<AddressBookAction> =
                 environment.data.addressBook
                 .followUserAsync(did: did, petname: petname)

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
@@ -44,18 +44,6 @@ struct AddressBookView: View {
                         }
                     }
                 }
-                // Basic error visibility
-                if let msg = state.failUnfollowErrorMessage {
-                    HStack {
-                        Image(systemName: "exclamationmark.circle")
-                            .frame(width: 24, height: 22)
-                            .padding(.horizontal, 8)
-                            .foregroundColor(.red)
-                            .background(Color.clear)
-                        Text(msg)
-                            .foregroundColor(.red)
-                    }
-                }
                 
                 if let did = state.did {
                     Section(header: Text("My DID")) {
@@ -91,6 +79,28 @@ struct AddressBookView: View {
                 )
             ) {
                 FollowUserView(state: state, send: send)
+            }
+            .alert(
+                state.failUnfollowErrorMessage ?? "",
+                isPresented: Binding(
+                    get: { state.failUnfollowErrorMessage != nil },
+                    set: { _ in send(.dismissFailUnfollowError) }
+                )
+            ) {}
+            .confirmationDialog(
+                "Are you sure?",
+                isPresented:
+                    Binding(
+                        get: { state.unfollowCandidate != nil },
+                        set: { _ in send(.cancelUnfollow) }
+                    )
+            ) {
+                Button(
+                    "Unfollow \(state.unfollowCandidate?.verbatim ?? "user")?",
+                    role: .destructive
+                ) {
+                    send(.confirmUnfollow)
+                }
             }
         }
     }

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
@@ -81,12 +81,16 @@ struct AddressBookView: View {
                 FollowUserView(state: state, send: send)
             }
             .alert(
-                state.failUnfollowErrorMessage ?? "",
                 isPresented: Binding(
                     get: { state.failUnfollowErrorMessage != nil },
                     set: { _ in send(.dismissFailUnfollowError) }
                 )
-            ) {}
+            ) {
+                Alert(
+                    title: Text("Failed to Unfollow User"),
+                    message: Text(state.failUnfollowErrorMessage ?? "An unknown error occurred")
+                )
+            }
             .confirmationDialog(
                 "Are you sure?",
                 isPresented:
@@ -101,6 +105,8 @@ struct AddressBookView: View {
                 ) {
                     send(.confirmUnfollow)
                 }
+            } message: {
+                Text("You cannot undo this action")
             }
         }
     }

--- a/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
@@ -64,19 +64,6 @@ struct FollowUserView: View {
                             .disableAutocorrection(true)
                         }
                     }
-                    
-                    // Basic error visibility
-                    if let msg = state.failFollowErrorMessage {
-                        HStack {
-                            Image(systemName: "exclamationmark.circle")
-                                .frame(width: 24, height: 22)
-                                .padding(.horizontal, 8)
-                                .foregroundColor(.red)
-                                .background(Color.clear)
-                            Text(msg)
-                                .foregroundColor(.red)
-                        }
-                    }
                 }
             }
             .navigationTitle("Follow User")
@@ -93,6 +80,13 @@ struct FollowUserView: View {
                 }
             }
             .navigationBarTitleDisplayMode(.inline)
+            .alert(
+                state.failFollowErrorMessage ?? "",
+                isPresented: Binding(
+                    get: { state.failFollowErrorMessage != nil },
+                    set: { _ in send(.dismissFailFollowError) }
+                )
+            ) { }
         }
     }
 }

--- a/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/FollowUserView.swift
@@ -81,12 +81,16 @@ struct FollowUserView: View {
             }
             .navigationBarTitleDisplayMode(.inline)
             .alert(
-                state.failFollowErrorMessage ?? "",
                 isPresented: Binding(
                     get: { state.failFollowErrorMessage != nil },
                     set: { _ in send(.dismissFailFollowError) }
                 )
-            ) { }
+            ) {
+                Alert(
+                    title: Text("Failed to Follow User"),
+                    message: Text(state.failFollowErrorMessage ?? "An unknown error ocurred")
+                )
+            }
         }
     }
 }

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -962,7 +962,7 @@ struct AppEnvironment {
             migrations: Config.migrations
         )
         
-        let addresBook = AddressBookService(noosphere: noosphere)
+        let addresBook = AddressBookService(noosphere: noosphere, database: databaseService)
         
         self.data = DataService(
             noosphere: noosphere,

--- a/xcode/Subconscious/Shared/Services/AddressBookService.swift
+++ b/xcode/Subconscious/Shared/Services/AddressBookService.swift
@@ -38,7 +38,7 @@ class AddressBookService {
                         .map { did -> AddressBookEntry? in
                             guard let did = did else { return nil }
                             // TODO: hardcoded pfp
-                            return AddressBookEntry(pfp: Image("pfp-dog"), petname: f, did: did)
+                            return AddressBookEntry(pfp: AppTheme.brandMarkDark, petname: f, did: did)
                         }
                         .compactMap { value in value }
                 })

--- a/xcode/Subconscious/Shared/Services/AddressBookService.swift
+++ b/xcode/Subconscious/Shared/Services/AddressBookService.swift
@@ -64,7 +64,7 @@ class AddressBookService {
     
     /// Associates the passed DID with the passed petname within the sphere, saves the changes and updates the database.
     func followUserAsync(did: Did, petname: Petname) -> AnyPublisher<Void, Error> {
-        CombineUtilities.async(qos: .utility) {
+        CombineUtilities.async(qos: .default) {
             return try self.followUser(did: did, petname: petname)
         }
     }
@@ -77,7 +77,7 @@ class AddressBookService {
     
     /// Unassociates the passed DID with the passed petname within the sphere, saves the changes and updates the database.
     func unfollowUserAsync(petname: Petname) -> AnyPublisher<Void, Error> {
-        CombineUtilities.async(qos: .utility) {
+        CombineUtilities.async(qos: .default) {
             return try self.unfollowUser(petname: petname)
         }
     }

--- a/xcode/Subconscious/Shared/Services/Noosphere/Noosphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Noosphere.swift
@@ -189,4 +189,14 @@ public final class Noosphere {
     ) throws -> Z {
         try Self.callWithError { error in perform(a, b, c, error) }
     }
+    
+    static func callWithError<A, B, C, D, Z>(
+        _ perform: (A, B, C, D, UnsafeMutablePointer<OpaquePointer?>) -> Z,
+        _ a: A,
+        _ b: B,
+        _ c: C,
+        _ d: D
+    ) throws -> Z {
+        try Self.callWithError { error in perform(a, b, c, d, error) }
+    }
 }

--- a/xcode/Subconscious/Shared/Services/Noosphere/SphereFS.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/SphereFS.swift
@@ -331,7 +331,7 @@ public final class SphereFS: SphereProtocol {
             ns_string_array_free(petnames)
         }
         
-        return petnames.toSwift()
+        return petnames.toStringArray()
     }
     
     public func getPetnameChanges(sinceCid: String) throws -> [String] {
@@ -345,7 +345,7 @@ public final class SphereFS: SphereProtocol {
             ns_string_array_free(changes)
         }
         
-        return changes.toSwift()
+        return changes.toStringArray()
     }
     
     /// Save outstanding writes and return new Sphere version
@@ -380,7 +380,7 @@ public final class SphereFS: SphereProtocol {
             ns_string_array_free(slugs)
         }
         
-        return slugs.toSwift()
+        return slugs.toStringArray()
     }
     
     /// Sync sphere with gateway.
@@ -414,7 +414,7 @@ public final class SphereFS: SphereProtocol {
             ns_string_array_free(changes)
         }
         
-        return changes.toSwift()
+        return changes.toStringArray()
     }
     
     deinit {
@@ -448,12 +448,12 @@ public final class SphereFS: SphereProtocol {
             ns_string_array_free(file_header_names)
         }
 
-        return file_header_names.toSwift()
+        return file_header_names.toStringArray()
     }
 }
 
 extension slice_boxed_char_ptr_t {
-    func toSwift() -> [String] {
+    func toStringArray() -> [String] {
         let count = self.len
         guard var pointer = self.ptr else {
             return []

--- a/xcode/Subconscious/Shared/Services/Noosphere/SphereFS.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/SphereFS.swift
@@ -265,70 +265,102 @@ public final class SphereFS: SphereProtocol {
     }
     
     public func getPetname(petname: String) throws -> String {
-        throw NoosphereError.foreignError("Not Implemented: getPetname")
+        let name = try Noosphere.callWithError(
+            ns_sphere_petname_get,
+            noosphere.noosphere,
+            fs,
+            petname
+        )
         
-//        return try Noosphere.callWithError(
-//            ns_sphere_petname_get,
-//            noosphere.noosphere,
-//            sphere,
-//            petname
-//        )
+        guard let name = name else {
+            throw NoosphereError.nullPointer
+        }
+        defer {
+            ns_string_free(name)
+        }
+        
+        return String(cString: name)
     }
     
     public func setPetname(did: String, petname: String) throws {
-        throw NoosphereError.foreignError("Not Implemented: setPetname")
-        
-//        return try Noosphere.callWithError(
-//            ns_sphere_petname_set,
-//            noosphere.noosphere,
-//            sphere,
-//            petname,
-//            did
-//        )
+        try Noosphere.callWithError(
+            ns_sphere_petname_set,
+            noosphere.noosphere,
+            fs,
+            petname,
+            did
+        )
     }
     
     public func unsetPetname(petname: String) throws {
-        throw NoosphereError.foreignError("Not Implemented: unsetPetname")
-        
-//        return try Noosphere.callWithError(
-//            ns_sphere_petname_set,
-//            noosphere.noosphere,
-//            sphere,
-//            petname,
-//            nil
-//        )
+        try Noosphere.callWithError(
+            ns_sphere_petname_set,
+            noosphere.noosphere,
+            fs,
+            petname,
+            nil
+        )
     }
     
     public func resolvePetname(petname: String) throws -> String {
-        throw NoosphereError.foreignError("Not Implemented: resolvePetname")
+        let did = try Noosphere.callWithError(
+            ns_sphere_petname_resolve,
+            noosphere.noosphere,
+            fs,
+            petname
+        )
         
-//        return try Noosphere.callWithError(
-//            ns_sphere_petname_resolve,
-//            noosphere.noosphere,
-//            sphere,
-//            petname
-//        )
+        guard let did = did else {
+            throw NoosphereError.nullPointer
+        }
+        defer {
+            ns_string_free(did)
+        }
+        
+        return String(cString: did)
+    }
+    
+    private static func makeStringArray(cArray: slice_boxed_char_ptr_t) -> [String] {
+        let name_count = cArray.len
+        guard var pointer = cArray.ptr else {
+            return []
+        }
+
+        var result: [String] = []
+        for _ in 0..<name_count {
+            let item = String(cString: pointer.pointee!)
+            result.append(item)
+            pointer += 1;
+        }
+        return result
     }
     
     public func listPetnames() throws -> [String] {
-        throw NoosphereError.foreignError("Not Implemented: listPetnames")
+        let petnames = try Noosphere.callWithError(
+            ns_sphere_petname_list,
+            noosphere.noosphere,
+            fs
+        )
         
-//        return try Noosphere.callWithError(
-//            ns_sphere_petname_list,
-//            noosphere.noosphere,
-//            sphere
-//        )
+        defer {
+            ns_string_array_free(petnames)
+        }
+        
+        return petnames.toSwift()
     }
     
     public func getPetnameChanges(sinceCid: String) throws -> [String] {
-        throw NoosphereError.foreignError("Not Implemented: getPetnameChanges")
+        let changes = try Noosphere.callWithError(
+            ns_sphere_petname_changes,
+            noosphere.noosphere,
+            fs,
+            sinceCid
+        )
+        defer {
+            ns_string_array_free(changes)
+        }
         
-//        return try Noosphere.callWithError(
-//            ns_sphere_petname_list,
-//            noosphere.noosphere,
-//            sphere,
-//            sinceCid
-//        )
+        return changes.toSwift()
     }
     
     /// Save outstanding writes and return new Sphere version
@@ -363,16 +395,7 @@ public final class SphereFS: SphereProtocol {
             ns_string_array_free(slugs)
         }
         
-        let slugCount = slugs.len
-        var pointer = slugs.ptr!
-        
-        var output: [String] = []
-        for _ in 0..<slugCount {
-            let slug = String.init(cString: pointer.pointee!)
-            output.append(slug)
-            pointer += 1;
-        }
-        return output
+        return slugs.toSwift()
     }
     
     /// Sync sphere with gateway.
@@ -406,16 +429,7 @@ public final class SphereFS: SphereProtocol {
             ns_string_array_free(changes)
         }
         
-        let changesCount = changes.len
-        var pointer = changes.ptr!
-        
-        var slugs: [String] = []
-        for _ in 0..<changesCount {
-            let slug = String.init(cString: pointer.pointee!)
-            slugs.append(slug)
-            pointer += 1;
-        }
-        return slugs
+        return changes.toSwift()
     }
     
     deinit {
@@ -449,17 +463,23 @@ public final class SphereFS: SphereProtocol {
             ns_string_array_free(file_header_names)
         }
 
-        let name_count = file_header_names.len
-        guard var pointer = file_header_names.ptr else {
+        return file_header_names.toSwift()
+    }
+}
+
+extension slice_boxed_char_ptr_t {
+    func toSwift() -> [String] {
+        let count = self.len
+        guard var pointer = self.ptr else {
             return []
         }
 
-        var names: [String] = []
-        for _ in 0..<name_count {
-            let name = String(cString: pointer.pointee!)
-            names.append(name)
+        var result: [String] = []
+        for _ in 0..<count {
+            let item = String(cString: pointer.pointee!)
+            result.append(item)
             pointer += 1;
         }
-        return names
+        return result
     }
 }

--- a/xcode/Subconscious/Shared/Services/Noosphere/SphereFS.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/SphereFS.swift
@@ -320,21 +320,6 @@ public final class SphereFS: SphereProtocol {
         return String(cString: did)
     }
     
-    private static func makeStringArray(cArray: slice_boxed_char_ptr_t) -> [String] {
-        let name_count = cArray.len
-        guard var pointer = cArray.ptr else {
-            return []
-        }
-
-        var result: [String] = []
-        for _ in 0..<name_count {
-            let item = String(cString: pointer.pointee!)
-            result.append(item)
-            pointer += 1;
-        }
-        return result
-    }
-    
     public func listPetnames() throws -> [String] {
         let petnames = try Noosphere.callWithError(
             ns_sphere_petname_list,

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/subconsciousnetwork/noosphere",
       "state" : {
         "branch" : "main",
-        "revision" : "791bc3996cfac12cb077c3721f22d080a71d33ba"
+        "revision" : "44f71e57918e0e8ca8d806db0aff82ff5ed0a5ba"
       }
     },
     {

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/subconsciousnetwork/noosphere",
       "state" : {
         "branch" : "main",
-        "revision" : "44f71e57918e0e8ca8d806db0aff82ff5ed0a5ba"
+        "revision" : "4cd2e3af8b10cdaae710d87e4b919b5180d10fec"
       }
     },
     {

--- a/xcode/Subconscious/SubconsciousTests/Tests_DataService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DataService.swift
@@ -61,7 +61,10 @@ final class Tests_DataService: XCTestCase {
         )
         
         let local = HeaderSubtextMemoStore(store: files)
-        let addressBook = AddressBookService(noosphere: noosphere)
+        let addressBook = AddressBookService(
+            noosphere: noosphere,
+            database: database
+        )
         
         return DataService(
             noosphere: noosphere,
@@ -223,7 +226,10 @@ final class Tests_DataService: XCTestCase {
                 gatewayURL: URL(string: "http://unavailable-gateway.fakewebsite"),
                 sphereIdentity: sphereIdentity
             )
-            let addressBook = AddressBookService(noosphere: noosphere)
+            let addressBook = AddressBookService(
+                noosphere: noosphere,
+                database: database
+            )
 
             let data = DataService(
                 noosphere: noosphere,
@@ -261,7 +267,10 @@ final class Tests_DataService: XCTestCase {
             gatewayURL: URL(string: "http://unavailable-gateway.fakewebsite"),
             sphereIdentity: sphereIdentity
         )
-        let addressBook = AddressBookService(noosphere: noosphere)
+        let addressBook = AddressBookService(
+            noosphere: noosphere,
+            database: database
+        )
 
         let data = DataService(
             noosphere: noosphere,


### PR DESCRIPTION
This PR introduces support for reading and writing address book content from the local sphere. The `AddressBookService` is responsible for providing an abstraction over the underlying petname storage.

# Added
- Confirmation for unfollow
- Human readable errors
- Error alert popups
- Actual FFI calls
- Extracted C array -> Swift array utility

Resolves https://github.com/subconsciousnetwork/subconscious/issues/448

# Tasks
- [x] Confirmation dialog for unfollowing a user
- [x] Error popups
- [x] Implement smarter caching & refetch logic 
- [x] Improve error handling, human readable errors
    - https://www.avanderlee.com/swiftui/error-alert-presenting/