### PR TITLE
Fix Subtext perf regression, add Subtext perf test and baseline

### DIFF
--- a/xcode/Subconscious/Shared/Parsers/Subtext.swift
+++ b/xcode/Subconscious/Shared/Parsers/Subtext.swift
@@ -188,17 +188,91 @@ struct Subtext: Hashable, Equatable, LosslessStringConvertible {
         }
     }
 
-    /// Check if character is space
-    /// Currently this matches only against a minimal set of space characters.
-    /// For convenience, character is an optional type, since peek
-    /// returns an optional type.
-    private static func isSpace(character: Character?) -> Bool {
-        switch character {
-        case " ", "\n":
-            return true
-        default:
-            return false
+    /// Consume a well-formed bracket link, or else backtrack
+    private static func consumeBracketLink(
+        tape: inout Tape
+    ) -> Substring? {
+        tape.save()
+        while !tape.isExhausted() {
+            if tape.consumeMatch(" ") {
+                tape.backtrack()
+                return nil
+            } else if tape.consumeMatch(">") {
+                return tape.cut()
+            } else {
+                tape.advance()
+            }
         }
+        tape.backtrack()
+        return nil
+    }
+
+    /// Consume a well-formed bracket link, or else backtrack
+    private static func consumeWikilink(
+        tape: inout Tape
+    ) -> Substring? {
+        tape.save()
+        while !tape.isExhausted() {
+            // Brackets are not allowed in wikilink bodies
+            if tape.consumeMatch("[") {
+                tape.backtrack()
+                return nil
+            } else if tape.consumeMatch("]]") {
+                return tape.cut()
+            } else {
+                tape.advance()
+            }
+        }
+        tape.backtrack()
+        return nil
+    }
+
+    /// Consume a well-formed italics run, or else backtrack
+    private static func consumeBold(
+        tape: inout Tape
+    ) -> Substring? {
+        tape.save()
+        while !tape.isExhausted() {
+            if tape.consumeMatch("*") {
+                return tape.cut()
+            } else {
+                tape.advance()
+            }
+        }
+        tape.backtrack()
+        return nil
+    }
+
+    /// Consume a well-formed italics run, or else backtrack
+    private static func consumeItalic(
+        tape: inout Tape
+    ) -> Substring? {
+        tape.save()
+        while !tape.isExhausted() {
+            if tape.consumeMatch("_") {
+                return tape.cut()
+            } else {
+                tape.advance()
+            }
+        }
+        tape.backtrack()
+        return nil
+    }
+
+    /// Consume a well-formed code run, or else backtrack
+    private static func consumeCode(
+        tape: inout Tape
+    ) -> Substring? {
+        tape.save()
+        while !tape.isExhausted() {
+            if tape.consumeMatch("`") {
+                return tape.cut()
+            } else {
+                tape.advance()
+            }
+        }
+        tape.backtrack()
+        return nil
     }
 
     /// Is character a valid URL character that is punctuation?
@@ -219,6 +293,53 @@ struct Subtext: Hashable, Equatable, LosslessStringConvertible {
         }
     }
 
+    /// Check if character is space
+    /// Currently this matches only against a minimal set of space characters.
+    /// For convenience, character is an optional type, since peek
+    /// returns an optional type.
+    private static func isSpace(character: Character?) -> Bool {
+        switch character {
+        case " ", "\n":
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Consume all non-space characters excluding trailing punctuation.
+    private static func consumeAddressBody(
+        tape: inout Tape
+    ) -> Substring {
+        while !tape.isExhausted() {
+            let c0 = tape.peek(offset: 0)
+            let c1 = tape.peek(offset: 1)
+            // If c0 is URL-valid punctuation, but is followed by a space
+            // character, we treat it as terminal punctuation and ignore it.
+            // Cut the tape and return.
+            if
+               isPossibleTrailingPunctuation(character: c0) &&
+               isSpace(character: c1)
+            {
+                return tape.cut()
+            }
+            // If current character is trailing punctionation and the
+            // one after that is end-of-tape, cut and return.
+            else if isPossibleTrailingPunctuation(character: c0) && c1 == nil {
+                return tape.cut()
+            }
+            // If c0 is a space we've reached the end of the address,
+            // cut and return.
+            else if isSpace(character: c0) {
+                return tape.cut()
+            }
+            //
+            else {
+                tape.advance()
+            }
+        }
+        return tape.cut()
+    }
+
     /// Parse all inline forms within the line
     /// - Returns: an array of inline forms
     private static func parseInline(
@@ -227,36 +348,46 @@ struct Subtext: Hashable, Equatable, LosslessStringConvertible {
         var inline: [Inline] = []
         while !tape.isExhausted() {
             tape.start()
-            if tape.consumeMatch(/(?:^|\s)((@[\w\d\-]+)?(\/[\w\d\-\/]+))/) {
-                var substring = tape.cut()
-                if isSpace(character: substring.first) {
-                    substring.removeFirst()
+            if tape.isAtBeginning && tape.consumeMatch("/") {
+                let span = consumeAddressBody(tape: &tape)
+                inline.append(.slashlink(Slashlink(span: span)))
+            } else if tape.consumeMatch(" /") {
+                let span = consumeAddressBody(tape: &tape)
+                let cleaned = span.dropFirst()
+                inline.append(.slashlink(Slashlink(span: cleaned)))
+            } else if tape.isAtBeginning && tape.consumeMatch("@") {
+                let span = consumeAddressBody(tape: &tape)
+                inline.append(.slashlink(Slashlink(span: span)))
+            } else if tape.consumeMatch(" @") {
+                let span = consumeAddressBody(tape: &tape)
+                let cleaned = span.dropFirst()
+                inline.append(.slashlink(Slashlink(span: cleaned)))
+            } else if tape.consumeMatch("<") {
+                if let link = consumeBracketLink(tape: &tape) {
+                    inline.append(.bracketlink(Bracketlink(span: link)))
                 }
-                if isPossibleTrailingPunctuation(character: substring.last) {
-                    substring.removeLast()
+            } else if tape.consumeMatch("[[") {
+                if let wikilink = consumeWikilink(tape: &tape) {
+                    inline.append(.wikilink(Wikilink(span: wikilink)))
                 }
-                inline.append(.slashlink(Slashlink(span: substring)))
-            } else if tape.consumeMatch(/\<[^>]+>/) {
-                let substring = tape.cut()
-                inline.append(.bracketlink(Bracketlink(span: substring)))
-            } else if tape.consumeMatch(/\[\[[^\[\]]+\]\]/) {
-                let substring = tape.cut()
-                inline.append(.wikilink(Wikilink(span: substring)))
-            } else if tape.consumeMatch(/https?\:\/\/[^\s]+/) {
-                var substring = tape.cut()
-                if isPossibleTrailingPunctuation(character: substring.last) {
-                    substring.removeLast()
+            } else if tape.consumeMatch("https://") {
+                let span = consumeAddressBody(tape: &tape)
+                inline.append(.link(Link(span: span)))
+            } else if tape.consumeMatch("http://") {
+                let span = consumeAddressBody(tape: &tape)
+                inline.append(.link(Link(span: span)))
+            } else if tape.consumeMatch("*") {
+                if let bold = consumeBold(tape: &tape) {
+                    inline.append(.bold(Bold(span: bold)))
                 }
-                inline.append(.link(Link(span: substring)))
-            } else if tape.consumeMatch(/\*[^\*]+\*/) {
-                let substring = tape.cut()
-                inline.append(.bold(Bold(span: substring)))
-            } else if tape.consumeMatch(/_[^_]+_/) {
-                let substring = tape.cut()
-                inline.append(.italic(Italic(span: substring)))
-            } else if tape.consumeMatch(/`[^`]+`/) {
-                let substring = tape.cut()
-                inline.append(.code(Code(span: substring)))
+            } else if tape.consumeMatch("_") {
+                if let italic = consumeItalic(tape: &tape) {
+                    inline.append(.italic(Italic(span: italic)))
+                }
+            } else if tape.consumeMatch("`") {
+                if let code = consumeCode(tape: &tape) {
+                    inline.append(.code(Code(span: code)))
+                }
             } else {
                 tape.advance()
             }
@@ -291,6 +422,196 @@ struct Subtext: Hashable, Equatable, LosslessStringConvertible {
     /// Parse all blocks from tape
     static func parseBlocks(_ tape: inout Tape) -> [Block] {
         Parser.parseLines(&tape, keepEnds: false).map(Self.parseBlock)
+    }
+}
+
+extension Subtext {
+    private static func renderInlineAttributeOf(
+        _ attributedString: NSMutableAttributedString,
+        inline: Subtext.Inline,
+        url: (String, String) -> URL?
+    ) {
+        switch inline {
+        case let .link(link):
+            if let url = link.url {
+                attributedString.addAttribute(
+                    .link,
+                    value: url,
+                    range: NSRange(
+                        link.span.range,
+                        in: attributedString.string
+                    )
+                )
+            }
+        case let .bracketlink(bracketlink):
+            if let url = bracketlink.url {
+                attributedString.addAttribute(
+                    .foregroundColor,
+                    value: UIColor(Color.tertiaryLabel),
+                    range: NSRange(
+                        bracketlink.span.range,
+                        in: attributedString.string
+                    )
+                )
+                attributedString.addAttribute(
+                    .link,
+                    value: url,
+                    range: NSRange(
+                        bracketlink.body().range,
+                        in: attributedString.string
+                    )
+                )
+            }
+        case let .slashlink(slashlink):
+            if
+                let slug = Slug(formatting: String(describing: slashlink)),
+                let url = url(slug.description, slug.toTitle())
+            {
+                attributedString.addAttribute(
+                    .link,
+                    value: url,
+                    range: NSRange(
+                        slashlink.span.range,
+                        in: attributedString.string
+                    )
+                )
+            }
+        case let .wikilink(wikilink):
+            let text = String(wikilink.text)
+            if
+                let slug = Slug(formatting: text),
+                let url = url(slug.description, text)
+            {
+                attributedString.addAttribute(
+                    .foregroundColor,
+                    value: UIColor(Color.tertiaryLabel),
+                    range: NSRange(
+                        wikilink.span.range,
+                        in: attributedString.string
+                    )
+                )
+                attributedString.addAttribute(
+                    .link,
+                    value: url,
+                    range: NSRange(
+                        wikilink.text.range,
+                        in: attributedString.string
+                    )
+                )
+            }
+        case .bold(let bold):
+            attributedString.addAttribute(
+                .font,
+                value: UIFont.appTextMonoBold,
+                range: NSRange(
+                    bold.span.range,
+                    in: attributedString.string
+                )
+            )
+        case .italic(let italic):
+            attributedString.addAttribute(
+                .font,
+                value: UIFont.appTextMonoItalic,
+                range: NSRange(
+                    italic.span.range,
+                    in: attributedString.string
+                )
+            )
+        case .code(let code):
+            attributedString.addAttribute(
+                .backgroundColor,
+                value: UIColor(Color.secondaryBackground),
+                range: NSRange(
+                    code.span.range,
+                    in: attributedString.string
+                )
+            )
+        }
+    }
+
+    /// Read markup in NSMutableAttributedString, and render as attributes.
+    /// Resets all attributes on string, replacing them with style attributes
+    /// corresponding to the semantic meaning of Subtext markup.
+    static func renderAttributesOf(
+        _ attributedString: NSMutableAttributedString,
+        url: (String, String) -> URL?
+    ) {
+        let dom = Subtext(markup: attributedString.string)
+
+        // Get range of all text, using new Swift NSRange constructor
+        // that takes a Swift range which knows how to handle Unicode
+        // glyphs correctly.
+        let baseNSRange = NSRange(
+            dom.base.startIndex...,
+            in: dom.base
+        )
+
+        // Set default font for entire string
+        attributedString.addAttribute(
+            .font,
+            value: UIFont.appTextMono,
+            range: baseNSRange
+        )
+
+        // Set line-spacing for entire string
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = AppTheme.lineSpacing
+        attributedString.addAttribute(
+            .paragraphStyle,
+            value: paragraphStyle,
+            range: baseNSRange
+        )
+
+        // Set text color
+        attributedString.addAttribute(
+            .foregroundColor,
+            value: UIColor(Color.primary),
+            range: baseNSRange
+        )
+
+        for block in dom.blocks {
+            switch block {
+            case .empty:
+                break
+            case let .heading(line):
+                let nsRange = NSRange(line.range, in: dom.base)
+                attributedString.addAttribute(
+                    .font,
+                    value: UIFont.appTextMonoBold,
+                    range: nsRange
+                )
+            case .list(_, let inline):
+                for inline in inline {
+                    renderInlineAttributeOf(
+                        attributedString,
+                        inline: inline,
+                        url: url
+                    )
+                }
+            case .quote(let line, let inline):
+                let nsRange = NSRange(line.range, in: dom.base)
+                attributedString.addAttribute(
+                    .font,
+                    value: UIFont.appTextMonoItalic,
+                    range: nsRange
+                )
+                for inline in inline {
+                    renderInlineAttributeOf(
+                        attributedString,
+                        inline: inline,
+                        url: url
+                    )
+                }
+            case .text(_, let inline):
+                for inline in inline {
+                    renderInlineAttributeOf(
+                        attributedString,
+                        inline: inline,
+                        url: url
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -873,7 +873,6 @@
 				B58FE48B28DED9B600E000CC /* StoryCombo.swift */,
 				B8A59D6828B692900010DB2F /* StoryPrompt.swift */,
 				B8B54F3C271F7C6B00B9B507 /* Suggestion.swift */,
-				B8CBAFAF2996A7D50079107E /* UnqualifiedLink.swift */,
 				B59D556229BBFF56007915E2 /* FormField.swift */,
 			);
 			path = Models;
@@ -1433,7 +1432,7 @@
 				B8DEBF192798B6A8007CB528 /* NavigationToolbar.swift in Sources */,
 				B822F18D27C9C0AB00943C6B /* CountChip.swift in Sources */,
 				B87288DE299AB02400EF7E07 /* SphereFS.swift in Sources */,
-				B8879EAC26F944DA00A0B4FF /* Detail.swift in Sources */,
+				B8879EAC26F944DA00A0B4FF /* MemoEditorDetail.swift in Sources */,
 				B5F6ADC929C02F4A00690DE4 /* AddressBookService.swift in Sources */,
 				B8879EAC26F944DA00A0B4FF /* MemoEditorDetail.swift in Sources */,
 				B8925B2F29C23017001F9503 /* MemoViewerDetailView.swift in Sources */,

--- a/xcode/Subconscious/Subconscious.xcodeproj/xcshareddata/xcbaselines/B80057E727DC355E002C0129.xcbaseline/73DEAF14-78DE-4620-81A3-9232B506BA93.plist
+++ b/xcode/Subconscious/Subconscious.xcodeproj/xcshareddata/xcbaselines/B80057E727DC355E002C0129.xcbaseline/73DEAF14-78DE-4620-81A3-9232B506BA93.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>Tests_SubtextAttributedStringRendererToURL</key>
+		<dict>
+			<key>testPerformance()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.381000</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/xcode/Subconscious/Subconscious.xcodeproj/xcshareddata/xcbaselines/B80057E727DC355E002C0129.xcbaseline/73DEAF14-78DE-4620-81A3-9232B506BA93.plist
+++ b/xcode/Subconscious/Subconscious.xcodeproj/xcshareddata/xcbaselines/B80057E727DC355E002C0129.xcbaseline/73DEAF14-78DE-4620-81A3-9232B506BA93.plist
@@ -11,7 +11,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.381000</real>
+					<real>0.012800</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/xcode/Subconscious/Subconscious.xcodeproj/xcshareddata/xcbaselines/B80057E727DC355E002C0129.xcbaseline/Info.plist
+++ b/xcode/Subconscious/Subconscious.xcodeproj/xcshareddata/xcbaselines/B80057E727DC355E002C0129.xcbaseline/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>73DEAF14-78DE-4620-81A3-9232B506BA93</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>0</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Apple M1 Pro</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>0</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>10</integer>
+				<key>modelCode</key>
+				<string>MacBookPro18,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>10</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>arm64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone14,7</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphonesimulator</string>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/xcode/Subconscious/SubconsciousTests/Tests_Subtext.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Subtext.swift
@@ -485,10 +485,10 @@ class Tests_Subtext: XCTestCase {
         )
     }
     
-    func testDoesNotParsePetnameWithoutPath() throws {
+    func testParsesPetnameWithoutPath() throws {
         let markup = "A @petname without a slashlink part."
         let dom = Subtext.parse(markup: markup)
-        XCTAssertNil(dom.blocks.get(0)?.inline.get(0))
+        XCTAssertNotNil(dom.blocks.get(0)?.inline.get(0))
     }
     
     func testWikilinkParsing0() throws {

--- a/xcode/Subconscious/SubconsciousTests/Tests_SubtextAttributedStringRenderer.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_SubtextAttributedStringRenderer.swift
@@ -69,4 +69,65 @@ final class Tests_SubtextAttributedStringRendererToURL: XCTestCase {
         
         XCTAssertEqual(link.fallback, "Lo and behold")
     }
+    
+    func testPerformance() throws {
+        let renderer = SubtextAttributedStringRenderer()
+        let attributedString = NSMutableAttributedString(
+            string: """
+            Recombinant processes expand the [[adjacent possible]].
+            
+            https://overcast.fm/+UtNTuX9Ms/21:54
+            
+            Related: [[Sara Walker]], [[Stuart Kauffman]] [[SFI]], [[Assembly Theory]], [[Emergence comes from alphabets]], [[Alphabet]]
+            
+            # Mentioned Papers
+            
+            - Intelligence as a planetary scale process by Adam Frank, David Grinspoon & [[Sara Walker]]
+            - [[The Algorithmic Origins of Life]] by Sara Imari Walker & Paul C. W. Davies
+            - *Beyond prebiotic chemistry*: What dynamic network properties allow the emergence of life? by Leroy Cronin & Sara Walker /emergence-of-life
+            - Identifying molecules as biosignatures with [[assembly theory]] and mass spectrometry by Stuart Marshall, Cole Mathis, Emma Carrick, Graham Keenan, Geoffrey Cooper, Heather Graham, Matthew Craven, Piotr Gromski, Douglas Moore, Sara Walker & Leroy Cronin
+            - _Assembly Theory Explains and Quantifies the Emergence of Selection and Evolution_ by Abhishek Sharma, Dániel Czégel, Michael Lachmann, Christopher Kempes, [[Sara Walker]], Leroy Cronin
+            - _Quantum Non-Barking Dogs_ by [[Sara Imari Walker]], Paul C. W. Davies, Prasant Samantray, Yakir Aharonov
+            - _The Multiple Paths to Multiple Life_ by Christopher P. Kempes & [[David C. Krakauer]]
+            
+            # Other Related Videos & Writing
+            
+            - SFI Seminar - _Why Black Holes Eat Information_ by Vijay Balasubramanian
+            - _Major Transitions in Planetary Evolution_ by Hikaru Furukawa and Sara Imari Walker
+            - 2022 Community Lecture: “Recognizing The Alien in Us” by [[Sara Walker]]
+            - Sara Walker and Lee Cronin: The Alien Debate on The Lex Fridman Show
+            - If Cancer Were Easy, Every Cell Would Do It. SFI Press Release on work by Michael Lachmann
+            - [[The Ministry for The Future]] by [[Kim Stanley Robinson]]
+            - Re: Wheeler’s delayed choice experiment
+            - On the SFI “Exploring Life’s Origins” Research Project
+            - Complexity Explorer’s Origins of Life Free Open Online Course
+            - Chiara Marletto on Constructor Theory
+            - Simon Saunders, Philosopher of Physics at Oxford
+
+            # Related SFI Podcast Episodes
+
+            - Complexity 2 - The Origins of Life: David Krakauer, Sarah Maurer, and Chris Kempes at InterPlanetary Festival 2019
+            - Complexity 8 - Olivia Judson on Major Energy Transitions in Evolutionary History
+            - Complexity 17 - Chris Kempes on The Physical Constraints on Life & Evolution
+            - Complexity 40 - The Information Theory of Biology & Origins of Life with Sara Imari Walker (Big Biology Podcast Crossover)
+            - Complexity 41 - Natalie Grefenstette on Agnostic Biosignature Detection
+            - Complexity 68 - W. Brian Arthur on Economics in Nouns & Verbs (Part 1)
+            - Complexity 80 - Mingzhen Lu on The Evolution of Root Systems & Biogeochemical Cycling
+            - Alien Crash Site 015 - Cole Mathis
+            - Alien Crash Site 019 - Heather Graham
+            - Alien Crash Site 020 - Chris Kempes
+            - Alien Crash Site 021 - Natalie Grefenstette
+
+            # Related notes
+            
+            [[SFI]]
+            
+            @sfi/podcast
+            """
+        )
+        // Measure performance of render
+        self.measure {
+            _ = renderer.renderAttributesOf(attributedString)
+        }
+    }
 }


### PR DESCRIPTION
Fixes #447.

This commit replaces the Regex-based matches with the old faster hand-rolled
recursive descent logic from https://github.com/subconsciousnetwork/subconscious/commit/16709dfa95a99d37c8ce53423e2f1a9e4c3a7c5a.

## Background

Profiling the newer regex-based Subtext parser logic against the old hand-rolled non-regex recursive descent logic revealed that the non-regex approach is 97% faster than regex approach (0.013s vs 0.381s). Not sure why regex is so slow here, but we can put up with the inconvenience of a hand-written recursive descent parser in exchange for the sizable perf win.

## Changes

- Replaces subtext parsing logic with faster recursive descent logic from https://github.com/subconsciousnetwork/subconscious/commit/16709dfa95a99d37c8ce53423e2f1a9e4c3a7c5a
- Adds perf test and baseline

All tests pass, with one updated test. We now accept `@bare-handles-without-paths` because it would be a bit of a pain to do backtracking. The petname parsing code for URLs rejects bare petnames right now, so the user-facing behavior is the same. And we'll want to support petname-only slashlinks at some point anyway.