### PR TITLE
Scale editor text and audience menu button with preferred font size

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/Audience/AudienceMenuButtonView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Audience/AudienceMenuButtonView.swift
@@ -8,6 +8,9 @@
 import SwiftUI
 
 struct AudienceMenuButtonView: View {
+    @ScaledMetric(relativeTo: .caption)
+    private var width: CGFloat = 140
+    
     @Binding var audience: Audience
 
     var body: some View {
@@ -41,7 +44,7 @@ struct AudienceMenuButtonView: View {
                     icon: Image(audience: audience),
                     label: audience.description
                 )
-                .frame(width: 140)
+                .frame(width: width)
             }
         )
     }

--- a/xcode/Subconscious/Shared/Components/Common/Audience/MenuButtonView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Audience/MenuButtonView.swift
@@ -9,24 +9,30 @@ import SwiftUI
 
 /// Generic menu pill button view
 struct MenuButtonView<Icon: View>: View {
+    @ScaledMetric(relativeTo: .caption)
+    private var height: CGFloat = 30
+
+    @ScaledMetric(relativeTo: .caption)
+    private var iconSize: CGFloat = 12
+    
     var icon: Icon
     var label: String
 
     var body: some View {
         HStack(spacing: AppTheme.unit) {
             icon
-                .font(.system(size: 12))
+                .font(.system(size: iconSize))
             Text(label)
                 .bold()
                 .font(.caption)
             Spacer()
             Image(systemName: "chevron.down")
-                .font(.system(size: 12))
+                .font(.system(size: iconSize))
                 .foregroundColor(Color.secondary)
         }
         .foregroundColor(Color.accentColor)
         .lineLimit(1)
-        .frame(height: 30)
+        .frame(height: height)
         .padding(
             .horizontal, AppTheme.unit2
         )

--- a/xcode/Subconscious/Shared/Parsers/SubtextAttributedStringRenderer.swift
+++ b/xcode/Subconscious/Shared/Parsers/SubtextAttributedStringRenderer.swift
@@ -101,6 +101,9 @@ struct SubtextAttributedStringRenderer {
         return sub.toURL()
     }
     
+    /// Body font size. Should be passed down from view using
+    /// `@ScaledMetric(relativeTo: .body)`.
+    var bodySize: CGFloat
     /// Delegate allowing slashlink-to-url override
     var slashlinkToURL: (String) -> URL? = Self.slashlinkToURL
     /// Delegate allowing wikilink-to-url override
@@ -143,7 +146,7 @@ struct SubtextAttributedStringRenderer {
         // Set default font for entire string
         attributedString.addAttribute(
             .font,
-            value: UIFont.appTextMono,
+            value: UIFont.appTextMono.withSize(bodySize),
             range: baseNSRange
         )
         

--- a/xcode/Subconscious/SubconsciousTests/Tests_SubtextAttributedStringRenderer.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_SubtextAttributedStringRenderer.swift
@@ -71,7 +71,7 @@ final class Tests_SubtextAttributedStringRendererToURL: XCTestCase {
     }
     
     func testPerformance() throws {
-        let renderer = SubtextAttributedStringRenderer()
+        let renderer = SubtextAttributedStringRenderer(bodySize: 17)
         let attributedString = NSMutableAttributedString(
             string: """
             Recombinant processes expand the [[adjacent possible]].


### PR DESCRIPTION
Fixes #436
Fixes #435

Uses https://developer.apple.com/documentation/swiftui/scaledmetric property wrapper to define scalable units. 

## Approach

`@ScaledMetric` is a view property wrapper. We keep the same `AppTheme.unit` constants, but use the property wrapper in particular views to scale these units as needed.