### PR TITLE
Refactor SphereProtocol to enable traverse on read

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/Byline/SlashlinkBylineView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Byline/SlashlinkBylineView.swift
@@ -9,18 +9,17 @@ import SwiftUI
 
 /// Compact byline combines a small profile pic, username, and path
 struct SlashlinkBylineView: View {
-    var petname: String?
-    var slug: String
-    private var petnameColor = Color.accentColor
-    private var slugColor = Color.secondary
+    var slashlink: Slashlink
+    var petnameColor = Color.accentColor
+    var slugColor = Color.secondary
     
     var body: some View {
         HStack(spacing: 0) {
-            if let petname = petname.flatMap({ string in Petname(string) }) {
+            if let petname = slashlink.petname {
                 PetnameBylineView(petname: petname)
                     .theme(petname: petnameColor)
             }
-            Text(verbatim: "/\(slug)")
+            Text(verbatim: slashlink.slug.markup)
                 .foregroundColor(slugColor)
             Spacer()
         }
@@ -35,17 +34,6 @@ struct SlashlinkBylineView: View {
         this.petnameColor = petnameColor
         this.slugColor = slugColor
         return this
-    }
-}
-
-extension SlashlinkBylineView {
-    init(
-        slashlink: Slashlink
-    ) {
-        self.init(
-            petname: slashlink.petnamePart,
-            slug: slashlink.slugPart
-        )
     }
 }
 

--- a/xcode/Subconscious/Shared/Components/Common/Byline/SlashlinkBylineView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Byline/SlashlinkBylineView.swift
@@ -19,7 +19,7 @@ struct SlashlinkBylineView: View {
                 PetnameBylineView(petname: petname)
                     .theme(petname: petnameColor)
             }
-            Text(verbatim: slashlink.slug.markup)
+            Text(verbatim: slashlink.slug.verbatimMarkup)
                 .foregroundColor(slugColor)
             Spacer()
         }

--- a/xcode/Subconscious/Shared/Components/Common/SlashlinkBarView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SlashlinkBarView.swift
@@ -21,7 +21,7 @@ struct SlashlinkBarView: View {
                         onSelectLink(link)
                     },
                     label: {
-                        Text(link.address.slug.markup)
+                        Text(link.address.slug.verbatimMarkup)
                             .lineLimit(1)
                     }
                 )

--- a/xcode/Subconscious/Shared/Components/Detail/MemoDetailDescription.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoDetailDescription.swift
@@ -45,7 +45,7 @@ extension MemoDetailDescription {
                     defaultAudience: .local
                 )
             )
-        case .public(let slashlink) where slashlink.petnamePart == nil:
+        case .public(let slashlink) where slashlink.petname == nil:
             return .editor(
                 MemoEditorDetailDescription(
                     address: slashlink.toPublicMemoAddress(),

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -1666,7 +1666,7 @@ struct MemoEditorDetailModel: ModelProtocol {
             through: { markup in
                 switch markup {
                 case .slashlink(let slashlink):
-                    let replacement = link.address.slug.markup
+                    let replacement = link.address.slug.verbatimMarkup
                     let range = NSRange(
                         slashlink.span.range,
                         in: state.editor.text

--- a/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
@@ -899,7 +899,7 @@ struct NotebookModel: ModelProtocol {
         // If slashlink pointing to other sphere, dispatch action for viewer.
         // If slashlink pointing to our sphere, dispatch findAndPushEditDetail
         // to find in local or sphere content and then push editor detail.
-        switch slashlink.petnamePart {
+        switch slashlink.petname {
         case .some:
             if Config.default.memoViewerDetailEnabled {
                 return update(

--- a/xcode/Subconscious/Shared/Components/OmniboxView.swift
+++ b/xcode/Subconscious/Shared/Components/OmniboxView.swift
@@ -27,10 +27,7 @@ struct OmniboxView: View {
             
             Spacer(minLength: AppTheme.unit)
             if let slashlink = address?.toSlashlink() {
-                OmniboxSlashlinkView(
-                    petname: slashlink.petnamePart,
-                    slug: slashlink.slugPart
-                )
+                OmniboxSlashlinkView(slashlink: slashlink)
             } else {
                 Text("Untitled")
                     .foregroundColor(Color.secondary)
@@ -53,23 +50,19 @@ struct OmniboxView: View {
 
 /// Helper view that knows how to format slashlinks with or without petname.
 struct OmniboxSlashlinkView: View {
-    var petname: String?
-    var slug: String
+    var slashlink: Slashlink
     
     var body: some View {
         HStack(spacing: 0) {
-            if let petname = petname {
-                Text(verbatim: "@\(petname)").fontWeight(.medium)
+            if let petname = slashlink.petname {
+                Text(verbatim: petname.markup).fontWeight(.medium)
                 
                 // Hide the slug if it's the profile view, just the username is cleaner
-                if let slug = Slug(slug) {
-                    if !slug.isProfile() {
-                        Text(verbatim: "/\(slug)")
-                    }
+                if !slashlink.slug.isProfile() {
+                    Text(verbatim: slashlink.slug.markup)
                 }
-                
             } else {
-                Text(verbatim: slug)
+                Text(verbatim: slashlink.slug.description)
             }
         }
         .lineLimit(1)

--- a/xcode/Subconscious/Shared/Components/OmniboxView.swift
+++ b/xcode/Subconscious/Shared/Components/OmniboxView.swift
@@ -55,14 +55,14 @@ struct OmniboxSlashlinkView: View {
     var body: some View {
         HStack(spacing: 0) {
             if let petname = slashlink.petname {
-                Text(verbatim: petname.markup).fontWeight(.medium)
+                Text(verbatim: petname.verbatimMarkup).fontWeight(.medium)
                 
                 // Hide the slug if it's the profile view, just the username is cleaner
                 if !slashlink.slug.isProfile() {
-                    Text(verbatim: slashlink.slug.markup)
+                    Text(verbatim: slashlink.slug.verbatimMarkup)
                 }
             } else {
-                Text(verbatim: slashlink.slug.description)
+                Text(verbatim: slashlink.slug.verbatim)
             }
         }
         .lineLimit(1)

--- a/xcode/Subconscious/Shared/Models/MemoAddress.swift
+++ b/xcode/Subconscious/Shared/Models/MemoAddress.swift
@@ -40,7 +40,7 @@ extension MemoAddress: LosslessStringConvertible, Identifiable, Comparable {
                 return nil
             }
             // Local addresses must not include petnames
-            guard slashlink.petnamePart == nil else {
+            guard slashlink.petname == nil else {
                 return nil
             }
             self = .local(slashlink.toSlug())
@@ -76,7 +76,7 @@ extension MemoAddress {
         switch self {
         case .local:
             return true
-        case .public(let slashlink) where slashlink.petnamePart == nil:
+        case .public(let slashlink) where slashlink.petname == nil:
             return true
         case .public:
             return false

--- a/xcode/Subconscious/Shared/Models/Petname.swift
+++ b/xcode/Subconscious/Shared/Models/Petname.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A type representing a valid petname (`@petname`)
-struct Petname:
+public struct Petname:
     Hashable,
     Equatable,
     Identifiable,
@@ -18,11 +18,11 @@ struct Petname:
 {
     private static let petnameRegex = /[\w\d\-]+/
     
-    static func < (lhs: Self, rhs: Self) -> Bool {
+    public static func < (lhs: Self, rhs: Self) -> Bool {
         lhs.id < rhs.id
     }
     
-    static func == (lhs: Self, rhs: Self) -> Bool {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.id == rhs.id
     }
 
@@ -48,15 +48,15 @@ struct Petname:
         return formatted
     }
 
-    let description: String
-    let verbatim: String
-    var id: String { description }
+    public let description: String
+    public let verbatim: String
+    public var id: String { description }
     
-    var markup: String {
+    public var markup: String {
         "@\(self.verbatim)"
     }
     
-    init?(_ description: String) {
+    public init?(_ description: String) {
         guard description.wholeMatch(of: Self.petnameRegex) != nil else {
             return nil
         }
@@ -66,7 +66,7 @@ struct Petname:
     
     /// Convert a string into a petname.
     /// This will sanitize the string as best it can to create a valid petname.
-    init?(formatting string: String) {
+    public init?(formatting string: String) {
         self.init(Self.format(string))
     }
 }

--- a/xcode/Subconscious/Shared/Models/Petname.swift
+++ b/xcode/Subconscious/Shared/Models/Petname.swift
@@ -53,9 +53,13 @@ public struct Petname:
     public var id: String { description }
     
     public var markup: String {
-        "@\(self.verbatim)"
+        "@\(self.description)"
     }
     
+    public var verbatimMarkup: String {
+        "@\(self.verbatim)"
+    }
+
     public init?(_ description: String) {
         guard description.wholeMatch(of: Self.petnameRegex) != nil else {
             return nil

--- a/xcode/Subconscious/Shared/Models/Slashlink.swift
+++ b/xcode/Subconscious/Shared/Models/Slashlink.swift
@@ -26,11 +26,23 @@ public struct Slashlink:
         lhs.id == rhs.id
     }
     
-    public let description: String
-    public let verbatim: String
-    let petnamePart: String?
-    let slugPart: String
+    let petname: Petname?
+    let slug: Slug
     
+    public var description: String {
+        guard let petname = petname else {
+            return "/\(slug.description)"
+        }
+        return "@\(petname.description)/\(slug.description)"
+    }
+
+    public var verbatim: String {
+        guard let petname = petname else {
+            return "/\(slug.verbatim)"
+        }
+        return "@\(petname.verbatim)/\(slug.verbatim)"
+    }
+
     public var id: String { description }
     
     static let profileSlug = Slug("_profile_")!
@@ -42,11 +54,8 @@ public struct Slashlink:
         petname: Petname? = nil,
         slug: Slug
     ) {
-        self.petnamePart = petname?.verbatim
-        self.slugPart = slug.verbatim
-        let description = "\(petname?.markup ?? "")\(slug.markup)"
-        self.description = description.lowercased()
-        self.verbatim = description
+        self.petname = petname
+        self.slug = slug
     }
     
     public init?(_ description: String) {
@@ -55,11 +64,11 @@ public struct Slashlink:
         else {
             return nil
         }
-        self.description = description.lowercased()
-        self.verbatim = description
-        let slug = match.slug.toString()
-        self.slugPart = slug
-        self.petnamePart = match.petname?.toString()
+        let slug = Slug(uncheckedRawString: match.slug.toString())
+        let petname = match.petname.map({ substring in
+            Petname(uncheckedRawString: substring.toString())
+        })
+        self.init(petname: petname, slug: slug)
     }
     
     /// Convenience initializer that creates a link to `@user/_profile_`
@@ -89,7 +98,7 @@ extension Slug {
 
 extension Slashlink {
     func toSlug() -> Slug {
-        Slug(uncheckedRawString: self.slugPart)
+        self.slug
     }
 }
 
@@ -104,10 +113,7 @@ extension Petname {
 
 extension Slashlink {
     func toPetname() -> Petname? {
-        guard let petnamePart = self.petnamePart else {
-            return nil
-        }
-        return Petname(uncheckedRawString: petnamePart)
+        self.petname
     }
 }
 

--- a/xcode/Subconscious/Shared/Models/Slashlink.swift
+++ b/xcode/Subconscious/Shared/Models/Slashlink.swift
@@ -50,6 +50,9 @@ public struct Slashlink:
     // The normalized markup form of the slashlink
     public var markup: String { description }
 
+    // The non-normalized markup form of the slashlink
+    public var verbatimMarkup: String { verbatim }
+
     public init(
         petname: Petname? = nil,
         slug: Slug

--- a/xcode/Subconscious/Shared/Models/Slashlink.swift
+++ b/xcode/Subconscious/Shared/Models/Slashlink.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Represents a fully-qualified slashlink with petname and slug.
-struct Slashlink:
+public struct Slashlink:
     Hashable,
     Equatable,
     Identifiable,
@@ -18,27 +18,27 @@ struct Slashlink:
 {
     private static let slashlinkRegex = /(\@(?<petname>[\w\d\-]+))?\/(?<slug>(?:[\w\d\-]+)(?:\/[\w\d\-]+)*)/
     
-    static func < (lhs: Slashlink, rhs: Slashlink) -> Bool {
+    public static func < (lhs: Slashlink, rhs: Slashlink) -> Bool {
         lhs.id < rhs.id
     }
     
-    static func == (lhs: Self, rhs: Self) -> Bool {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.id == rhs.id
     }
     
-    let description: String
-    let verbatim: String
+    public let description: String
+    public let verbatim: String
     let petnamePart: String?
     let slugPart: String
     
-    var id: String { description }
+    public var id: String { description }
     
     static let profileSlug = Slug("_profile_")!
     
     // The normalized markup form of the slashlink
-    var markup: String { description }
+    public var markup: String { description }
 
-    init(
+    public init(
         petname: Petname? = nil,
         slug: Slug
     ) {
@@ -49,7 +49,7 @@ struct Slashlink:
         self.verbatim = description
     }
     
-    init?(_ description: String) {
+    public init?(_ description: String) {
         guard
             let match = description.wholeMatch(of: Self.slashlinkRegex)
         else {

--- a/xcode/Subconscious/Shared/Models/Slug.swift
+++ b/xcode/Subconscious/Shared/Models/Slug.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A type representing a valid slug (`/slug`)
-struct Slug:
+public struct Slug:
     Hashable,
     Equatable,
     Identifiable,
@@ -18,11 +18,11 @@ struct Slug:
 {
     private static let slugRegex = /([\w\d\-]+)(\/[\w\d\-]+)*/
 
-    static func < (lhs: Slug, rhs: Slug) -> Bool {
+    public static func < (lhs: Slug, rhs: Slug) -> Bool {
         lhs.id < rhs.id
     }
     
-    static func == (lhs: Self, rhs: Self) -> Bool {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.id == rhs.id
     }
     
@@ -49,19 +49,19 @@ struct Slug:
         return formatted
     }
     
-    let description: String
-    let verbatim: String
+    public let description: String
+    public let verbatim: String
 
-    var id: String { description }
+    public var id: String { description }
 
-    var markup: String {
+    public var markup: String {
         "/\(verbatim)"
     }
     
     /// Losslessly create a slug from a string.
     /// This requires that the string already be formatted like a
     /// valid slug.
-    init?(_ description: String) {
+    public init?(_ description: String) {
         guard description.wholeMatch(of: Self.slugRegex) != nil else {
             return nil
         }
@@ -71,7 +71,7 @@ struct Slug:
     
     /// Convert a string into a slug.
     /// This will sanitize the string as best it can to create a valid slug.
-    init?(formatting string: String) {
+    public init?(formatting string: String) {
         self.init(Self.format(string))
     }
 
@@ -79,7 +79,7 @@ struct Slug:
     ///
     /// Note this is lossless, so it will only support URLs that contain
     /// valid slug strings as paths.
-    init?(url: URL, relativeTo base: URL) {
+    public init?(url: URL, relativeTo base: URL) {
         // NOTE: it is extremely important that we call relativizingPath
         // WITHOUT calling `url.deletePathExtension()`.
         // This is because `url.relativizingPath()` calls

--- a/xcode/Subconscious/Shared/Models/Slug.swift
+++ b/xcode/Subconscious/Shared/Models/Slug.swift
@@ -55,6 +55,10 @@ public struct Slug:
     public var id: String { description }
 
     public var markup: String {
+        "/\(description)"
+    }
+    
+    public var verbatimMarkup: String {
         "/\(verbatim)"
     }
     

--- a/xcode/Subconscious/Shared/Models/StoryCombo.swift
+++ b/xcode/Subconscious/Shared/Models/StoryCombo.swift
@@ -55,8 +55,8 @@ extension MemoEntry {
                 body: """
                 \(story.prompt)
                 
-                \(x.address.slug.toSlashlink().description)
-                \(y.address.slug.toSlashlink().description)
+                \(x.address.slug.toSlashlink().verbatim)
+                \(y.address.slug.toSlashlink().verbatim)
                 """
             )
         )

--- a/xcode/Subconscious/Shared/Models/StoryCombo.swift
+++ b/xcode/Subconscious/Shared/Models/StoryCombo.swift
@@ -55,8 +55,8 @@ extension MemoEntry {
                 body: """
                 \(story.prompt)
                 
-                \(x.address.slug.toSlashlink().verbatim)
-                \(y.address.slug.toSlashlink().verbatim)
+                \(x.address.slug.toSlashlink().description)
+                \(y.address.slug.toSlashlink().description)
                 """
             )
         )

--- a/xcode/Subconscious/Shared/Services/AddressBookService.swift
+++ b/xcode/Subconscious/Shared/Services/AddressBookService.swift
@@ -106,7 +106,7 @@ class AddressBookService {
     }
     
     func getPetname(petname: Petname) throws -> Did? {
-        return try Did(noosphere.getPetname(petname: petname.verbatim))
+        return try Did(noosphere.getPetname(petname: petname))
     }
 
     func getPetnameAsync(petname: Petname) -> AnyPublisher<Did?, Error> {
@@ -116,7 +116,7 @@ class AddressBookService {
     }
 
     func setPetname(did: Did, petname: Petname) throws {
-        try noosphere.setPetname(did: did.did, petname: petname.verbatim)
+        try noosphere.setPetname(did: did.did, petname: petname)
     }
 
     func setPetnameAsync(did: Did, petname: Petname) -> AnyPublisher<Void, Error> {
@@ -126,7 +126,7 @@ class AddressBookService {
     }
 
     func unsetPetname(petname: Petname) throws {
-        try noosphere.unsetPetname(petname: petname.verbatim)
+        try noosphere.unsetPetname(petname: petname)
     }
 
     func unsetPetnameAsync(petname: Petname) -> AnyPublisher<Void, Error> {
@@ -137,8 +137,6 @@ class AddressBookService {
 
     func listPetnames() throws -> [Petname] {
         return try noosphere.listPetnames()
-            .map { name in Petname(name) }
-            .compactMap { $0 }
     }
 
     func listPetnamesAsync() -> AnyPublisher<[Petname], Error> {
@@ -147,11 +145,11 @@ class AddressBookService {
         }
     }
 
-    func getPetnameChanges(sinceCid: String) throws -> [String] {
+    func getPetnameChanges(sinceCid: String) throws -> [Petname] {
         return try noosphere.getPetnameChanges(sinceCid: sinceCid)
     }
       
-    func getPetnameChangesAsync(sinceCid: String) -> AnyPublisher<[String], Error> {
+    func getPetnameChangesAsync(sinceCid: String) -> AnyPublisher<[Petname], Error> {
         CombineUtilities.async(qos: .utility) {
             return try self.getPetnameChanges(sinceCid: sinceCid)
         }

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -163,13 +163,13 @@ final class NoosphereService: SphereProtocol, SphereIdentityProtocol {
         }
     }
     
-    func getFileVersion(slashlink: String) -> String? {
+    func getFileVersion(slashlink: Slashlink) -> String? {
         queue.sync {
             try? self.sphere().getFileVersion(slashlink: slashlink)
         }
     }
     
-    func readHeaderValueFirst(slashlink: String, name: String) -> String? {
+    func readHeaderValueFirst(slashlink: Slashlink, name: String) -> String? {
         queue.sync {
             try? self.sphere().readHeaderValueFirst(
                 slashlink: slashlink,
@@ -178,7 +178,7 @@ final class NoosphereService: SphereProtocol, SphereIdentityProtocol {
         }
     }
     
-    func readHeaderNames(slashlink: String) -> [String] {
+    func readHeaderNames(slashlink: Slashlink) -> [String] {
         queue.sync {
             guard let names = try? self.sphere().readHeaderNames(
                 slashlink: slashlink
@@ -189,14 +189,14 @@ final class NoosphereService: SphereProtocol, SphereIdentityProtocol {
         }
     }
     
-    func read(slashlink: String) throws -> MemoData {
+    func read(slashlink: Slashlink) throws -> MemoData {
         try queue.sync {
             try self.sphere().read(slashlink: slashlink)
         }
     }
     
     func write(
-        slug: String,
+        slug: Slug,
         contentType: String,
         additionalHeaders: [Header],
         body: Data
@@ -211,7 +211,7 @@ final class NoosphereService: SphereProtocol, SphereIdentityProtocol {
         }
     }
     
-    func remove(slug: String) throws {
+    func remove(slug: Slug) throws {
         try queue.sync {
             try self.sphere().remove(slug: slug)
         }
@@ -223,7 +223,7 @@ final class NoosphereService: SphereProtocol, SphereIdentityProtocol {
         }
     }
     
-    func list() throws -> [String] {
+    func list() throws -> [Slug] {
         try queue.sync {
             try self.sphere().list()
         }
@@ -235,49 +235,49 @@ final class NoosphereService: SphereProtocol, SphereIdentityProtocol {
         }
     }
     
-    func changes(_ since: String?) throws -> [String] {
+    func changes(_ since: String?) throws -> [Slug] {
         try queue.sync {
             try self.sphere().changes(since)
         }
     }
     
-    func getPetname(petname: String) throws -> String {
+    func getPetname(petname: Petname) throws -> String {
         try queue.sync {
             try self.sphere().getPetname(petname: petname)
         }
     }
     
-    func setPetname(did: String, petname: String) throws {
+    func setPetname(did: String, petname: Petname) throws {
         try queue.sync {
             try self.sphere().setPetname(did: did, petname: petname)
         }
     }
     
-    func unsetPetname(petname: String) throws {
+    func unsetPetname(petname: Petname) throws {
         try queue.sync {
             try self.sphere().unsetPetname(petname: petname)
         }
     }
     
-    func resolvePetname(petname: String) throws -> String {
+    func resolvePetname(petname: Petname) throws -> String {
         try queue.sync {
             try self.sphere().resolvePetname(petname: petname)
         }
     }
     
-    func listPetnames() throws -> [String] {
+    func listPetnames() throws -> [Petname] {
         try queue.sync {
             try self.sphere().listPetnames()
         }
     }
     
-    func getPetnameChanges(sinceCid: String) throws -> [String] {
+    func getPetnameChanges(sinceCid: String) throws -> [Petname] {
         try queue.sync {
             try self.sphere().getPetnameChanges(sinceCid: sinceCid)
         }
     }
 
-    func traverse(petname: String) throws -> Sphere {
+    func traverse(petname: Petname) throws -> Sphere {
         try queue.sync {
             try self.sphere().traverse(petname: petname)
         }

--- a/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
@@ -44,6 +44,18 @@ public protocol SphereProtocol {
     
     func changes(_ since: String?) throws -> [Slug]
     
+    func getPetname(petname: Petname) throws -> String
+    
+    func setPetname(did: String, petname: Petname) throws
+    
+    func unsetPetname(petname: Petname) throws
+    
+    func resolvePetname(petname: Petname) throws -> String
+    
+    func listPetnames() throws -> [Petname]
+    
+    func getPetnameChanges(sinceCid: String) throws -> [Petname]
+    
     /// Attempt to retrieve the sphere of a recorded petname, this can be chained to walk
     /// over multiple spheres:
     ///
@@ -371,7 +383,6 @@ public final class Sphere: SphereProtocol {
             )
         })
     }
-    
     
     public func traverse(petname: Petname) throws -> Sphere {
         let identity = try self.getPetname(petname: petname)

--- a/xcode/Subconscious/SubconsciousTests/Tests_NoosphereService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_NoosphereService.swift
@@ -32,28 +32,31 @@ final class Tests_NoosphereService: XCTestCase {
         let bobReceipt = try noosphere.createSphere(ownerKeyName: "bob")
         let aliceReceipt = try noosphere.createSphere(ownerKeyName: "alice")
         
+        let bob = Petname("bob")!
+        let alice = Petname("alice")!
+
         // Put bob in alice's address book
         noosphere.resetSphere(aliceReceipt.identity)
-        try noosphere.setPetname(did: bobReceipt.identity, petname: "bob")
+        try noosphere.setPetname(did: bobReceipt.identity, petname: bob)
         try noosphere.save()
         
-        let bobDid = try noosphere.getPetname(petname: "bob")
+        let bobDid = try noosphere.getPetname(petname: bob)
         XCTAssertEqual(bobDid, bobReceipt.identity)
         
         // Put alice in bob's address book & set bob as default sphere
         noosphere.resetSphere(bobReceipt.identity)
-        try noosphere.setPetname(did: aliceReceipt.identity, petname: "alice")
+        try noosphere.setPetname(did: aliceReceipt.identity, petname: alice)
         try noosphere.save()
         
-        let aliceDid = try noosphere.getPetname(petname: "alice")
+        let aliceDid = try noosphere.getPetname(petname: alice)
         XCTAssertEqual(aliceDid, aliceReceipt.identity)
         
         
-        let result = try noosphere.sync()
+        _ = try noosphere.sync()
         // This should loop back around to bob
         let destinationSphere = try noosphere
-            .traverse(petname: "alice")
-            .traverse(petname: "bob")
+            .traverse(petname: alice)
+            .traverse(petname: bob)
 
         // Clear out Noosphere and Sphere instance
         noosphere.reset()
@@ -79,7 +82,7 @@ final class Tests_NoosphereService: XCTestCase {
         
         let body = try "Test content".toData().unwrap()
         try noosphere.write(
-            slug: "a",
+            slug: Slug("a")!,
             contentType: "text/subtext",
             additionalHeaders: [],
             body: body
@@ -88,13 +91,13 @@ final class Tests_NoosphereService: XCTestCase {
         XCTAssertNotEqual(versionA, versionB)
 
         try noosphere.write(
-            slug: "b",
+            slug: Slug("b")!,
             contentType: "text/subtext",
             additionalHeaders: [],
             body: body
         )
         try noosphere.write(
-            slug: "c",
+            slug: Slug("c")!,
             contentType: "text/subtext",
             additionalHeaders: [],
             body: body

--- a/xcode/Subconscious/SubconsciousTests/Tests_Petname.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Petname.swift
@@ -60,7 +60,8 @@ class Tests_Petname: XCTestCase {
     
     func testMarkup() throws {
         let petname = Petname("VALID-petname")
-        XCTAssertEqual(petname?.markup, "@VALID-petname")
+        XCTAssertEqual(petname?.markup, "@valid-petname")
+        XCTAssertEqual(petname?.verbatimMarkup, "@VALID-petname")
     }
     
     func testFormatStripsInvalidCharacters() throws {

--- a/xcode/Subconscious/SubconsciousTests/Tests_Slashlink.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Slashlink.swift
@@ -46,8 +46,8 @@ final class Tests_Slashlink: XCTestCase {
             return
         }
         XCTAssertEqual(slashlink.description, "/valid-slashlink")
-        XCTAssertEqual(slashlink.slugPart, "valid-slashlink")
-        XCTAssertNil(slashlink.petnamePart)
+        XCTAssertEqual(slashlink.slug.description, "valid-slashlink")
+        XCTAssertNil(slashlink.petname)
     }
     
     func testFull() throws {
@@ -56,8 +56,8 @@ final class Tests_Slashlink: XCTestCase {
             return
         }
         XCTAssertEqual(slashlink.description, "@valid-petname/valid-slashlink")
-        XCTAssertEqual(slashlink.petnamePart, "valid-petname")
-        XCTAssertEqual(slashlink.slugPart, "valid-slashlink")
+        XCTAssertEqual(slashlink.petname?.description, "valid-petname")
+        XCTAssertEqual(slashlink.slug.description, "valid-slashlink")
     }
     
     func testUnicode() throws {
@@ -66,8 +66,8 @@ final class Tests_Slashlink: XCTestCase {
             return
         }
         XCTAssertEqual(slashlink.description, "@ⴙvalid-petname/valid-slashlink")
-        XCTAssertEqual(slashlink.petnamePart, "ⴙvalid-petname")
-        XCTAssertEqual(slashlink.slugPart, "valid-slashlink")
+        XCTAssertEqual(slashlink.petname?.description, "ⴙvalid-petname")
+        XCTAssertEqual(slashlink.slug.description, "valid-slashlink")
     }
     
     func testUppercase() throws {
@@ -77,8 +77,8 @@ final class Tests_Slashlink: XCTestCase {
         }
         XCTAssertEqual(slashlink.description, "@valid-petname/valid-slashlink")
         XCTAssertEqual(slashlink.verbatim, "@VALID-PETNAME/valid-slashlink")
-        XCTAssertEqual(slashlink.petnamePart, "VALID-PETNAME")
-        XCTAssertEqual(slashlink.slugPart, "valid-slashlink")
+        XCTAssertEqual(slashlink.petname?.verbatim, "VALID-PETNAME")
+        XCTAssertEqual(slashlink.slug.description, "valid-slashlink")
     }
     
     func testDeepSlashlink() throws {
@@ -87,7 +87,7 @@ final class Tests_Slashlink: XCTestCase {
             XCTFail("Failed to parse deep slashlink")
             return
         }
-        XCTAssertEqual(slashlink.slugPart, "deep/slashlinks/supported")
+        XCTAssertEqual(slashlink.slug.description, "deep/slashlinks/supported")
     }
     
     func testInvalidDoubleSlash() throws {
@@ -135,8 +135,8 @@ final class Tests_Slashlink: XCTestCase {
         let slashlink = Slashlink(petname: petname, slug: slug)
         XCTAssertEqual(slashlink.description, "@foo/bar-baz")
         XCTAssertEqual(slashlink.verbatim, "@FOO/BAR-baz")
-        XCTAssertEqual(slashlink.petnamePart, "FOO")
-        XCTAssertEqual(slashlink.slugPart, "BAR-baz")
+        XCTAssertEqual(slashlink.petname?.verbatim, "FOO")
+        XCTAssertEqual(slashlink.slug.verbatim, "BAR-baz")
     }
 
     func testsInitFromSlug() throws {

--- a/xcode/Subconscious/SubconsciousTests/Tests_Slug.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Slug.swift
@@ -51,7 +51,8 @@ class Tests_Slug: XCTestCase {
 
     func testMarkup() throws {
         let slug = Slug("VALID-slug")
-        XCTAssertEqual(slug?.markup, "/VALID-slug")
+        XCTAssertEqual(slug?.markup, "/valid-slug")
+        XCTAssertEqual(slug?.verbatimMarkup, "/VALID-slug")
     }
 
     func testSlugFromPathlike() throws {

--- a/xcode/Subconscious/SubconsciousTests/Tests_Sphere.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Sphere.swift
@@ -45,12 +45,12 @@ final class Tests_Sphere: XCTestCase {
             )
             
             try sphere.write(
-                slug: "foo",
+                slug: Slug("foo")!,
                 contentType: "text/subtext",
                 body: "Test".toData(encoding: .utf8)!
             )
             _ = try sphere.save()
-            let memo = try sphere.read(slashlink: "/foo")
+            let memo = try sphere.read(slashlink: Slashlink("/foo")!)
             XCTAssertEqual(memo.contentType, "text/subtext")
             let content = memo.body.toString()
             XCTAssertEqual(content, "Test")
@@ -62,7 +62,7 @@ final class Tests_Sphere: XCTestCase {
                 noosphere: noosphere,
                 identity: sphereReceipt.identity
             )
-            let memo = try sphere.read(slashlink: "/foo")
+            let memo = try sphere.read(slashlink: Slashlink("/foo")!)
             XCTAssertEqual(memo.contentType, "text/subtext")
         }
     }
@@ -90,7 +90,7 @@ final class Tests_Sphere: XCTestCase {
         
         let then = Date.distantPast.ISO8601Format()
         try sphere.write(
-            slug: "foo",
+            slug: Slug("foo")!,
             contentType: "text/subtext",
             additionalHeaders: [
                 Header(name: "Title", value: "Foo"),
@@ -101,7 +101,7 @@ final class Tests_Sphere: XCTestCase {
             body: "Test".toData(encoding: .utf8)!
         )
         _ = try sphere.save()
-        let memo = try sphere.read(slashlink: "/foo")
+        let memo = try sphere.read(slashlink: Slashlink("/foo")!)
         XCTAssertEqual(memo.contentType, "text/subtext")
         XCTAssertEqual(memo.body.toString(), "Test")
         
@@ -142,17 +142,17 @@ final class Tests_Sphere: XCTestCase {
         let body = "Test".toData(encoding: .utf8)!
         
         try sphere.write(
-            slug: "foo",
+            slug: Slug("foo")!,
             contentType: "text/subtext",
             body: body
         )
         try sphere.write(
-            slug: "bar",
+            slug: Slug("bar")!,
             contentType: "text/subtext",
             body: body
         )
         try sphere.write(
-            slug: "baz",
+            slug: Slug("baz")!,
             contentType: "text/subtext",
             body: body
         )
@@ -167,9 +167,9 @@ final class Tests_Sphere: XCTestCase {
         _ = try sphere.save()
         
         let slugsB = try sphere.list()
-        XCTAssertTrue(slugsB.contains("foo"))
-        XCTAssertTrue(slugsB.contains("bar"))
-        XCTAssertTrue(slugsB.contains("baz"))
+        XCTAssertTrue(slugsB.contains(Slug("foo")!))
+        XCTAssertTrue(slugsB.contains(Slug("bar")!))
+        XCTAssertTrue(slugsB.contains(Slug("baz")!))
     }
     
     func testChanges() throws {
@@ -196,7 +196,7 @@ final class Tests_Sphere: XCTestCase {
         let body = "Test".toData(encoding: .utf8)!
         
         try sphere.write(
-            slug: "foo",
+            slug: Slug("foo")!,
             contentType: "text/subtext",
             body: body
         )
@@ -204,15 +204,15 @@ final class Tests_Sphere: XCTestCase {
         let a = try sphere.save()
         let changesA = try sphere.changes()
         XCTAssertEqual(changesA.count, 1)
-        XCTAssertTrue(changesA.contains("foo"))
+        XCTAssertTrue(changesA.contains(Slug("foo")!))
         
         try sphere.write(
-            slug: "bar",
+            slug: Slug("bar")!,
             contentType: "text/subtext",
             body: body
         )
         try sphere.write(
-            slug: "baz",
+            slug: Slug("baz")!,
             contentType: "text/subtext",
             body: body
         )
@@ -220,12 +220,12 @@ final class Tests_Sphere: XCTestCase {
         
         let changesB = try sphere.changes(a)
         XCTAssertEqual(changesB.count, 2)
-        XCTAssertTrue(changesB.contains("bar"))
-        XCTAssertTrue(changesB.contains("baz"))
-        XCTAssertFalse(changesB.contains("foo"))
+        XCTAssertTrue(changesB.contains(Slug("bar")!))
+        XCTAssertTrue(changesB.contains(Slug("baz")!))
+        XCTAssertFalse(changesB.contains(Slug("foo")!))
         
         try sphere.write(
-            slug: "bing",
+            slug: Slug("bing")!,
             contentType: "text/subtext",
             body: body
         )
@@ -233,9 +233,9 @@ final class Tests_Sphere: XCTestCase {
         
         let changesC = try sphere.changes(b)
         XCTAssertEqual(changesC.count, 1)
-        XCTAssertTrue(changesC.contains("bing"))
-        XCTAssertFalse(changesC.contains("baz"))
-        XCTAssertFalse(changesC.contains("foo"))
+        XCTAssertTrue(changesC.contains(Slug("bing")!))
+        XCTAssertFalse(changesC.contains(Slug("baz")!))
+        XCTAssertFalse(changesC.contains(Slug("foo")!))
     }
     
     func testRemove() throws {
@@ -262,27 +262,27 @@ final class Tests_Sphere: XCTestCase {
         let body = "Test".toData(encoding: .utf8)!
         
         try sphere.write(
-            slug: "foo",
+            slug: Slug("foo")!,
             contentType: "text/subtext",
             body: body
         )
         try sphere.write(
-            slug: "bar",
+            slug: Slug("bar")!,
             contentType: "text/subtext",
             body: body
         )
         
         _ = try sphere.save()
         
-        try sphere.remove(slug: "foo")
+        try sphere.remove(slug: Slug("foo")!)
         
         _ = try sphere.save()
         
         let slugs = try sphere.list()
         
         XCTAssertEqual(slugs.count, 1)
-        XCTAssertTrue(slugs.contains("bar"))
-        XCTAssertFalse(slugs.contains("foo"))
+        XCTAssertTrue(slugs.contains(Slug("bar")!))
+        XCTAssertFalse(slugs.contains(Slug("foo")!))
     }
     
     func testSaveVersion() throws {
@@ -309,7 +309,7 @@ final class Tests_Sphere: XCTestCase {
         let versionA = try sphere.version()
         
         try sphere.write(
-            slug: "foo",
+            slug: Slug("foo")!,
             contentType: "text/subtext",
             body: "Test".toData(encoding: .utf8)!
         )
@@ -357,14 +357,14 @@ final class Tests_Sphere: XCTestCase {
         _ = try? sphere.sync()
         
         try sphere.write(
-            slug: "foo",
+            slug: Slug("foo")!,
             contentType: "text/subtext",
             body: "Test".toData(encoding: .utf8)!
         )
         
         try sphere.save()
         
-        let foo = try sphere.read(slashlink: "/foo")
+        let foo = try sphere.read(slashlink: Slashlink("/foo")!)
         
         // Should fail
         _ = try? sphere.sync()
@@ -407,9 +407,9 @@ final class Tests_Sphere: XCTestCase {
             
             let body = try "Test content".toData().unwrap()
             let contentType = "text/subtext"
-            try sphere.write(slug: "a", contentType: contentType, body: body)
-            try sphere.write(slug: "b", contentType: contentType, body: body)
-            try sphere.write(slug: "c", contentType: contentType, body: body)
+            try sphere.write(slug: Slug("a")!, contentType: contentType, body: body)
+            try sphere.write(slug: Slug("b")!, contentType: contentType, body: body)
+            try sphere.write(slug: Slug("c")!, contentType: contentType, body: body)
             let version = try sphere.save()
             endVersion = try sphere.version()
             XCTAssertEqual(version, endVersion)
@@ -459,12 +459,12 @@ final class Tests_Sphere: XCTestCase {
 
         let body = try "Test content".toData().unwrap()
         let contentType = "text/subtext"
-        try sphere.write(slug: "a", contentType: contentType, body: body)
+        try sphere.write(slug: Slug("a")!, contentType: contentType, body: body)
 
         let versionA1 = try sphere.save()
 
-        try sphere.write(slug: "b", contentType: contentType, body: body)
-        try sphere.write(slug: "c", contentType: contentType, body: body)
+        try sphere.write(slug: Slug("b")!, contentType: contentType, body: body)
+        try sphere.write(slug: Slug("c")!, contentType: contentType, body: body)
         let versionA2 = try sphere.save()
 
         let versionAN = try sphere.version()


### PR DESCRIPTION
This refactor smooths a few sharp edges I encountered while working on #486. Mostly it makes the Noosphere APIs strongly typed instead of stringly typed.

- `Slashlink` now holds an actual `Petname?` and `Slug` instead of a string `petnamePart` and `slugPart`
- SphereProtocol APIs now receive and return actual `Slashlink`, `Slug`, and `Petname` instead of `String`
- Update `SphereProtocol` to include petname methods.
- `Sphere.read(slashlink:)` now automatically handles traversal if the slashlink contains a Petname.
    -`slashlink:` is now a proper `Slashlink` enabling us to inspect its structure and choose to traverse or not. This was the motivation for these changes.