### PR TITLE
Read initial UserDefaultsProperty value from UserDefaults

### DIFF
--- a/xcode/Subconscious/Shared/Library/UserDefaultsProperty.swift
+++ b/xcode/Subconscious/Shared/Library/UserDefaultsProperty.swift
@@ -7,22 +7,36 @@
 import Combine
 import Foundation
 
-/// Creates a type-safe getter and setter for a UserDefaults key.
-/// Properties decorated with `@UserDefaultsProperty` will get and set their
-/// value from UserDefaults.
+/// Property wrapper that creates a type-safe getter/setter for a
+/// UserDefaults key.
 ///
-/// The property's default value will be used if no value is found in the
-/// UserDefaults for that key.
+/// Properties decorated with `@UserDefaultsProperty` will get and set their
+/// value from UserDefaults. The property's default value will be used if
+/// no value is found in the UserDefaults for that key.
 ///
 /// You can subscribe to changes in this default via the projected value, using
 /// `$name`, where name is the name of your property. Projected value is a
 /// publisher that emits any time the wrapped value changes.
 @propertyWrapper struct UserDefaultsProperty<Value: Equatable> {
+    /// Create a type-safe accessor for a UserDefaults key.
+    private struct UserDefaultsKey<Value: Equatable> {
+        var key: String
+        var `default`: Value
+        var scope = UserDefaults.standard
+        
+        var value: Value {
+            get {
+                scope.value(forKey: key) as? Value ?? `default`
+            }
+            nonmutating set {
+                scope.set(newValue, forKey: key)
+            }
+        }
+    }
+
     /// UserDefaults key
     let key: String
-    /// Default value for key if not found in UserDefaults.
-    let `default`: Value
-    var scope = UserDefaults.standard
+    private var store: UserDefaultsKey<Value>
     private var subject: CurrentValueSubject<Value, Never>
 
     init(
@@ -31,8 +45,12 @@ import Foundation
         scope: UserDefaults = .standard
     ) {
         self.key = key
-        self.default = wrappedValue
-        self.subject = CurrentValueSubject(wrappedValue)
+        self.store = UserDefaultsKey(
+            key: key,
+            default: wrappedValue,
+            scope: scope
+        )
+        self.subject = CurrentValueSubject(store.value)
     }
     
     // Projected value is accessable via the `$` notation.
@@ -44,11 +62,10 @@ import Foundation
 
     var wrappedValue: Value {
         get {
-            scope.value(forKey: key) as? Value ?? `default`
+            store.value
         }
         nonmutating set {
-            scope.set(newValue, forKey: key)
-            self.subject.send(newValue)
+            store.value = newValue
         }
     }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_UserDefaultProperty.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_UserDefaultProperty.swift
@@ -46,6 +46,6 @@ final class Tests_UserDefaultProperty: XCTestCase {
         test.isToggled = false
         test.isToggled = false
         test.isToggled = false
-        XCTAssertEqual(count, 2)
+        XCTAssertEqual(count, 1)
     }
 }


### PR DESCRIPTION
Fixes #487.

Previously, we were setting the initial value to the wrapped `default` value. What we should have been doing is reading from UserDefaults at construction, and passing that to our `CurrentValueSubject`. This PR fixes the problem.

This is what was causing our Noosphere flag to spontaneously turn itself off between runs.