### PR TITLE
Use ShareLink for sharing links

### DIFF
--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailMetaSheetView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailMetaSheetView.swift
@@ -62,7 +62,7 @@ enum MemoViewerDetailMetaSheetAction: Hashable {
 
 struct MemoViewerDetailMetaSheetModel: ModelProtocol {
     typealias Action = MemoViewerDetailMetaSheetAction
-    typealias Environment = PasteboardProtocol
+    typealias Environment = ()
     
     static let logger = Logger(
         subsystem: Config.default.rdns,

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailMetaSheetView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailMetaSheetView.swift
@@ -76,16 +76,13 @@ struct MemoViewerDetailMetaSheetModel: ModelProtocol {
     
     var shareableLink: String? {
         guard let address = address else {
-            Self.logger.log("Copy link: (nil)")
             return nil
         }
         
         switch address {
         case .local(let slug):
-            Self.logger.log("Copy link: \(slug)")
             return slug.markup
         case .public(let slashlink):
-            Self.logger.log("Copy link: \(slashlink)")
             return slashlink.markup
         }
     }

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailMetaSheetView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailMetaSheetView.swift
@@ -40,18 +40,11 @@ struct MemoViewerDetailMetaSheetView: View {
             ScrollView {
                 VStack(spacing: AppTheme.unit4) {
                     MetaTableView {
-                        Button(
-                            action: {
-                                send(.copyLink)
-                            }
-                        ) {
-                            Label(
-                                "Copy link",
-                                systemImage: "doc.on.doc"
-                            )
-                        }
-                        .disabled(state.address == nil)
-                        .buttonStyle(RowButtonStyle())
+                        MetaTableItemShareLinkView(
+                            label: "Copy link",
+                            item: state.shareableLink ?? ""
+                        )
+                        .disabled(state.shareableLink == nil)
                     }
                 }
                 .padding()
@@ -64,7 +57,6 @@ struct MemoViewerDetailMetaSheetView: View {
 
 enum MemoViewerDetailMetaSheetAction: Hashable {
     case setAddress(_ address: MemoAddress?)
-    case copyLink
     case requestDismiss
 }
 
@@ -82,6 +74,22 @@ struct MemoViewerDetailMetaSheetModel: ModelProtocol {
     var noteVersion: String?
     var authorKey: String?
     
+    var shareableLink: String? {
+        guard let address = address else {
+            Self.logger.log("Copy link: (nil)")
+            return nil
+        }
+        
+        switch address {
+        case .local(let slug):
+            Self.logger.log("Copy link: \(slug)")
+            return slug.markup
+        case .public(let slashlink):
+            Self.logger.log("Copy link: \(slashlink)")
+            return slashlink.markup
+        }
+    }
+    
     static func update(
         state: Self,
         action: Action,
@@ -92,38 +100,9 @@ struct MemoViewerDetailMetaSheetModel: ModelProtocol {
             var model = state
             model.address = address
             return Update(state: model)
-        case .copyLink:
-            return copyLink(
-                state: state,
-                environment: environment
-            )
         case .requestDismiss:
             return Update(state: state)
         }
-    }
-    
-    static func copyLink(
-        state: Self,
-        environment: Environment
-    ) -> Update<Self> {
-        guard let address = state.address else {
-            Self.logger.log("Copy link: (nil)")
-            return Update(state: state)
-        }
-        
-        switch address {
-        case .local(let slug):
-            environment.string = slug.markup
-            logger.log("Copy link: \(slug)")
-        case .public(let slashlink):
-            environment.string = slashlink.markup
-            logger.log("Copy link: \(slashlink)")
-        }
-        
-        let fx: Fx<Action> = Just(Action.requestDismiss)
-            .eraseToAnyPublisher()
-        
-        return Update(state: state, fx: fx)
     }
 }
 

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -243,7 +243,7 @@ struct MemoViewerDetailModel: ModelProtocol {
             return MemoViewerDetailMetaSheetCursor.update(
                 state: state,
                 action: action,
-                environment: environment.pasteboard
+                environment: ()
             )
         case .appear(let description):
             return appear(

--- a/xcode/Subconscious/SubconsciousTests/Tests_MemoViewerDetailMetaSheet.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_MemoViewerDetailMetaSheet.swift
@@ -11,30 +11,7 @@ import Combine
 @testable import Subconscious
 
 final class Tests_MemoViewerDetailMetaSheet: XCTestCase {
-    var cancellables: Set<AnyCancellable> = Set()
-    
-    override func setUp() {
-        self.cancellables = Set()
-    }
-    
-    class MockPasteboard: PasteboardProtocol {
-        private(set) var copies: Int = 0
-        private(set) var store: String?
-        
-        var string: String? {
-            get {
-                store
-            }
-            set {
-                store = newValue
-                copies = copies + 1
-            }
-        }
-    }
-    
     func testSetAddress() throws {
-        let environment = MockPasteboard()
-        
         let state = MemoViewerDetailMetaSheetModel(
             address: nil
         )
@@ -43,38 +20,9 @@ final class Tests_MemoViewerDetailMetaSheet: XCTestCase {
         let update = MemoViewerDetailMetaSheetModel.update(
             state: state,
             action: .setAddress(address),
-            environment: environment
+            environment: ()
         )
         
         XCTAssertEqual(update.state.address, address)
-    }
-    
-    func testCopyLink() throws {
-        let environment = MockPasteboard()
-        
-        let state = MemoViewerDetailMetaSheetModel(
-            address: MemoAddress("public::@bob/foo")
-        )
-        
-        let update = MemoViewerDetailMetaSheetModel.update(
-            state: state,
-            action: .copyLink,
-            environment: environment
-        )
-        
-        XCTAssertEqual(environment.string, "@bob/foo")
-        XCTAssertEqual(environment.copies, 1)
-        
-        let expectation = XCTestExpectation(
-            description: "Sends dismiss fx"
-        )
-        
-        update.fx.sink(receiveValue: { action in
-            if case .requestDismiss = action {
-                expectation.fulfill()
-            }
-        }).store(in: &cancellables)
-        
-        wait(for: [expectation], timeout: 0.2)
     }
 }


### PR DESCRIPTION
This PR picks up on the discussion I started in https://github.com/subconsciousnetwork/subconscious/pull/486#discussion_r1162195697.

> To me, it seems cleaner to use ShareLink here instead of copying to the clipboard. I think it's more idiomatic in iOS in general to go via the share sheet since it offers copy to pasteboard within it anyway & it's more directly useful for sending a link in an iMessage etc.

> This apple link looked promising for guidance but I can't load it right now because of an SSL error(!!): https://developer.apple.com/design/human-interface-guidelines/patterns/collaboration-and-sharing/

> We could expose a computed shareableLink property from the model to keep the logic from the .copyLink handler in the model, then use the MetaTableItemShareLinkView I implemented recently...

This PR shows what it would look like to make this switch.

# Changes

- Convert .copyLink action to ShareLink control
- Remove unused pasteboard environment
