### PR TITLE
Allow @name-only Slashlinks and dotted Petnames

### DIFF
--- a/xcode/Subconscious/Shared/Models/Petname.swift
+++ b/xcode/Subconscious/Shared/Models/Petname.swift
@@ -16,7 +16,7 @@ public struct Petname:
     Codable,
     LosslessStringConvertible
 {
-    private static let petnameRegex = /[\w\d\-]+/
+    private static let petnameRegex = /[\w\d\-\.]+/
     
     public static func < (lhs: Self, rhs: Self) -> Bool {
         lhs.id < rhs.id
@@ -66,6 +66,11 @@ public struct Petname:
         }
         self.description = description.lowercased()
         self.verbatim = description
+    }
+    
+    public init?(petnames: [Petname]) {
+        let petnamePath = petnames.map({ s in s.verbatim }).joined(separator: ".")
+        self.init(petnamePath)
     }
     
     /// Convert a string into a petname.

--- a/xcode/Subconscious/Shared/Models/Petname.swift
+++ b/xcode/Subconscious/Shared/Models/Petname.swift
@@ -16,7 +16,7 @@ public struct Petname:
     Codable,
     LosslessStringConvertible
 {
-    private static let petnameRegex = /[\w\d\-\.]+/
+    private static let petnameRegex = /([\w\d\-]+)(\.[\w\d\-]+)*/
     
     public static func < (lhs: Self, rhs: Self) -> Bool {
         lhs.id < rhs.id

--- a/xcode/Subconscious/Shared/Models/Petname.swift
+++ b/xcode/Subconscious/Shared/Models/Petname.swift
@@ -68,6 +68,8 @@ public struct Petname:
         self.verbatim = description
     }
     
+    /// Join a list of petnames into a dotted string, i.e. [foo, bar, baz] -> foo.bar.baz
+    /// Names are joined in order of their appearance in `petnames`
     public init?(petnames: [Petname]) {
         let petnamePath = petnames.map({ s in s.verbatim }).joined(separator: ".")
         self.init(petnamePath)

--- a/xcode/Subconscious/Shared/Models/Slashlink.swift
+++ b/xcode/Subconscious/Shared/Models/Slashlink.swift
@@ -78,15 +78,15 @@ public struct Slashlink:
             Petname(uncheckedRawString: substring.toString())
         })
         
-        if let slug = slug {
+        switch (petname, slug) {
+        case (.some(let petname), .some(let slug)):
             self.init(petname: petname, slug: slug)
-        } else {
-            guard let petname = petname else {
-                return nil
-            }
-            
-            // Petname only
+        case (.none, .some(let slug)):
+            self.init(slug: slug)
+        case (.some(let petname), .none):
             self.init(petname: petname, slug: Self.profileSlug)
+        case (_, _):
+            return nil
         }
     }
     

--- a/xcode/Subconscious/Shared/Models/Slashlink.swift
+++ b/xcode/Subconscious/Shared/Models/Slashlink.swift
@@ -16,7 +16,7 @@ public struct Slashlink:
     Codable,
     LosslessStringConvertible
 {
-    private static let slashlinkRegex = /(\@(?<petname>[\w\d\-]+))?\/(?<slug>(?:[\w\d\-]+)(?:\/[\w\d\-]+)*)/
+    private static let slashlinkRegex = /(\@(?<petname>[\w\d\-\.]+))?(\/(?<slug>(?:[\w\d\-]+)(?:\/[\w\d\-]+)*))?/
     
     public static func < (lhs: Slashlink, rhs: Slashlink) -> Bool {
         lhs.id < rhs.id
@@ -67,11 +67,27 @@ public struct Slashlink:
         else {
             return nil
         }
-        let slug = Slug(uncheckedRawString: match.slug.toString())
+        
+        // There are four cases: petname-only, slug-only, petname+slug and empty.
+        // All are valid constructions except for empty.
+        // Petname only will use `profileSlug` as the slug.
+        let slug = match.slug.map({ substring in
+            Slug(uncheckedRawString: substring.toString()
+        )})
         let petname = match.petname.map({ substring in
             Petname(uncheckedRawString: substring.toString())
         })
-        self.init(petname: petname, slug: slug)
+        
+        if let slug = slug {
+            self.init(petname: petname, slug: slug)
+        } else {
+            guard let petname = petname else {
+                return nil
+            }
+            
+            // Petname only
+            self.init(petname: petname, slug: Self.profileSlug)
+        }
     }
     
     /// Convenience initializer that creates a link to `@user/_profile_`

--- a/xcode/Subconscious/Shared/Models/Slashlink.swift
+++ b/xcode/Subconscious/Shared/Models/Slashlink.swift
@@ -70,7 +70,7 @@ public struct Slashlink:
         
         // There are four cases: petname-only, slug-only, petname+slug and empty.
         // All are valid constructions except for empty.
-        // Petname only will use `profileSlug` as the slug.
+        // Petname-only will use `profileSlug` as the slug.
         let slug = match.slug.map({ substring in
             Slug(uncheckedRawString: substring.toString()
         )})

--- a/xcode/Subconscious/Shared/Models/Slashlink.swift
+++ b/xcode/Subconscious/Shared/Models/Slashlink.swift
@@ -16,7 +16,7 @@ public struct Slashlink:
     Codable,
     LosslessStringConvertible
 {
-    private static let slashlinkRegex = /(\@(?<petname>[\w\d\-\.]+))?(\/(?<slug>(?:[\w\d\-]+)(?:\/[\w\d\-]+)*))?/
+    private static let slashlinkRegex = /(\@(?<petname>(?:[\w\d\-]+)(?:\.[\w\d\-]+)*))?(\/(?<slug>(?:[\w\d\-]+)(?:\/[\w\d\-]+)*))?/
     
     public static func < (lhs: Slashlink, rhs: Slashlink) -> Bool {
         lhs.id < rhs.id

--- a/xcode/Subconscious/SubconsciousTests/Tests_Petname.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Petname.swift
@@ -10,10 +10,15 @@ import XCTest
 
 class Tests_Petname: XCTestCase {
     func testValid() throws {
+        XCTAssertNotNil(Petname("bob"))
         XCTAssertNotNil(Petname("valid-petname"))
         XCTAssertNotNil(Petname("PETNAME"))
         XCTAssertNotNil(Petname("PET_NAME"))
         XCTAssertNotNil(Petname("-_-"))
+        XCTAssertNotNil(Petname("alice.bob"))
+        XCTAssertNotNil(Petname("dan.charlie.bob.alice"))
+        XCTAssertNotNil(Petname("bob-foo.alice-foo"))
+        XCTAssertNotNil(Petname("bob_foo.alice_foo"))
     }
     
     func testNotValid() throws {
@@ -24,6 +29,10 @@ class Tests_Petname: XCTestCase {
         XCTAssertNil(Petname("invalid@petname"))
         XCTAssertNil(Petname("invalid-petname "))
         XCTAssertNil(Petname("invalid😈petname"))
+        XCTAssertNil(Petname("eve...alice"))
+        XCTAssertNil(Petname("eve.alice..bob"))
+        XCTAssertNil(Petname(".eve.alice"))
+        XCTAssertNil(Petname("alice.eve."))
     }
     
     func testLosslessStringConvertable() throws {

--- a/xcode/Subconscious/SubconsciousTests/Tests_Slashlink.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Slashlink.swift
@@ -15,7 +15,14 @@ final class Tests_Slashlink: XCTestCase {
         XCTAssertNotNil(Slashlink("@__valid-petname__/__foo__"))
         XCTAssertNotNil(Slashlink("@PETNAME/foo"))
         XCTAssertNotNil(Slashlink("/bar"))
+        XCTAssertNotNil(Slashlink("/bar/baz/foo"))
         XCTAssertNotNil(Slashlink("@-_-/-_-"))
+        XCTAssertNotNil(Slashlink("@bob"))
+        XCTAssertNotNil(Slashlink("@alice.bob"))
+        XCTAssertNotNil(Slashlink("@dan.charlie.bob.alice"))
+        XCTAssertNotNil(Slashlink("@bob-foo.alice-foo"))
+        XCTAssertNotNil(Slashlink("@bob_foo.alice_foo"))
+        XCTAssertNotNil(Slashlink("@bob_foo.alice_foo/foo/bar/baz"))
     }
     
     func testNotValid() throws {
@@ -38,6 +45,15 @@ final class Tests_Slashlink: XCTestCase {
         XCTAssertNil(Slashlink("/special//slashlink"))
         XCTAssertNil(Slashlink("/invalid😈petname"))
         XCTAssertNil(Slashlink("@invalid😈petname/foo"))
+        XCTAssertNil(Slashlink("@eve...alice"))
+        XCTAssertNil(Slashlink("@.eve.alice"))
+        XCTAssertNil(Slashlink("@alice.eve."))
+        XCTAssertNil(Slashlink("@@eve.alice"))
+        XCTAssertNil(Slashlink("@eve@alice"))
+        XCTAssertNil(Slashlink("@eve//foo"))
+        XCTAssertNil(Slashlink("@eve..alice/foo"))
+        XCTAssertNil(Slashlink("@eve.evelyn/foo//bar"))
+        XCTAssertNil(Slashlink("@eve.evelyn/foo/@bar"))
     }
     
     func testSlugOnly() throws {

--- a/xcode/Subconscious/SubconsciousTests/Tests_Slashlink.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Slashlink.swift
@@ -95,8 +95,12 @@ final class Tests_Slashlink: XCTestCase {
         XCTAssertNil(Slashlink("@bork/invalid//deep/slashlink"))
     }
 
-    func testPetnameOnlyInvalid() throws {
-        XCTAssertNil(Slashlink("@only-petname-should-fail"))
+    func testPetnameOnlyImplicitlyPointsToProfile() throws {
+        guard let slashlink = Slashlink("@only-petname-points-to-profile") else {
+            XCTFail("Failed to parse slashlink")
+            return
+        }
+        XCTAssertEqual(slashlink.description, "@only-petname-points-to-profile/\(Slashlink.profileSlug.description)")
     }
     
     func testToPetname() throws {


### PR DESCRIPTION
- Allow dotted petnames
- Allow petname-only constructor for a Slashlink (i.e. @ben)

These changes render all forms of slashlink as clickable in the TextView.

```
/test
@ben
@ben/test/test/test
@ben.foo.bar/baz/qux
```