### PR TITLE
Integrate traversal FFI calls into NoosphereService

### DIFF
--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -275,7 +275,7 @@ final class NoosphereService: SphereProtocol, SphereIdentityProtocol {
         }
     }
 
-    func traverse(petname: String) throws -> Sphere? {
+    func traverse(petname: String) throws -> Sphere {
         try queue.sync {
             try self.sphere().traverse(petname: petname)
         }

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -141,19 +141,17 @@ final class NoosphereService: SphereProtocol, SphereIdentityProtocol {
             throw NoosphereServiceError.defaultSphereNotFound
         }
         
-        return try open(identity: identity)
+        return try sphere(identity: identity)
     }
     
     /// Open a sphere using its identity
-    func open(identity: String) throws -> Sphere {
+    func sphere(identity: String) throws -> Sphere {
         let noosphere = try noosphere()
         logger.debug("init Sphere with identity: \(identity)")
-        let sphere = try Sphere(
+        return try Sphere(
             noosphere: noosphere,
             identity: identity
         )
-        self._sphere = sphere
-        return sphere
     }
     
     func identity() throws -> String {
@@ -282,15 +280,14 @@ final class NoosphereService: SphereProtocol, SphereIdentityProtocol {
         }
     }
     
+    /// Attempt to retrieve the sphere of a recorded petname, this can be chained to walk
+    /// over multiple spheres:
+    ///
+    /// `sphere().traverse(petname: "alice")?.traverse(petname: "bob")?.traverse(petname: "alice)` etc.
+    ///
     func traverse(petname: String) throws -> Sphere? {
         try queue.sync {
-            try self.sphere().traverseByPetname(petname: petname)
-        }
-    }
-    
-    func traverse(sphere: Sphere, petname: String) throws -> Sphere? {
-        try queue.sync {
-            try sphere.traverseByPetname(petname: petname)
+            try self.sphere().traverse(petname: petname)
         }
     }
 }

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -143,10 +143,12 @@ final class NoosphereService: SphereProtocol, SphereIdentityProtocol {
         
         let noosphere = try noosphere()
         logger.debug("init Sphere with identity: \(identity)")
-        return try Sphere(
+        let sphere = try Sphere(
             noosphere: noosphere,
             identity: identity
         )
+        self._sphere = sphere
+        return sphere
     }
     
     func identity() throws -> String {

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -141,11 +141,6 @@ final class NoosphereService: SphereProtocol, SphereIdentityProtocol {
             throw NoosphereServiceError.defaultSphereNotFound
         }
         
-        return try sphere(identity: identity)
-    }
-    
-    /// Open a sphere using its identity
-    func sphere(identity: String) throws -> Sphere {
         let noosphere = try noosphere()
         logger.debug("init Sphere with identity: \(identity)")
         return try Sphere(

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -140,6 +140,12 @@ final class NoosphereService: SphereProtocol, SphereIdentityProtocol {
         guard let identity = self._sphereIdentity else {
             throw NoosphereServiceError.defaultSphereNotFound
         }
+        
+        return try open(identity: identity)
+    }
+    
+    /// Open a sphere using its identity
+    func open(identity: String) throws -> Sphere {
         let noosphere = try noosphere()
         logger.debug("init Sphere with identity: \(identity)")
         let sphere = try Sphere(
@@ -273,6 +279,18 @@ final class NoosphereService: SphereProtocol, SphereIdentityProtocol {
     func getPetnameChanges(sinceCid: String) throws -> [String] {
         try queue.sync {
             try self.sphere().getPetnameChanges(sinceCid: sinceCid)
+        }
+    }
+    
+    func traverse(petname: String) throws -> Sphere? {
+        try queue.sync {
+            try self.sphere().traverseByPetname(petname: petname)
+        }
+    }
+    
+    func traverse(sphere: Sphere, petname: String) throws -> Sphere? {
+        try queue.sync {
+            try sphere.traverseByPetname(petname: petname)
         }
     }
 }

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -279,12 +279,7 @@ final class NoosphereService: SphereProtocol, SphereIdentityProtocol {
             try self.sphere().getPetnameChanges(sinceCid: sinceCid)
         }
     }
-    
-    /// Attempt to retrieve the sphere of a recorded petname, this can be chained to walk
-    /// over multiple spheres:
-    ///
-    /// `sphere().traverse(petname: "alice")?.traverse(petname: "bob")?.traverse(petname: "alice)` etc.
-    ///
+
     func traverse(petname: String) throws -> Sphere? {
         try queue.sync {
             try self.sphere().traverse(petname: petname)

--- a/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
@@ -47,9 +47,9 @@ public protocol SphereProtocol {
     /// Attempt to retrieve the sphere of a recorded petname, this can be chained to walk
     /// over multiple spheres:
     ///
-    /// `sphere().traverse(petname: "alice")?.traverse(petname: "bob")?.traverse(petname: "alice)` etc.
+    /// `sphere().traverse(petname: "alice").traverse(petname: "bob").traverse(petname: "alice)` etc.
     ///
-    func traverse(petname: String) throws -> Sphere?
+    func traverse(petname: String) throws -> Sphere
 }
 
 protocol SphereIdentityProtocol {
@@ -362,7 +362,7 @@ public final class Sphere: SphereProtocol {
     }
     
     
-    public func traverse(petname: String) throws -> Sphere? {
+    public func traverse(petname: String) throws -> Sphere {
         let identity = try self.getPetname(petname: petname)
         
         let sphere = try Noosphere.callWithError(
@@ -373,8 +373,7 @@ public final class Sphere: SphereProtocol {
         )
         
         guard let sphere = sphere else {
-            logger.warning("Failed to traverse sphere for \(petname)")
-            return nil
+            throw NoosphereError.foreignError("ns_sphere_traverse_by_petname failed to find sphere")
         }
         
         return Sphere(noosphere: noosphere, sphere: sphere, identity: identity)

--- a/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
@@ -75,6 +75,12 @@ public final class Sphere: SphereProtocol {
     public let sphere: OpaquePointer
     public let identity: String
     
+    init(noosphere: Noosphere, sphere: OpaquePointer, identity: String) {
+        self.noosphere = noosphere
+        self.sphere = sphere
+        self.identity = identity
+    }
+    
     init(noosphere: Noosphere, identity: String) throws {
         self.noosphere = noosphere
         self.identity = identity
@@ -346,6 +352,26 @@ public final class Sphere: SphereProtocol {
         }
         
         return changes.toStringArray()
+    }
+    
+    /// Load the sphere of a user by petname, they must already
+    /// be present in your address book
+    public func traverseByPetname(petname: String) throws -> Sphere? {
+        let identity = try self.resolvePetname(petname: petname)
+        
+        let sphere = try Noosphere.callWithError(
+            ns_sphere_traverse_by_petname,
+            noosphere.noosphere,
+            sphere,
+            petname
+        )
+        
+        guard let sphere = sphere else {
+            logger.warning("Failed to traverse sphere for \(petname)")
+            return nil
+        }
+        
+        return Sphere(noosphere: noosphere, sphere: sphere, identity: identity)
     }
     
     /// Save outstanding writes and return new Sphere version

--- a/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
@@ -82,7 +82,7 @@ public final class Sphere: SphereProtocol {
     public let sphere: OpaquePointer
     public let identity: String
     
-    init(noosphere: Noosphere, sphere: OpaquePointer, identity: String) {
+    private init(noosphere: Noosphere, sphere: OpaquePointer, identity: String) {
         self.noosphere = noosphere
         self.sphere = sphere
         self.identity = identity

--- a/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
@@ -44,6 +44,11 @@ public protocol SphereProtocol {
     
     func changes(_ since: String?) throws -> [String]
     
+    /// Attempt to retrieve the sphere of a recorded petname, this can be chained to walk
+    /// over multiple spheres:
+    ///
+    /// `sphere().traverse(petname: "alice")?.traverse(petname: "bob")?.traverse(petname: "alice)` etc.
+    ///
     func traverse(petname: String) throws -> Sphere?
 }
 
@@ -356,8 +361,7 @@ public final class Sphere: SphereProtocol {
         return changes.toStringArray()
     }
     
-    /// Load the sphere of a user by petname, they must already
-    /// be present in your address book
+    
     public func traverse(petname: String) throws -> Sphere? {
         let identity = try self.getPetname(petname: petname)
         

--- a/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
@@ -43,6 +43,8 @@ public protocol SphereProtocol {
     func sync() throws -> String
     
     func changes(_ since: String?) throws -> [String]
+    
+    func traverse(petname: String) throws -> Sphere?
 }
 
 protocol SphereIdentityProtocol {
@@ -356,7 +358,7 @@ public final class Sphere: SphereProtocol {
     
     /// Load the sphere of a user by petname, they must already
     /// be present in your address book
-    public func traverseByPetname(petname: String) throws -> Sphere? {
+    public func traverse(petname: String) throws -> Sphere? {
         let identity = try self.getPetname(petname: petname)
         
         let sphere = try Noosphere.callWithError(

--- a/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
@@ -357,7 +357,7 @@ public final class Sphere: SphereProtocol {
     /// Load the sphere of a user by petname, they must already
     /// be present in your address book
     public func traverseByPetname(petname: String) throws -> Sphere? {
-        let identity = try self.resolvePetname(petname: petname)
+        let identity = try self.getPetname(petname: petname)
         
         let sphere = try Noosphere.callWithError(
             ns_sphere_traverse_by_petname,

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		B58FE48A28DED93F00E000CC /* ComboGeist.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58FE48928DED93F00E000CC /* ComboGeist.swift */; };
 		B58FE48C28DED9B600E000CC /* StoryCombo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58FE48B28DED9B600E000CC /* StoryCombo.swift */; };
 		B58FE48E28DEDAEA00E000CC /* StoryComboView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58FE48D28DEDAEA00E000CC /* StoryComboView.swift */; };
+		B5908BEB29DAB05B00225B1A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5908BEA29DAB05B00225B1A /* TestUtilities.swift */; };
 		B59D556329BBFF56007915E2 /* FormField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59D556229BBFF56007915E2 /* FormField.swift */; };
 		B5D8D2FF29AF1DBB0011D820 /* Test_Did.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D8D2FE29AF1DBB0011D820 /* Test_Did.swift */; };
 		B5F6ADC929C02F4A00690DE4 /* AddressBookService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F6ADC829C02F4A00690DE4 /* AddressBookService.swift */; };
@@ -384,6 +385,7 @@
 		B58FE48928DED93F00E000CC /* ComboGeist.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComboGeist.swift; sourceTree = "<group>"; };
 		B58FE48B28DED9B600E000CC /* StoryCombo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryCombo.swift; sourceTree = "<group>"; };
 		B58FE48D28DEDAEA00E000CC /* StoryComboView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryComboView.swift; sourceTree = "<group>"; };
+		B5908BEA29DAB05B00225B1A /* TestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUtilities.swift; sourceTree = "<group>"; };
 		B59D556229BBFF56007915E2 /* FormField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormField.swift; sourceTree = "<group>"; };
 		B5D8D2FE29AF1DBB0011D820 /* Test_Did.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_Did.swift; sourceTree = "<group>"; };
 		B5D8D30029AF1F9B0011D820 /* Did.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Did.swift; sourceTree = "<group>"; };
@@ -718,6 +720,7 @@
 				B84AD8E72811C827006B3153 /* Tests_URLComponentsUtilities.swift */,
 				B8D328B929A69D2D00850A37 /* Tests_URLUtilities.swift */,
 				B8E62AE729D61E69008F7E74 /* Tests_UserDefaultProperty.swift */,
+				B5908BEA29DAB05B00225B1A /* TestUtilities.swift */,
 			);
 			path = SubconsciousTests;
 			sourceTree = "<group>";
@@ -1374,6 +1377,7 @@
 				B85DF78F29B7B5440042D725 /* Tests_Prose.swift in Sources */,
 				B85D5E3D28BE4B2C00EE0078 /* Tests_NotebookUpdate.swift in Sources */,
 				B8682DCD2804C379001CD8DD /* Tests_CollectionUtilities.swift in Sources */,
+				B5908BEB29DAB05B00225B1A /* TestUtilities.swift in Sources */,
 				B8EA3757299EBA5500D98E2B /* Tests_NoosphereService.swift in Sources */,
 				B88CC95B284FF64300994928 /* Tests_OrderedCollectionUtilities.swift in Sources */,
 				B80057F427DC35BE002C0129 /* Tests_Slug.swift in Sources */,

--- a/xcode/Subconscious/SubconsciousTests/TestUtilities.swift
+++ b/xcode/Subconscious/SubconsciousTests/TestUtilities.swift
@@ -1,0 +1,76 @@
+//
+//  TestUtilities.swift
+//  SubconsciousTests
+//
+//  Created by Ben Follington on 3/4/2023.
+//
+
+import XCTest
+import Combine
+import ObservableStore
+@testable import Subconscious
+
+struct TestUtilities {
+    /// Create a unique temp dir and return URL
+    static func createTmpDir() throws -> URL {
+        let path = UUID().uuidString
+        let url = FileManager.default.temporaryDirectory.appending(
+            path: path,
+            directoryHint: .isDirectory
+        )
+        try FileManager.default.createDirectory(
+            at: url,
+            withIntermediateDirectories: true
+        )
+        return url
+    }
+    
+    /// Set up and return a data service instance
+    static func createDataService(
+        tmp: URL
+    ) throws -> DataService {
+        let globalStorageURL = tmp.appending(path: "noosphere")
+        let sphereStorageURL = tmp.appending(path: "sphere")
+        
+        let noosphere = NoosphereService(
+            globalStorageURL: globalStorageURL,
+            sphereStorageURL: sphereStorageURL,
+            gatewayURL: URL(string: "http://unavailable-gateway.fakewebsite")
+        )
+        
+        let receipt = try noosphere.createSphere(ownerKeyName: "bob")
+        noosphere.resetSphere(receipt.identity)
+        
+        let databaseURL = tmp.appending(
+            path: "database.sqlite",
+            directoryHint: .notDirectory
+        )
+        let db = SQLite3Database(
+            path: databaseURL.path(percentEncoded: false),
+            mode: .readwrite
+        )
+        
+        let database = DatabaseService(
+            database: db,
+            migrations: Config.migrations
+        )
+        _ = try database.migrate()
+        
+        let files = FileStore(
+            documentURL: tmp.appending(path: "docs")
+        )
+        
+        let local = HeaderSubtextMemoStore(store: files)
+        let addressBook = AddressBookService(
+            noosphere: noosphere,
+            database: database
+        )
+        
+        return DataService(
+            noosphere: noosphere,
+            database: database,
+            local: local,
+            addressBook: addressBook
+        )
+    }
+}

--- a/xcode/Subconscious/SubconsciousTests/Tests_DataService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DataService.swift
@@ -11,77 +11,14 @@ import ObservableStore
 @testable import Subconscious
 
 final class Tests_DataService: XCTestCase {
-    /// Create a unique temp dir and return URL
-    func createTmpDir() throws -> URL {
-        let path = UUID().uuidString
-        let url = FileManager.default.temporaryDirectory.appending(
-            path: path,
-            directoryHint: .isDirectory
-        )
-        try FileManager.default.createDirectory(
-            at: url,
-            withIntermediateDirectories: true
-        )
-        return url
-    }
-    
-    /// Set up and return a data service instance
-    func createDataService(
-        tmp: URL
-    ) throws -> DataService {
-        let globalStorageURL = tmp.appending(path: "noosphere")
-        let sphereStorageURL = tmp.appending(path: "sphere")
-        
-        let noosphere = NoosphereService(
-            globalStorageURL: globalStorageURL,
-            sphereStorageURL: sphereStorageURL,
-            gatewayURL: URL(string: "http://unavailable-gateway.fakewebsite")
-        )
-        
-        let receipt = try noosphere.createSphere(ownerKeyName: "bob")
-        noosphere.resetSphere(receipt.identity)
-        
-        let databaseURL = tmp.appending(
-            path: "database.sqlite",
-            directoryHint: .notDirectory
-        )
-        let db = SQLite3Database(
-            path: databaseURL.path(percentEncoded: false),
-            mode: .readwrite
-        )
-        
-        let database = DatabaseService(
-            database: db,
-            migrations: Config.migrations
-        )
-        _ = try database.migrate()
-        
-        let files = FileStore(
-            documentURL: tmp.appending(path: "docs")
-        )
-        
-        let local = HeaderSubtextMemoStore(store: files)
-        let addressBook = AddressBookService(
-            noosphere: noosphere,
-            database: database
-        )
-        
-        return DataService(
-            noosphere: noosphere,
-            database: database,
-            local: local,
-            addressBook: addressBook
-        )
-    }
-    
     /// A place to put cancellables from publishers
     var cancellables: Set<AnyCancellable> = Set()
     
     var data: DataService?
     
     func testWriteThenReadMemo() throws {
-        let tmp = try createTmpDir()
-        let data = try createDataService(tmp: tmp)
+        let tmp = try TestUtilities.createTmpDir()
+        let data = try TestUtilities.createDataService(tmp: tmp)
         
         let address = Slug(formatting: "Test")!.toPublicMemoAddress()
         let memoIn = Memo(
@@ -104,8 +41,8 @@ final class Tests_DataService: XCTestCase {
     }
     
     func testReadMemoBeforeWrite() throws {
-        let tmp = try createTmpDir()
-        let data = try createDataService(tmp: tmp)
+        let tmp = try TestUtilities.createTmpDir()
+        let data = try TestUtilities.createDataService(tmp: tmp)
         
         let address = Slug(formatting: "Test")!.toPublicMemoAddress()
         
@@ -113,8 +50,8 @@ final class Tests_DataService: XCTestCase {
     }
     
     func testWriteThenBadSyncThenReadMemo() throws {
-        let tmp = try createTmpDir()
-        let data = try createDataService(tmp: tmp)
+        let tmp = try TestUtilities.createTmpDir()
+        let data = try TestUtilities.createDataService(tmp: tmp)
         
         let address = Slug(formatting: "Test")!.toPublicMemoAddress()
         let memoIn = Memo(
@@ -140,8 +77,8 @@ final class Tests_DataService: XCTestCase {
     }
     
     func testWriteThenBadSyncThenReadDetail() throws {
-        let tmp = try createTmpDir()
-        let data = try createDataService(tmp: tmp)
+        let tmp = try TestUtilities.createTmpDir()
+        let data = try TestUtilities.createDataService(tmp: tmp)
         
         let address = Slug(formatting: "Test")!.toPublicMemoAddress()
         let memo = Memo(
@@ -171,7 +108,7 @@ final class Tests_DataService: XCTestCase {
     }
     
     func testManyWritesThenCloseThenReopen() throws {
-        let tmp = try createTmpDir()
+        let tmp = try TestUtilities.createTmpDir()
         
         let globalStorageURL = tmp.appending(path: "noosphere")
         let sphereStorageURL = tmp.appending(path: "sphere")
@@ -296,8 +233,8 @@ final class Tests_DataService: XCTestCase {
     }
     
     func testFindUniqueAddressFor() throws {
-        let tmp = try createTmpDir()
-        let data = try createDataService(tmp: tmp)
+        let tmp = try TestUtilities.createTmpDir()
+        let data = try TestUtilities.createDataService(tmp: tmp)
         
         let memo = Memo(
             contentType: ContentType.subtext.rawValue,
@@ -317,8 +254,8 @@ final class Tests_DataService: XCTestCase {
     }
     
     func testReadMemoDetail() throws {
-        let tmp = try createTmpDir()
-        let data = try createDataService(tmp: tmp)
+        let tmp = try TestUtilities.createTmpDir()
+        let data = try TestUtilities.createDataService(tmp: tmp)
         
         let memo = Memo(
             contentType: ContentType.subtext.rawValue,
@@ -339,8 +276,8 @@ final class Tests_DataService: XCTestCase {
     }
     
     func testReadMemoDetailDoesNotExist() throws {
-        let tmp = try createTmpDir()
-        let data = try createDataService(tmp: tmp)
+        let tmp = try TestUtilities.createTmpDir()
+        let data = try TestUtilities.createDataService(tmp: tmp)
         
         let addressA = MemoAddress.public(Slashlink("/a")!)
 

--- a/xcode/Subconscious/SubconsciousTests/Tests_NoosphereService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_NoosphereService.swift
@@ -23,6 +23,8 @@ final class Tests_NoosphereService: XCTestCase {
     }
     
     func testSphereTraversal() throws {
+        throw XCTSkip("Sphere Traversal relies on running a gateway, this test will not pass currently.")
+        
         let tmp = try TestUtilities.createTmpDir()
         let data = try TestUtilities.createDataService(tmp: tmp)
         let noosphere = data.noosphere
@@ -46,7 +48,7 @@ final class Tests_NoosphereService: XCTestCase {
         let bobDid = try aliceSphere.getPetname(petname: "bob")
         XCTAssertEqual(bobDid, bobReceipt.identity)
         
-//        let result = try noosphere.sync()
+        let result = try noosphere.sync()
         // This should loop back around to bob
         let destinationSphere = try noosphere
             .traverse(petname: "alice")?

--- a/xcode/Subconscious/SubconsciousTests/Tests_NoosphereService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_NoosphereService.swift
@@ -34,12 +34,13 @@ final class Tests_NoosphereService: XCTestCase {
         let bobSphere = try noosphere.open(identity: bobReceipt.identity)
         
         try bobSphere.setPetname(did: aliceReceipt.identity, petname: "alice")
+        try aliceSphere.setPetname(did: bobReceipt.identity, petname: "bob")
         try noosphere.save()
         
         let aliceDid = try bobSphere.getPetname(petname: "alice")
         XCTAssertEqual(aliceDid, aliceReceipt.identity)
         
-        let result = try noosphere.sync() // Must sync before we can resolve, no gateway atm
+//        let result = try noosphere.sync() 
         let newSphere = try noosphere.traverse(sphere: bobSphere, petname: "alice")
 
         // Clear out Noosphere and Sphere instance

--- a/xcode/Subconscious/SubconsciousTests/Tests_NoosphereService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_NoosphereService.swift
@@ -52,13 +52,13 @@ final class Tests_NoosphereService: XCTestCase {
         let result = try noosphere.sync()
         // This should loop back around to bob
         let destinationSphere = try noosphere
-            .traverse(petname: "alice")?
+            .traverse(petname: "alice")
             .traverse(petname: "bob")
 
         // Clear out Noosphere and Sphere instance
         noosphere.reset()
         
-        XCTAssertEqual(destinationSphere?.identity, bobReceipt.identity)
+        XCTAssertEqual(destinationSphere.identity, bobReceipt.identity)
     }
     
     func testNoosphereReset() throws {

--- a/xcode/Subconscious/SubconsciousTests/Tests_NoosphereService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_NoosphereService.swift
@@ -33,9 +33,12 @@ final class Tests_NoosphereService: XCTestCase {
         let aliceReceipt = try noosphere.createSphere(ownerKeyName: "alice")
         
         // Put bob in alice's address book
-        let aliceSphere = try noosphere.sphere(identity: aliceReceipt.identity)
-        try aliceSphere.setPetname(did: bobReceipt.identity, petname: "bob")
-        try aliceSphere.save()
+        noosphere.resetSphere(aliceReceipt.identity)
+        try noosphere.setPetname(did: bobReceipt.identity, petname: "bob")
+        try noosphere.save()
+        
+        let bobDid = try noosphere.getPetname(petname: "bob")
+        XCTAssertEqual(bobDid, bobReceipt.identity)
         
         // Put alice in bob's address book & set bob as default sphere
         noosphere.resetSphere(bobReceipt.identity)
@@ -45,8 +48,6 @@ final class Tests_NoosphereService: XCTestCase {
         let aliceDid = try noosphere.getPetname(petname: "alice")
         XCTAssertEqual(aliceDid, aliceReceipt.identity)
         
-        let bobDid = try aliceSphere.getPetname(petname: "bob")
-        XCTAssertEqual(bobDid, bobReceipt.identity)
         
         let result = try noosphere.sync()
         // This should loop back around to bob


### PR DESCRIPTION
# Changes

- Added `traverse(petname: String) throws -> Sphere` to `SphereProtocol`
- Add private `Sphere.init` that constructs a `Sphere` from an `ns_sphere_t`
- Add `testSphereTraversal` (skipped test) to demonstrate usage

Resolves https://github.com/subconsciousnetwork/subconscious/issues/483