### PR TITLE
Update to Noosphere v0.8.2

### DIFF
--- a/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
@@ -194,16 +194,16 @@ public final class Sphere: SphereProtocol {
         return Self.readFileHeaderNames(file: file)
     }
     
-    /// Read the value of a memo from this Sphere
+    /// Read the value of a memo from this, or another sphere
     /// - Returns: `MemoData`
-    private func read(slug: Slug) throws -> MemoData {
+    public func read(slashlink: Slashlink) throws -> MemoData {
         guard let file = try Noosphere.callWithError(
             ns_sphere_content_read,
             noosphere.noosphere,
             sphere,
-            slug.markup
+            slashlink.markup
         ) else {
-            throw SphereError.fileDoesNotExist(slug.description)
+            throw SphereError.fileDoesNotExist(slashlink.description)
         }
         defer {
             ns_sphere_file_free(file)
@@ -213,7 +213,7 @@ public final class Sphere: SphereProtocol {
             file: file,
             name: "Content-Type"
         ) else {
-            throw SphereError.contentTypeMissing(slug.description)
+            throw SphereError.contentTypeMissing(slashlink.description)
         }
         
         let bodyRaw = try Noosphere.callWithError(
@@ -249,17 +249,6 @@ public final class Sphere: SphereProtocol {
         )
     }
     
-    /// Read the value of a memo from this, or another sphere
-    /// - Returns: `MemoData`
-    public func read(slashlink: Slashlink) throws -> MemoData {
-        // If slashlink is local, just read from this sphere
-        guard let petname = slashlink.petname else {
-            return try read(slug: slashlink.slug)
-        }
-        // Otherwise, traverse, then read
-        return try traverse(petname: petname).read(slug: slashlink.slug)
-    }
-
     /// Write to sphere
     public func write(
         slug: Slug,

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -2320,7 +2320,7 @@
 			repositoryURL = "https://github.com/subconsciousnetwork/noosphere";
 			requirement = {
 				kind = revision;
-				revision = 8ed33aaa3555efef343807611214f6436c7eefb3;
+				revision = ffcff5d1d6f5cec3b6c34731dc5c99cc25c3bc34;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/subconsciousnetwork/noosphere",
       "state" : {
-        "revision" : "8ed33aaa3555efef343807611214f6436c7eefb3"
+        "branch" : "main",
+        "revision" : "ffcff5d1d6f5cec3b6c34731dc5c99cc25c3bc34"
       }
     },
     {


### PR DESCRIPTION
- Lock in new commit
- Update `Sphere` wrapper class to defer to Noosphere traversal logic instead of attempting to implement on Swift side.