### PR TITLE
Expand transclude hit area to include empty space

### DIFF
--- a/xcode/Subconscious/Shared/Components/BacklinksView.swift
+++ b/xcode/Subconscious/Shared/Components/BacklinksView.swift
@@ -20,20 +20,13 @@ struct BacklinksView: View {
             }
             if backlinks.count > 0 {
                 ForEach(backlinks) { entry in
-                    Button(
+                    Transclude2View(
+                        address: entry.address,
+                        excerpt: entry.excerpt,
                         action: {
-                            onSelect(
-                                EntryLink(entry)
-                            )
-                        },
-                        label: {
-                            Transclude2View(
-                                address: entry.address,
-                                excerpt: entry.excerpt
-                            )
+                            onSelect(EntryLink(entry))
                         }
                     )
-                    .buttonStyle(.plain)
                 }
             } else {
                 TitleGroupView(

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryComboView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryComboView.swift
@@ -28,32 +28,22 @@ struct StoryComboView: View {
             Divider()
             VStack(alignment: .leading, spacing: AppTheme.unit4) {
                 Text(story.prompt)
-                
-                Button(
+
+                Transclude2View(
+                    address: story.entryA.address,
+                    excerpt: story.entryA.excerpt,
                     action: {
                         action(story.entryA.address, story.entryA.excerpt)
-                    },
-                    label: {
-                        Transclude2View(
-                            address: story.entryA.address,
-                            excerpt: story.entryA.excerpt
-                        )
                     }
                 )
-                .buttonStyle(.plain)
                 
-                Button(
+                Transclude2View(
+                    address: story.entryB.address,
+                    excerpt: story.entryB.excerpt,
                     action: {
                         action(story.entryB.address, story.entryB.excerpt)
-                    },
-                    label: {
-                        Transclude2View(
-                            address: story.entryB.address,
-                            excerpt: story.entryB.excerpt
-                        )
                     }
                 )
-                .buttonStyle(.plain)
             }
             .padding()
             Divider()

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/Transclude2View.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/Transclude2View.swift
@@ -13,22 +13,21 @@ import SwiftUI
 struct Transclude2View: View {
     var address: MemoAddress
     var excerpt: String
+    var action: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: AppTheme.unit) {
-            Text(excerpt)
-                .lineLimit(5)
-            SlashlinkBylineView(slashlink: address.toSlashlink())
-                .theme(petname: Color.secondary)
-        }
-        .padding(.vertical, AppTheme.unit3)
-        .padding(.horizontal, AppTheme.unit4)
-        .overlay(
-            RoundedRectangle(
-                cornerRadius: AppTheme.cornerRadiusLg
-            )
-            .stroke(Color.separator, lineWidth: 0.5)
+        Button(
+            action: action,
+            label: {
+                VStack(alignment: .leading, spacing: AppTheme.unit) {
+                    Text(excerpt)
+                        .lineLimit(5)
+                    SlashlinkBylineView(slashlink: address.toSlashlink())
+                        .theme(petname: Color.secondary)
+                }
+            }
         )
+        .buttonStyle(TranscludeButtonStyle())
     }
 }
 
@@ -37,15 +36,18 @@ struct Transclude2View_Previews: PreviewProvider {
         VStack {
             Transclude2View(
                 address: MemoAddress.public(Slashlink("/short")!),
-                excerpt: "Short."
+                excerpt: "Short.",
+                action: { }
             )
             Transclude2View(
                 address: MemoAddress.public(Slashlink("@gordon/loomings")!),
-                excerpt: "Call me Ishmael. Some years ago- never mind how long precisely- having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little and see the watery part of the world. It is a way I have of driving off the spleen and regulating the circulation."
+                excerpt: "Call me Ishmael. Some years ago- never mind how long precisely- having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little and see the watery part of the world. It is a way I have of driving off the spleen and regulating the circulation.",
+                action: { }
             )
             Transclude2View(
                 address: MemoAddress.public(Slashlink("/loomings")!),
-                excerpt: "Call me Ishmael. Some years ago- never mind how long precisely- having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little and see the watery part of the world. It is a way I have of driving off the spleen and regulating the circulation."
+                excerpt: "Call me Ishmael. Some years ago- never mind how long precisely- having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little and see the watery part of the world. It is a way I have of driving off the spleen and regulating the circulation.",
+                action: { }
             )
         }
     }

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeButtonStyle.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeButtonStyle.swift
@@ -1,0 +1,43 @@
+//
+//  TranscludeButtonStyle.swift
+//  Subconscious (iOS)
+//
+//  Created by Gordon Brander on 3/16/23.
+//
+
+import SwiftUI
+
+struct TranscludeButtonStyle: ButtonStyle {
+    private var roundedRect = RoundedRectangle(
+        cornerRadius: AppTheme.cornerRadiusLg
+    )
+    @Environment(\.isEnabled) private var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding(.vertical, AppTheme.unit3)
+            .padding(.horizontal, AppTheme.unit4)
+            .expandAlignedLeading()
+            .background(
+                configuration.isPressed ?
+                    Color.backgroundPressed : Color.clear
+            )
+            .contentShape(roundedRect)
+            .clipShape(roundedRect)
+            .overlay(roundedRect.stroke(Color.separator, lineWidth: 0.5))
+            .animation(.default, value: configuration.isPressed)
+    }
+}
+
+struct TranscludeButtonStyle_Previews: PreviewProvider {
+    static var previews: some View {
+        Button(
+            action: {},
+            label: {
+                Text("Test")
+            }
+        ).buttonStyle(
+            TranscludeButtonStyle()
+        )
+    }
+}

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -118,6 +118,8 @@
 		B85EC467296F0D0A00558761 /* ProfilePicMd.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85EC465296F0D0A00558761 /* ProfilePicMd.swift */; };
 		B85EC469296F11F000558761 /* BylineSmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85EC468296F11F000558761 /* BylineSmView.swift */; };
 		B85EC46A296F11F000558761 /* BylineSmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85EC468296F11F000558761 /* BylineSmView.swift */; };
+		B8616DF829C38775001C666A /* TranscludeButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8616DF729C38775001C666A /* TranscludeButtonStyle.swift */; };
+		B8616DF929C3877F001C666A /* TranscludeButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8616DF729C38775001C666A /* TranscludeButtonStyle.swift */; };
 		B866868127AC4EF100A03A55 /* NSRangeUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B866868027AC4EF100A03A55 /* NSRangeUtilities.swift */; };
 		B866868227AC4EF100A03A55 /* NSRangeUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B866868027AC4EF100A03A55 /* NSRangeUtilities.swift */; };
 		B866868A27AC8BED00A03A55 /* DetailKeyboardToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B866868927AC8BED00A03A55 /* DetailKeyboardToolbarView.swift */; };
@@ -432,6 +434,7 @@
 		B85EC462296F0CBD00558761 /* ProfilePicSm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePicSm.swift; sourceTree = "<group>"; };
 		B85EC465296F0D0A00558761 /* ProfilePicMd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePicMd.swift; sourceTree = "<group>"; };
 		B85EC468296F11F000558761 /* BylineSmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BylineSmView.swift; sourceTree = "<group>"; };
+		B8616DF729C38775001C666A /* TranscludeButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscludeButtonStyle.swift; sourceTree = "<group>"; };
 		B866868027AC4EF100A03A55 /* NSRangeUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSRangeUtilities.swift; sourceTree = "<group>"; };
 		B866868927AC8BED00A03A55 /* DetailKeyboardToolbarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailKeyboardToolbarView.swift; sourceTree = "<group>"; };
 		B8682DCA2804BF04001CD8DD /* Tests_Subtext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_Subtext.swift; sourceTree = "<group>"; };
@@ -636,6 +639,7 @@
 				B8D328B629A671DA00850A37 /* Transclude2View.swift */,
 				B8A59D5F28B51D000010DB2F /* TranscludeView.swift */,
 				B532F8C229B1752E00CE9256 /* TranscludeBlockLayoutFragment.swift */,
+				B8616DF729C38775001C666A /* TranscludeButtonStyle.swift */,
 			);
 			path = Transclude;
 			sourceTree = "<group>";
@@ -873,7 +877,6 @@
 				B58FE48B28DED9B600E000CC /* StoryCombo.swift */,
 				B8A59D6828B692900010DB2F /* StoryPrompt.swift */,
 				B8B54F3C271F7C6B00B9B507 /* Suggestion.swift */,
-				B8CBAFAF2996A7D50079107E /* UnqualifiedLink.swift */,
 				B59D556229BBFF56007915E2 /* FormField.swift */,
 			);
 			path = Models;
@@ -1433,7 +1436,7 @@
 				B8DEBF192798B6A8007CB528 /* NavigationToolbar.swift in Sources */,
 				B822F18D27C9C0AB00943C6B /* CountChip.swift in Sources */,
 				B87288DE299AB02400EF7E07 /* SphereFS.swift in Sources */,
-				B8879EAC26F944DA00A0B4FF /* Detail.swift in Sources */,
+				B8879EAC26F944DA00A0B4FF /* MemoEditorDetail.swift in Sources */,
 				B5F6ADC929C02F4A00690DE4 /* AddressBookService.swift in Sources */,
 				B8879EAC26F944DA00A0B4FF /* MemoEditorDetail.swift in Sources */,
 				B8925B2F29C23017001F9503 /* MemoViewerDetailView.swift in Sources */,
@@ -1457,6 +1460,7 @@
 				B82C3A5626F529EF00833CC8 /* CombineUtilities.swift in Sources */,
 				B8A59D6928B692900010DB2F /* StoryPrompt.swift in Sources */,
 				B84AD8E3281073CE006B3153 /* InlineFormattingBarView.swift in Sources */,
+				B8616DF829C38775001C666A /* TranscludeButtonStyle.swift in Sources */,
 				B8CE40E728D2707D00819064 /* QueryPromptGeist.swift in Sources */,
 				B8CBAFA72994499A0079107E /* AudienceIconView.swift in Sources */,
 				B8B3EE77297AEE8B00779B7F /* FirstRunDoneView.swift in Sources */,
@@ -1572,6 +1576,7 @@
 				B82C3A7726F6B5BF00833CC8 /* StringUtilities.swift in Sources */,
 				B8D7F04327A4AE590042C7CF /* SuggestionViewModifier.swift in Sources */,
 				B8B4251028FDE6960081B8D5 /* FileStore.swift in Sources */,
+				B8616DF929C3877F001C666A /* TranscludeButtonStyle.swift in Sources */,
 				B8EB2A2026F27797006E97C3 /* SubconsciousApp.swift in Sources */,
 				B81A535D27275138001A6268 /* Tape.swift in Sources */,
 				B85BF47027BB0FA800F55730 /* RowViewModifier.swift in Sources */,


### PR DESCRIPTION
Additionally, add background wash on tap.

Fixes #446.