### PR TITLE
Make all calls to Noosphere non-blocking on main thread

### DIFF
--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
@@ -18,10 +18,12 @@ struct AddressBookEntry: Equatable {
 }
 
 struct AddressBookEnvironment {
+    // Default logger for environment
     static let logger = Logger(
         subsystem: Config.default.rdns,
         category: "AddressBook"
     )
+    var logger: Logger = logger
     var noosphere: NoosphereService
     var data: DataService
     var addressBook: AddressBookService
@@ -160,7 +162,7 @@ struct AddressBookModel: ModelProtocol {
             return Update(state: model)
             
         case .failRefreshDid(let error):
-            AddressBookEnvironment.logger.log("Failed to refresh sphere did: \(error)")
+            environment.logger.log("Failed to refresh sphere did: \(error)")
             return Update(state: state)
             
         case .refreshEntries(let forceRefreshFromNoosphere):
@@ -180,7 +182,7 @@ struct AddressBookModel: ModelProtocol {
             return Update(state: state, fx: fx)
 
         case .failRefreshEntries(let error):
-            AddressBookEnvironment.logger.log("Failed to refresh entries: \(error)")
+            environment.logger.log("Failed to refresh entries: \(error)")
             return Update(state: state)
             
         case .populate(let follows):

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
@@ -18,7 +18,7 @@ struct AddressBookEntry: Equatable {
 }
 
 struct AddressBookEnvironment {
-    var logger = Logger(
+    static let logger = Logger(
         subsystem: Config.default.rdns,
         category: "AddressBook"
     )
@@ -145,10 +145,10 @@ struct AddressBookModel: ModelProtocol {
                 .identityPublisher()
                 .tryMap({ identity in
                     let did = try Did(identity).unwrap()
-                    return .succeedRefreshDid(did)
+                    return AddressBookAction.succeedRefreshDid(did)
                 })
                 .recover({error in
-                        .failRefreshDid(error.localizedDescription)
+                    AddressBookAction.failRefreshDid(error.localizedDescription)
                 })
                 .eraseToAnyPublisher()
             return Update(state: state, fx: fx)
@@ -159,7 +159,7 @@ struct AddressBookModel: ModelProtocol {
             return Update(state: model)
             
         case .failRefreshDid(let error):
-            environment.logger.log("Failed to refresh sphere did: \(error)")
+            AddressBookEnvironment.logger.log("Failed to refresh sphere did: \(error)")
             return Update(state: state)
             
         case .refreshEntries(let forceRefreshFromNoosphere):

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
@@ -58,7 +58,6 @@ struct AddressBookView: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Close", role: .cancel) {
-                        AddressBookModel.logger.debug("Close Address Book")
                         send(.present(false))
                     }
                 }

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -730,7 +730,7 @@ struct AppModel: ModelProtocol {
         // Persist to UserDefaults
         AppDefaults.standard.gatewayURL = gatewayURL
         // Reset gateway on environment
-        environment.data.noosphere.resetGateway(url: url)
+        environment.noosphere.resetGateway(url: url)
 
         /// Only set valid nicknames
         return Update(state: model)
@@ -857,7 +857,7 @@ struct AppModel: ModelProtocol {
         state: AppModel,
         environment: AppEnvironment
     ) -> Update<AppModel> {
-        environment.data.noosphere.reset()
+        environment.noosphere.reset()
         return Update(state: state)
     }
 
@@ -1022,7 +1022,7 @@ struct AppModel: ModelProtocol {
         state: AppModel,
         environment: AppEnvironment
     ) -> Update<AppModel> {
-        guard let gatewayURL = environment.data.noosphere.gatewayURL else {
+        guard let gatewayURL = environment.noosphere.gatewayURL else {
             logger.log("No gateway configured. Skipping sync.")
             return Update(state: state)
         }
@@ -1205,9 +1205,10 @@ struct AppEnvironment {
     var documentURL: URL
     var applicationSupportURL: URL
 
-    private let noosphere: NoosphereService
+    private var _noosphere: NoosphereService
+    var noosphere: some NoosphereServiceProtocol { _noosphere }
     /// Exposes sphere publisher protocol for Noosphere
-    var sphere: some SpherePublisherProtocol { noosphere }
+    var sphere: some SpherePublisherProtocol { _noosphere }
 
     var data: DataService
     var feed: FeedService
@@ -1231,7 +1232,7 @@ struct AppEnvironment {
     init() {
         self.documentURL = FileManager.default.urls(
             for: .documentDirectory,
-               in: .userDomainMask
+            in: .userDomainMask
         ).first!
 
         self.applicationSupportURL = try! FileManager.default.url(
@@ -1259,7 +1260,7 @@ struct AppEnvironment {
             gatewayURL: defaultGateway,
             sphereIdentity: defaultSphereIdentity
         )
-        self.noosphere = noosphere
+        self._noosphere = noosphere
 
         let databaseURL = self.applicationSupportURL
             .appendingPathComponent("database.sqlite")

--- a/xcode/Subconscious/Shared/Components/Common/Forms/Search.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Forms/Search.swift
@@ -182,7 +182,7 @@ struct SearchModel: ModelProtocol {
         query: String
     ) -> Update<SearchModel> {
         let fx: Fx<SearchAction> = environment.data
-            .searchSuggestions(query: query)
+            .searchSuggestionsPublisher(query: query)
             .map({ suggestions in
                 SearchAction.setSuggestions(suggestions)
             })
@@ -238,7 +238,7 @@ struct SearchModel: ModelProtocol {
             return Update(state: state)
         }
         let fx: Fx<SearchAction> = environment.data
-            .createSearchHistoryItem(query: query)
+            .createSearchHistoryItemPublisher(query: query)
             .map({ query in
                 SearchAction.succeedCreateSearchHistoryItem(query)
             })

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -1131,7 +1131,7 @@ struct MemoEditorDetailModel: ModelProtocol {
         fallback: String,
         autofocus: Bool
     ) -> Update<MemoEditorDetailModel> {
-        let fx: Fx<MemoEditorDetailAction> = environment.data.readMemoEditorDetailAsync(
+        let fx: Fx<MemoEditorDetailAction> = environment.data.readMemoEditorDetailPublisher(
             address: address,
             fallback: fallback
         ).map({ detail in
@@ -1161,7 +1161,7 @@ struct MemoEditorDetailModel: ModelProtocol {
         
         let model = prepareLoadDetail(state)
         
-        let fx: Fx<MemoEditorDetailAction> = environment.data.readMemoEditorDetailAsync(
+        let fx: Fx<MemoEditorDetailAction> = environment.data.readMemoEditorDetailPublisher(
             address: address,
             fallback: model.editor.text
         ).map({ detail in
@@ -1399,7 +1399,7 @@ struct MemoEditorDetailModel: ModelProtocol {
 
         let to = from.withAudience(audience)
 
-        let fx: Fx<MemoEditorDetailAction> = environment.data.moveEntryAsync(
+        let fx: Fx<MemoEditorDetailAction> = environment.data.moveEntryPublisher(
             from: from,
             to: to
         ).map({ receipt in
@@ -1528,7 +1528,7 @@ struct MemoEditorDetailModel: ModelProtocol {
         // Mark saving in-progress
         model.saveState = .saving
         
-        let fx: Fx<MemoEditorDetailAction> = environment.data.writeEntryAsync(
+        let fx: Fx<MemoEditorDetailAction> = environment.data.writeEntryPublisher(
             entry
         ).map({ _ in
             MemoEditorDetailAction.succeedSave(entry)
@@ -1624,7 +1624,7 @@ struct MemoEditorDetailModel: ModelProtocol {
         }
         
         // Search link suggestions
-        let fx: Fx<MemoEditorDetailAction> = environment.data.searchLinkSuggestions(
+        let fx: Fx<MemoEditorDetailAction> = environment.data.searchLinkSuggestionsPublisher(
             query: text,
             omitting: omitting,
             fallback: []
@@ -1725,7 +1725,7 @@ struct MemoEditorDetailModel: ModelProtocol {
         from: MemoAddress,
         to: MemoAddress
     ) -> Update<MemoEditorDetailModel> {
-        let fx: Fx<MemoEditorDetailAction> = environment.data.moveEntryAsync(
+        let fx: Fx<MemoEditorDetailAction> = environment.data.moveEntryPublisher(
             from: from,
             to: to
         )
@@ -1800,7 +1800,7 @@ struct MemoEditorDetailModel: ModelProtocol {
         parent: MemoAddress,
         child: MemoAddress
     ) -> Update<MemoEditorDetailModel> {
-        let fx: Fx<MemoEditorDetailAction> = environment.data.mergeEntryAsync(
+        let fx: Fx<MemoEditorDetailAction> = environment.data.mergeEntryPublisher(
             parent: parent,
             child: child
         ).map({ _ in

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -277,7 +277,7 @@ struct MemoViewerDetailModel: ModelProtocol {
         var model = state
         model.loadingState = .loading
         model.address = description.address
-        let fx: Fx<Action> = environment.data.readMemoDetailAsync(
+        let fx: Fx<Action> = environment.data.readMemoDetailPublisher(
             address: description.address
         ).map({ response in
             Action.setDetail(response)

--- a/xcode/Subconscious/Shared/Components/Detail/RenameSearchView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/RenameSearchView.swift
@@ -149,7 +149,7 @@ struct RenameSearchModel: ModelProtocol {
             return Update(state: model)
         }
         let fx: Fx<RenameSearchAction> = environment.data
-            .searchRenameSuggestions(
+            .searchRenameSuggestionsPublisher(
                 query: query,
                 current: current
             )

--- a/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
@@ -939,18 +939,18 @@ struct NotebookModel: ModelProtocol {
         fallback: String
     ) -> Update<NotebookModel> {
         let fallbackAddress = slug.toLocalMemoAddress()
-        let address = environment.data
-            .findAddressInOurs(slug: slug) ?? fallbackAddress
-        return update(
-            state: state,
-            action: .pushDetail(
-                MemoEditorDetailDescription(
-                    address: address,
-                    fallback: fallback
+        let fx: Fx<NotebookAction> = environment.data
+            .findAddressInOursPublisher(slug: slug)
+            .map({ address in
+                NotebookAction.pushDetail(
+                    MemoEditorDetailDescription(
+                        address: address ?? fallbackAddress,
+                        fallback: fallback
+                    )
                 )
-            ),
-            environment: environment
-        )
+            })
+            .eraseToAnyPublisher()
+        return Update(state: state, fx: fx)
     }
 
     /// Request detail for a random entry
@@ -959,7 +959,8 @@ struct NotebookModel: ModelProtocol {
         environment: AppEnvironment,
         autofocus: Bool
     ) -> Update<NotebookModel> {
-        let fx: Fx<NotebookAction> = environment.data.readRandomEntryLinkPublisher()
+        let fx: Fx<NotebookAction> = environment.data
+            .readRandomEntryLinkPublisher()
             .map({ link in
                 NotebookAction.pushDetail(
                     MemoEditorDetailDescription(

--- a/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
@@ -619,7 +619,7 @@ struct NotebookModel: ModelProtocol {
         state: NotebookModel,
         environment: AppEnvironment
     ) -> Update<NotebookModel> {
-        let fx: Fx<NotebookAction> = environment.data.countMemos()
+        let fx: Fx<NotebookAction> = environment.data.countMemosPublisher()
             .map({ count in
                 NotebookAction.setEntryCount(count)
             })
@@ -645,7 +645,7 @@ struct NotebookModel: ModelProtocol {
         state: NotebookModel,
         environment: AppEnvironment
     ) -> Update<NotebookModel> {
-        let fx: Fx<NotebookAction> = environment.data.listRecentMemos()
+        let fx: Fx<NotebookAction> = environment.data.listRecentMemosPublisher()
             .map({ entries in
                 NotebookAction.setRecent(entries)
             })
@@ -708,7 +708,7 @@ struct NotebookModel: ModelProtocol {
             return Update(state: state)
         }
         let fx: Fx<NotebookAction> = environment.data
-            .deleteMemoAsync(address)
+            .deleteMemoPublisher(address)
             .map({ _ in
                 NotebookAction.succeedDeleteEntry(address)
             })
@@ -959,7 +959,7 @@ struct NotebookModel: ModelProtocol {
         environment: AppEnvironment,
         autofocus: Bool
     ) -> Update<NotebookModel> {
-        let fx: Fx<NotebookAction> = environment.data.readRandomEntryLinkAsync()
+        let fx: Fx<NotebookAction> = environment.data.readRandomEntryLinkPublisher()
             .map({ link in
                 NotebookAction.pushDetail(
                     MemoEditorDetailDescription(

--- a/xcode/Subconscious/Shared/Library/CombineUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/CombineUtilities.swift
@@ -8,40 +8,6 @@
 import Foundation
 import Combine
 
-struct CombineUtilities {
-    /// Run a function asyncronously on the global DispatchQueue.
-    static func async<T>(
-        qos: DispatchQoS.QoSClass = .default,
-        execute: @escaping () -> T
-    ) -> AnyPublisher<T, Never> {
-        Future({ promise in
-            DispatchQueue.global(qos: qos).async(execute: {
-                let result: T = execute()
-                promise(.success(result))
-            })
-        })
-        .eraseToAnyPublisher()
-    }
-
-    /// Run a throwing function asyncronously on the global DispatchQueue.
-    static func async<T>(
-        qos: DispatchQoS.QoSClass = .default,
-        execute: @escaping () throws -> T
-    ) -> AnyPublisher<T, Error> {
-        Future({ promise in
-            DispatchQueue.global(qos: qos).async(execute: {
-                do {
-                    let success: T = try execute()
-                    promise(.success(success))
-                } catch {
-                    promise(.failure(error))
-                }
-            })
-        })
-        .eraseToAnyPublisher()
-    }
-}
-
 extension DispatchQueue {
     /// Run a closure async on this queue, returning a Combine Future.
     func future<T>(

--- a/xcode/Subconscious/Shared/Library/CombineUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/CombineUtilities.swift
@@ -97,3 +97,16 @@ extension Future where Failure == Never {
         }
     }
 }
+
+extension Publisher {
+    /// Recover from a failure.
+    /// Similar to `catch` but allows you to map an `Error` to an `Output`,
+    /// without having to wrap in a publisher.
+    func recover(
+        _ transform: @escaping (Error) -> Output
+    ) -> Publishers.Catch<Self, Just<Output>> {
+        self.catch({ error in
+            Just(transform(error))
+        })
+    }
+}

--- a/xcode/Subconscious/Shared/Library/CombineUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/CombineUtilities.swift
@@ -73,3 +73,27 @@ extension DispatchQueue {
         }
     }
 }
+
+extension Future where Failure == Error {
+    /// Initialize a future by immediately performing a throwing closure.
+    convenience init(_ perform: @escaping () throws -> Output) {
+        self.init { promise in
+            do {
+                let value = try perform()
+                promise(.success(value))
+            } catch {
+                promise(.failure(error))
+            }
+        }
+    }
+}
+
+extension Future where Failure == Never {
+    /// Initialize a future by immediately performing a throwing closure.
+    convenience init(_ perform: @escaping () -> Output) {
+        self.init { promise in
+            let value = perform()
+            promise(.success(value))
+        }
+    }
+}

--- a/xcode/Subconscious/Shared/Library/CombineUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/CombineUtilities.swift
@@ -76,7 +76,9 @@ extension DispatchQueue {
 
 extension Future where Failure == Error {
     /// Initialize a future by immediately performing a throwing closure.
-    convenience init(_ perform: @escaping () throws -> Output) {
+    static func resolve(
+        perform: @escaping () throws -> Output
+    ) -> Future {
         self.init { promise in
             do {
                 let value = try perform()
@@ -90,8 +92,8 @@ extension Future where Failure == Error {
 
 extension Future where Failure == Never {
     /// Initialize a future by immediately performing a throwing closure.
-    convenience init(_ perform: @escaping () -> Output) {
-        self.init { promise in
+    static func resolve(_ perform: @escaping () -> Output) -> Future {
+        Future { promise in
             let value = perform()
             promise(.success(value))
         }

--- a/xcode/Subconscious/Shared/Library/CombineUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/CombineUtilities.swift
@@ -8,6 +8,78 @@
 import Foundation
 import Combine
 
+/// Create a Combine Future from an async closure that never fails.
+/// Async actions are run in a task and fulfil the future's promise.
+public extension Future where Failure == Never {
+    convenience init(
+        priority: TaskPriority? = nil,
+        _ perform: @escaping () async -> Output
+    ) {
+        self.init { promise in
+            Task(priority: priority) {
+                let value = await perform()
+                promise(.success(value))
+            }
+        }
+    }
+}
+
+/// Create a Combine Future from an async closure that never fails.
+/// Async actions are run in a detatched task and fulfil the future's promise.
+public extension Future where Failure == Never {
+    static func detatched(
+        priority: TaskPriority? = nil,
+        perform: @escaping () async -> Output
+    ) -> Self {
+        self.init { promise in
+            Task.detached(priority: priority) {
+                let value = await perform()
+                promise(.success(value))
+            }
+        }
+    }
+}
+
+/// Create a Combine Future from an async throwing closure.
+/// Async actions are run in a task and fulfil the future's promise.
+public extension Future where Failure == Error {
+    convenience init(
+        priority: TaskPriority? = nil,
+        _ perform: @escaping () async throws -> Output
+    ) {
+        self.init { promise in
+            Task(priority: priority) {
+                do {
+                    let value = try await perform()
+                    promise(.success(value))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }
+    }
+}
+
+/// Create a Combine Future from an async throwing closure.
+/// Async actions are run in a detatched task and fulfil the future's promise.
+public extension Future where Failure == Error {
+    static func detatched(
+        priority: TaskPriority? = nil,
+        perform: @escaping () async throws -> Output
+    ) -> Self {
+        self.init { promise in
+            Task.detached(priority: priority) {
+                do {
+                    let value = try await perform()
+                    promise(.success(value))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }
+    }
+}
+
 extension DispatchQueue {
     /// Run a closure async on this queue, returning a Combine Future.
     func future<T>(

--- a/xcode/Subconscious/Shared/Library/CombineUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/CombineUtilities.swift
@@ -80,38 +80,6 @@ public extension Future where Failure == Error {
     }
 }
 
-extension DispatchQueue {
-    /// Run a closure async on this queue, returning a Combine Future.
-    func future<T>(
-        qos: DispatchQoS = .unspecified,
-        perform: @escaping () throws -> T
-    ) -> Future<T, Error> {
-        Future { promise in
-            self.async(qos: qos) {
-                do {
-                    let value = try perform()
-                    promise(.success(value))
-                } catch {
-                    promise(.failure(error))
-                }
-            }
-        }
-    }
-    
-    /// Run a closure async on this queue, returning a Combine Future.
-    func future<T>(
-        qos: DispatchQoS = .unspecified,
-        perform: @escaping () -> T
-    ) -> Future<T, Never> {
-        Future { promise in
-            self.async(qos: qos) {
-                let value = perform()
-                promise(.success(value))
-            }
-        }
-    }
-}
-
 extension Publisher {
     /// Recover from a failure.
     /// Similar to `catch` but allows you to map an `Error` to an `Output`,

--- a/xcode/Subconscious/Shared/Library/CombineUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/CombineUtilities.swift
@@ -40,32 +40,6 @@ extension DispatchQueue {
     }
 }
 
-extension Future where Failure == Error {
-    /// Initialize a future by immediately performing a throwing closure.
-    static func resolve(
-        perform: @escaping () throws -> Output
-    ) -> Future {
-        self.init { promise in
-            do {
-                let value = try perform()
-                promise(.success(value))
-            } catch {
-                promise(.failure(error))
-            }
-        }
-    }
-}
-
-extension Future where Failure == Never {
-    /// Initialize a future by immediately performing a throwing closure.
-    static func resolve(_ perform: @escaping () -> Output) -> Future {
-        Future { promise in
-            let value = perform()
-            promise(.success(value))
-        }
-    }
-}
-
 extension Publisher {
     /// Recover from a failure.
     /// Similar to `catch` but allows you to map an `Error` to an `Output`,

--- a/xcode/Subconscious/Shared/Library/CombineUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/CombineUtilities.swift
@@ -41,3 +41,35 @@ struct CombineUtilities {
         .eraseToAnyPublisher()
     }
 }
+
+extension DispatchQueue {
+    /// Run a closure async on this queue, returning a Combine Future.
+    func future<T>(
+        qos: DispatchQoS = .unspecified,
+        perform: @escaping () throws -> T
+    ) -> Future<T, Error> {
+        Future { promise in
+            self.async(qos: qos) {
+                do {
+                    let value = try perform()
+                    promise(.success(value))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }
+    }
+    
+    /// Run a closure async on this queue, returning a Combine Future.
+    func future<T>(
+        qos: DispatchQoS = .unspecified,
+        perform: @escaping () -> T
+    ) -> Future<T, Never> {
+        Future { promise in
+            self.async(qos: qos) {
+                let value = perform()
+                promise(.success(value))
+            }
+        }
+    }
+}

--- a/xcode/Subconscious/Shared/Library/Func.swift
+++ b/xcode/Subconscious/Shared/Library/Func.swift
@@ -19,15 +19,31 @@ struct Func {
     /// This is useful for working around some of Swift's syntactical
     /// shortcomings. In particular, this lets us treat switch as an
     /// expression that returns a value.
-    static func run<T>(_ closure: () -> T) -> T {
-        closure()
+    static func run<T>(_ perform: () -> T) -> T {
+        perform()
     }
     
     /// Immediately run the passed throwing closure, returning the result.
     /// Useful for wrapping switch statements so they can be treated as expressions.
     static func run<T>(
-        _ execute: () throws -> T
+        _ perform: () throws -> T
     ) throws -> T {
-        try execute()
+        try perform()
+    }
+    
+    /// Return the result of a closure immediately.
+    /// This is useful for working around some of Swift's syntactical
+    /// shortcomings. In particular, this lets us treat switch as an
+    /// expression that returns a value.
+    static func run<T>(_ perform: () async -> T) async -> T {
+        await perform()
+    }
+    
+    /// Immediately run the passed throwing closure, returning the result.
+    /// Useful for wrapping switch statements so they can be treated as expressions.
+    static func run<T>(
+        _ perform: () async throws -> T
+    ) async throws -> T {
+        try await perform()
     }
 }

--- a/xcode/Subconscious/Shared/Services/AddressBookService.swift
+++ b/xcode/Subconscious/Shared/Services/AddressBookService.swift
@@ -87,9 +87,10 @@ class AddressBookService {
     
     /// Associates the passed DID with the passed petname within the sphere, saves the changes and updates the database.
     func followUserAsync(did: Did, petname: Petname) -> AnyPublisher<Void, Error> {
-        CombineUtilities.async(qos: .default) {
+        DispatchQueue.global(qos: .default).future {
             return try self.followUser(did: did, petname: petname)
         }
+        .eraseToAnyPublisher()
     }
     
     func unfollowUser(petname: Petname) throws {
@@ -100,9 +101,10 @@ class AddressBookService {
     
     /// Unassociates the passed DID with the passed petname within the sphere, saves the changes and updates the database.
     func unfollowUserAsync(petname: Petname) -> AnyPublisher<Void, Error> {
-        CombineUtilities.async(qos: .default) {
+        DispatchQueue.global(qos: .default).future {
             return try self.unfollowUser(petname: petname)
         }
+        .eraseToAnyPublisher()
     }
     
     func getPetname(petname: Petname) throws -> Did? {
@@ -110,9 +112,10 @@ class AddressBookService {
     }
 
     func getPetnameAsync(petname: Petname) -> AnyPublisher<Did?, Error> {
-        CombineUtilities.async(qos: .utility) {
+        DispatchQueue.global(qos: .utility).future {
           return try self.getPetname(petname: petname)
         }
+        .eraseToAnyPublisher()
     }
 
     func setPetname(did: Did, petname: Petname) throws {
@@ -120,9 +123,10 @@ class AddressBookService {
     }
 
     func setPetnameAsync(did: Did, petname: Petname) -> AnyPublisher<Void, Error> {
-        CombineUtilities.async(qos: .utility) {
+        DispatchQueue.global(qos: .default).future {
           try self.setPetname(did: did, petname: petname)
         }
+        .eraseToAnyPublisher()
     }
 
     func unsetPetname(petname: Petname) throws {
@@ -130,9 +134,10 @@ class AddressBookService {
     }
 
     func unsetPetnameAsync(petname: Petname) -> AnyPublisher<Void, Error> {
-        CombineUtilities.async(qos: .utility) {
+        DispatchQueue.global(qos: .utility).future {
           try self.unsetPetname(petname: petname)
         }
+        .eraseToAnyPublisher()
     }
 
     func listPetnames() throws -> [Petname] {
@@ -140,9 +145,10 @@ class AddressBookService {
     }
 
     func listPetnamesAsync() -> AnyPublisher<[Petname], Error> {
-        CombineUtilities.async(qos: .utility) {
+        DispatchQueue.global(qos: .utility).future {
           return try self.listPetnames()
         }
+        .eraseToAnyPublisher()
     }
 
     func getPetnameChanges(sinceCid: String) throws -> [Petname] {
@@ -150,8 +156,9 @@ class AddressBookService {
     }
       
     func getPetnameChangesAsync(sinceCid: String) -> AnyPublisher<[Petname], Error> {
-        CombineUtilities.async(qos: .utility) {
+        DispatchQueue.global(qos: .utility).future {
             return try self.getPetnameChanges(sinceCid: sinceCid)
         }
+        .eraseToAnyPublisher()
     }
 }

--- a/xcode/Subconscious/Shared/Services/AddressBookService.swift
+++ b/xcode/Subconscious/Shared/Services/AddressBookService.swift
@@ -126,7 +126,7 @@ class AddressBookService {
     }
 
     func unsetPetname(petname: Petname) throws {
-        try noosphere.unsetPetname(petname: petname)
+        try noosphere.setPetname(did: nil, petname: petname)
     }
 
     func unsetPetnameAsync(petname: Petname) -> AnyPublisher<Void, Error> {

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -38,7 +38,7 @@ struct MoveReceipt: Hashable {
 /// Wraps both database and source-of-truth store, providing data
 /// access methods for the app.
 actor DataService {
-    static let logger = Logger(
+    private static let logger = Logger(
         subsystem: Config.default.rdns,
         category: "DataService"
     )

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -85,9 +85,7 @@ struct DataService {
 
     /// Sync local state to gateway
     func syncSphereWithGateway() -> AnyPublisher<String, Error> {
-        CombineUtilities.async(qos: .utility) {
-            try noosphere.sync()
-        }
+        noosphere.syncPublisher()
     }
 
     /// Migrate database off main thread, returning a publisher

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -47,7 +47,7 @@ actor DataService {
     private var noosphere: NoosphereService
     private var database: DatabaseService
     private var local: HeaderSubtextMemoStore
-    var logger: Logger = logger
+    private var logger: Logger = logger
     
     init(
         noosphere: NoosphereService,

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -38,10 +38,10 @@ struct MoveReceipt: Hashable {
 /// Wraps both database and source-of-truth store, providing data
 /// access methods for the app.
 struct DataService {
-    var addressBook: AddressBookService
-    var noosphere: NoosphereService
-    var database: DatabaseService
-    var local: HeaderSubtextMemoStore
+    private var addressBook: AddressBookService
+    private var noosphere: NoosphereService
+    private var database: DatabaseService
+    private var local: HeaderSubtextMemoStore
     var logger: Logger
 
     init(

--- a/xcode/Subconscious/Shared/Services/FeedService.swift
+++ b/xcode/Subconscious/Shared/Services/FeedService.swift
@@ -25,7 +25,7 @@ struct FeedService {
     /// We should consider other approaches, including using a tracery grammar.
     /// Eventually, we want to do something based on follows.
     func generate(max: Int) -> AnyPublisher<[Story], Error> {
-        DispatchQueue.global().future {
+        Future.detatched {
             let geists = geists.values
             var stories: [Story] = []
             for _ in 0..<max {

--- a/xcode/Subconscious/Shared/Services/FeedService.swift
+++ b/xcode/Subconscious/Shared/Services/FeedService.swift
@@ -25,7 +25,7 @@ struct FeedService {
     /// We should consider other approaches, including using a tracery grammar.
     /// Eventually, we want to do something based on follows.
     func generate(max: Int) -> AnyPublisher<[Story], Error> {
-        CombineUtilities.async {
+        DispatchQueue.global().future {
             let geists = geists.values
             var stories: [Story] = []
             for _ in 0..<max {
@@ -36,5 +36,6 @@ struct FeedService {
             }
             return stories
         }
+        .eraseToAnyPublisher()
     }
 }

--- a/xcode/Subconscious/Shared/Services/Noosphere/Noosphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Noosphere.swift
@@ -155,12 +155,13 @@ public final class Noosphere {
         }
     }
     
-    func createSphereFuture(
+    func createSpherePublisher(
         ownerKeyName: String
-    ) -> Future<SphereReceipt, Error> {
+    ) -> AnyPublisher<SphereReceipt, Error> {
         queue.future {
             try self._createSphere(ownerKeyName: ownerKeyName)
         }
+        .eraseToAnyPublisher()
     }
 
     deinit {

--- a/xcode/Subconscious/Shared/Services/Noosphere/Noosphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Noosphere.swift
@@ -65,7 +65,8 @@ public final class Noosphere {
     init(
         globalStoragePath: String,
         sphereStoragePath: String,
-        gatewayURL: String? = nil
+        gatewayURL: String? = nil,
+        queue: DispatchQueue
     ) throws {
         guard let noosphere = try Self.callWithError(
             ns_initialize,
@@ -79,11 +80,7 @@ public final class Noosphere {
         self.globalStoragePath = globalStoragePath
         self.sphereStoragePath = sphereStoragePath
         self.gatewayURL = gatewayURL
-        /// Note that queues are serial by default, making this a serial queue.
-        self.queue = DispatchQueue(
-            label: "NoosphereQueue",
-            qos: .default
-        )
+        self.queue = queue
         logger.debug("init")
     }
     

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -213,6 +213,12 @@ final class NoosphereService: SphereProtocol, SpherePublisherProtocol {
         try self.sphere().read(slashlink: slashlink)
     }
     
+    func readPublisher(slashlink: Slashlink) -> AnyPublisher<MemoData, Error> {
+        self.spherePublisher().flatMap({ sphere in
+            sphere.readPublisher(slashlink: slashlink)
+        }).eraseToAnyPublisher()
+    }
+    
     func write(
         slug: Slug,
         contentType: String,
@@ -227,6 +233,22 @@ final class NoosphereService: SphereProtocol, SpherePublisherProtocol {
         )
     }
     
+    func writePublisher(
+        slug: Slug,
+        contentType: String,
+        additionalHeaders: [Header],
+        body: Data
+    ) -> AnyPublisher<Void, Error> {
+        self.spherePublisher().flatMap({ sphere in
+            sphere.writePublisher(
+                slug: slug,
+                contentType: contentType,
+                additionalHeaders: additionalHeaders,
+                body: body
+            )
+        }).eraseToAnyPublisher()
+    }
+
     func remove(slug: Slug) throws {
         try self.sphere().remove(slug: slug)
     }

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -253,16 +253,43 @@ final class NoosphereService: SphereProtocol, SpherePublisherProtocol {
         try self.sphere().remove(slug: slug)
     }
     
+    func removePublisher(slug: Slug) -> AnyPublisher<Void, Error> {
+        self.spherePublisher().flatMap({ sphere in
+            sphere.removePublisher(slug: slug)
+        }).eraseToAnyPublisher()
+    }
+    
     @discardableResult func save() throws -> String {
         try self.sphere().save()
+    }
+    
+    func savePublisher() -> AnyPublisher<String, Error> {
+        self.spherePublisher().flatMap({ sphere in
+            sphere.savePublisher()
+        })
+        .eraseToAnyPublisher()
     }
     
     func list() throws -> [Slug] {
         try self.sphere().list()
     }
     
+    func listPublisher() -> AnyPublisher<[Slug], Error> {
+        self.spherePublisher().flatMap({ sphere in
+            sphere.listPublisher()
+        })
+        .eraseToAnyPublisher()
+    }
+    
     func sync() throws -> String {
         try self.sphere().sync()
+    }
+    
+    func syncPublisher() -> AnyPublisher<String, Error> {
+        self.spherePublisher().flatMap({ sphere in
+            sphere.syncPublisher()
+        })
+        .eraseToAnyPublisher()
     }
     
     func changes(_ since: String?) throws -> [Slug] {

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -162,7 +162,14 @@ final class NoosphereService:
     }
 
     func identity() throws -> String {
-        try self.sphere().identity
+        try self.sphere().identity()
+    }
+
+    func identityPublisher() -> AnyPublisher<String, Error> {
+        self.spherePublisher().flatMap({ sphere in
+            sphere.identityPublisher()
+        })
+        .eraseToAnyPublisher()
     }
 
     func version() throws -> String {

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -296,27 +296,83 @@ final class NoosphereService: SphereProtocol, SpherePublisherProtocol {
         try self.sphere().changes(since)
     }
     
+    func changesPublisher(_ since: String?) -> AnyPublisher<[Slug], Error> {
+        self.spherePublisher().flatMap({ sphere in
+            sphere.changesPublisher(since)
+        })
+        .eraseToAnyPublisher()
+    }
+    
     func getPetname(petname: Petname) throws -> String {
         try self.sphere().getPetname(petname: petname)
+    }
+    
+    func getPetnamePublisher(petname: Petname) -> AnyPublisher<String, Error> {
+        self.spherePublisher().flatMap({ sphere in
+            sphere.getPetnamePublisher(petname: petname)
+        })
+        .eraseToAnyPublisher()
     }
     
     func setPetname(did: String?, petname: Petname) throws {
         try self.sphere().setPetname(did: did, petname: petname)
     }
     
+    func setPetnamePublisher(
+        did: String?,
+        petname: Petname
+    ) -> AnyPublisher<Void, Error> {
+        self.spherePublisher().flatMap({ sphere in
+            sphere.setPetnamePublisher(did: did, petname: petname)
+        })
+        .eraseToAnyPublisher()
+    }
+    
     func resolvePetname(petname: Petname) throws -> String {
         try self.sphere().resolvePetname(petname: petname)
+    }
+    
+    func resolvePetnamePublisher(
+        petname: Petname
+    ) -> AnyPublisher<String, Error> {
+        self.spherePublisher().flatMap({ sphere in
+            sphere.resolvePetnamePublisher(petname: petname)
+        })
+        .eraseToAnyPublisher()
     }
     
     func listPetnames() throws -> [Petname] {
         try self.sphere().listPetnames()
     }
     
+    func listPetnamesPublisher() -> AnyPublisher<[Petname], Error> {
+        self.spherePublisher().flatMap({ sphere in
+            sphere.listPetnamesPublisher()
+        })
+        .eraseToAnyPublisher()
+    }
+    
     func getPetnameChanges(sinceCid: String) throws -> [Petname] {
         try self.sphere().getPetnameChanges(sinceCid: sinceCid)
+    }
+    
+    func getPetnameChangesPublisher(
+        sinceCid: String
+    ) -> AnyPublisher<[Petname], Error> {
+        self.spherePublisher().flatMap({ sphere in
+            sphere.getPetnameChangesPublisher(sinceCid: sinceCid)
+        })
+        .eraseToAnyPublisher()
     }
 
     func traverse(petname: Petname) throws -> Sphere {
         try self.sphere().traverse(petname: petname)
+    }
+    
+    func traversePublisher(petname: Petname) -> AnyPublisher<Sphere, Error> {
+        self.spherePublisher().flatMap({ sphere in
+            sphere.traversePublisher(petname: petname)
+        })
+        .eraseToAnyPublisher()
     }
 }

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -133,7 +133,7 @@ final class NoosphereService: SphereProtocol, SpherePublisherProtocol {
     }
     
     private func spherePublisher() -> AnyPublisher<Sphere, Error> {
-        Future {
+        Future.resolve {
             try self.sphere()
         }
         .eraseToAnyPublisher()

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -29,7 +29,7 @@ enum NoosphereServiceError: Error, LocalizedError {
 }
 
 /// Creates and manages Noosphere and default sphere singletons.
-final class NoosphereService: SphereProtocol {
+final class NoosphereService: SphereProtocol, SpherePublisherProtocol {
     /// Default logger for NoosphereService instances.
     private static let logger = Logger(
         subsystem: Config.default.rdns,
@@ -158,11 +158,36 @@ final class NoosphereService: SphereProtocol {
         try? self.sphere().getFileVersion(slashlink: slashlink)
     }
     
+    func getFileVersionPublisher(
+        slashlink: Slashlink
+    ) -> AnyPublisher<String?, Never> {
+        self.spherePublisher().flatMap({ sphere in
+            sphere.getFileVersionPublisher(slashlink: slashlink)
+        }).catch({ error in
+            Just(nil)
+        })
+        .eraseToAnyPublisher()
+    }
+    
     func readHeaderValueFirst(slashlink: Slashlink, name: String) -> String? {
         try? self.sphere().readHeaderValueFirst(
             slashlink: slashlink,
             name: name
         )
+    }
+    
+    func readHeaderValueFirstPublisher(
+        slashlink: Slashlink,
+        name: String
+    ) -> AnyPublisher<String?, Never> {
+        self.spherePublisher().flatMap({ sphere in
+            sphere.readHeaderValueFirstPublisher(
+                slashlink: slashlink,
+                name: name
+            )
+        }).catch({ error in
+            Just(nil)
+        }).eraseToAnyPublisher()
     }
     
     func readHeaderNames(slashlink: Slashlink) -> [String] {
@@ -172,6 +197,16 @@ final class NoosphereService: SphereProtocol {
             return []
         }
         return names
+    }
+    
+    func readHeaderNamesPublisher(
+        slashlink: Slashlink
+    ) -> AnyPublisher<[String], Never> {
+        self.spherePublisher().flatMap({ sphere in
+            sphere.readHeaderNamesPublisher(slashlink: slashlink)
+        }).catch({ error in
+            Just([])
+        }).eraseToAnyPublisher()
     }
     
     func read(slashlink: Slashlink) throws -> MemoData {

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -13,6 +13,7 @@
 //  4. Open sphere file system (on-demand)
 
 import Foundation
+import Combine
 import SwiftNoosphere
 import os
 
@@ -131,12 +132,26 @@ final class NoosphereService: SphereProtocol {
         return sphere
     }
     
+    private func spherePublisher() -> AnyPublisher<Sphere, Error> {
+        Future {
+            try self.sphere()
+        }
+        .eraseToAnyPublisher()
+    }
+
     func identity() throws -> String {
         try self.sphere().identity
     }
 
     func version() throws -> String {
         try self.sphere().version()
+    }
+    
+    func versionPublisher() -> AnyPublisher<String, Error> {
+        self.spherePublisher().flatMap({ sphere in
+            sphere.versionPublisher()
+        })
+        .eraseToAnyPublisher()
     }
     
     func getFileVersion(slashlink: Slashlink) -> String? {

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -28,8 +28,30 @@ enum NoosphereServiceError: Error, LocalizedError {
     }
 }
 
+protocol NoosphereServiceProtocol {
+    var globalStorageURL: URL { get }
+    var sphereStorageURL: URL { get }
+    var gatewayURL: URL? { get }
+
+    func createSphere(ownerKeyName: String) throws -> SphereReceipt
+
+    /// Set a new default sphere
+    func resetSphere(_ identity: String?)
+    
+    /// Update Gateway.
+    /// Resets memoized Noosphere and Sphere instances.
+    func resetGateway(url: URL?)
+    
+    /// Reset managed instances of Noosphere and Sphere
+    func reset()
+}
+
 /// Creates and manages Noosphere and default sphere singletons.
-final class NoosphereService: SphereProtocol, SpherePublisherProtocol {
+final class NoosphereService:
+    SphereProtocol,
+    SpherePublisherProtocol,
+    NoosphereServiceProtocol
+{
     /// Default logger for NoosphereService instances.
     private static let logger = Logger(
         subsystem: Config.default.rdns,

--- a/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
@@ -413,7 +413,7 @@ public final class Sphere: SphereProtocol, SpherePublisherProtocol {
     public func write(
         slug: Slug,
         contentType: String,
-        additionalHeaders: [Header],
+        additionalHeaders: [Header] = [],
         body: Data
     ) throws {
         try queue.sync {
@@ -431,7 +431,7 @@ public final class Sphere: SphereProtocol, SpherePublisherProtocol {
     public func writePublisher(
         slug: Slug,
         contentType: String,
-        additionalHeaders: [Header],
+        additionalHeaders: [Header] = [],
         body: Data
     ) -> AnyPublisher<Void, Error> {
         queue.future {

--- a/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
@@ -157,7 +157,7 @@ public final class Sphere: SphereProtocol, SpherePublisherProtocol {
     private var queue: DispatchQueue {
         noosphere.queue
     }
-
+    
     private init(noosphere: Noosphere, sphere: OpaquePointer, identity: String) {
         self.noosphere = noosphere
         self.sphere = sphere
@@ -300,6 +300,7 @@ public final class Sphere: SphereProtocol, SpherePublisherProtocol {
         .eraseToAnyPublisher()
     }
     
+
     /// Read the value of a memo from this, or another sphere
     /// - Returns: `MemoData`
     public func read(slashlink: Slashlink) throws -> MemoData {

--- a/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
@@ -187,10 +187,7 @@ public final class Sphere: SphereProtocol, SpherePublisherProtocol {
     }
 
     public func identityPublisher() -> AnyPublisher<String, Error> {
-        Future.resolve {
-            self._identity
-        }
-        .eraseToAnyPublisher()
+        Result.success(self._identity).publisher.eraseToAnyPublisher()
     }
 
     /// Get current version of sphere synchronously

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -761,6 +761,7 @@
 				B884565229D2102D00DBCD39 /* Tests_App.swift */,
 				B8B604EA29148C82006FCB77 /* Tests_AppMigrations.swift */,
 				B8682DCC2804C379001CD8DD /* Tests_CollectionUtilities.swift */,
+				B88DFEF029E7454100B00DE8 /* Tests_CombineUtilities.swift */,
 				B88CC955284FCF8C00994928 /* Tests_DatabaseService.swift */,
 				B87288DF299B05B500EF7E07 /* Tests_DataService.swift */,
 				B8AAAAD828CBD68600DBC8A9 /* Tests_Detail.swift */,
@@ -773,6 +774,7 @@
 				B809AFF328D8E7BC00D0589A /* Tests_MarkupText.swift */,
 				B80CC804299D14C900C4D7C0 /* Tests_Memo.swift */,
 				B886A9B729A7E41700BFF9A2 /* Tests_MemoAddress.swift */,
+				B88A76D629E0AA44005F3422 /* Tests_MemoViewerDetailMetaSheet.swift */,
 				B8B604E8291476E9006FCB77 /* Tests_Migrations.swift */,
 				B82FF241298C0DAF0097D688 /* Tests_Noosphere.swift */,
 				B8EA3756299EBA5500D98E2B /* Tests_NoosphereService.swift */,
@@ -795,8 +797,6 @@
 				B8D328B929A69D2D00850A37 /* Tests_URLUtilities.swift */,
 				B8E62AE729D61E69008F7E74 /* Tests_UserDefaultProperty.swift */,
 				B5908BEA29DAB05B00225B1A /* TestUtilities.swift */,
-				B88A76D629E0AA44005F3422 /* Tests_MemoViewerDetailMetaSheet.swift */,
-				B88DFEF029E7454100B00DE8 /* Tests_CombineUtilities.swift */,
 			);
 			path = SubconsciousTests;
 			sourceTree = "<group>";

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 		B88CC958284FF59900994928 /* OrderedCollectionUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88CC957284FF59900994928 /* OrderedCollectionUtilities.swift */; };
 		B88CC959284FF59900994928 /* OrderedCollectionUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88CC957284FF59900994928 /* OrderedCollectionUtilities.swift */; };
 		B88CC95B284FF64300994928 /* Tests_OrderedCollectionUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88CC95A284FF64300994928 /* Tests_OrderedCollectionUtilities.swift */; };
+		B88DFEF129E7454100B00DE8 /* Tests_CombineUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88DFEF029E7454100B00DE8 /* Tests_CombineUtilities.swift */; };
 		B8925B2B29C0FA43001F9503 /* Tests_Func.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8925B2A29C0FA43001F9503 /* Tests_Func.swift */; };
 		B8925B2D29C0FD91001F9503 /* MemoDetailResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8925B2C29C0FD91001F9503 /* MemoDetailResponse.swift */; };
 		B8925B2F29C23017001F9503 /* MemoViewerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8925B2E29C23017001F9503 /* MemoViewerDetailView.swift */; };
@@ -534,6 +535,7 @@
 		B88CC955284FCF8C00994928 /* Tests_DatabaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_DatabaseService.swift; sourceTree = "<group>"; };
 		B88CC957284FF59900994928 /* OrderedCollectionUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedCollectionUtilities.swift; sourceTree = "<group>"; };
 		B88CC95A284FF64300994928 /* Tests_OrderedCollectionUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_OrderedCollectionUtilities.swift; sourceTree = "<group>"; };
+		B88DFEF029E7454100B00DE8 /* Tests_CombineUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_CombineUtilities.swift; sourceTree = "<group>"; };
 		B8925B2A29C0FA43001F9503 /* Tests_Func.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_Func.swift; sourceTree = "<group>"; };
 		B8925B2C29C0FD91001F9503 /* MemoDetailResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoDetailResponse.swift; sourceTree = "<group>"; };
 		B8925B2E29C23017001F9503 /* MemoViewerDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoViewerDetailView.swift; sourceTree = "<group>"; };
@@ -794,6 +796,7 @@
 				B8E62AE729D61E69008F7E74 /* Tests_UserDefaultProperty.swift */,
 				B5908BEA29DAB05B00225B1A /* TestUtilities.swift */,
 				B88A76D629E0AA44005F3422 /* Tests_MemoViewerDetailMetaSheet.swift */,
+				B88DFEF029E7454100B00DE8 /* Tests_CombineUtilities.swift */,
 			);
 			path = SubconsciousTests;
 			sourceTree = "<group>";
@@ -1444,6 +1447,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B88DFEF129E7454100B00DE8 /* Tests_CombineUtilities.swift in Sources */,
 				B82FF242298C0DAF0097D688 /* Tests_Noosphere.swift in Sources */,
 				B80CC807299D4DF000C4D7C0 /* Tests_SQLite3Database.swift in Sources */,
 				B84AD8E1280F7A19006B3153 /* Tests_StringUtilities.swift in Sources */,

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,6 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/subconsciousnetwork/noosphere",
       "state" : {
-        "branch" : "main",
         "revision" : "ffcff5d1d6f5cec3b6c34731dc5c99cc25c3bc34"
       }
     },

--- a/xcode/Subconscious/SubconsciousTests/TestUtilities.swift
+++ b/xcode/Subconscious/SubconsciousTests/TestUtilities.swift
@@ -25,10 +25,17 @@ struct TestUtilities {
         return url
     }
     
+    struct DataServiceEnvironment {
+        var data: DataService
+        var noosphere: NoosphereService
+        var local: HeaderSubtextMemoStore
+        var addressBook: AddressBookService
+    }
+
     /// Set up and return a data service instance
-    static func createDataService(
+    static func createDataServiceEnvironment(
         tmp: URL
-    ) throws -> DataService {
+    ) async throws -> DataServiceEnvironment {
         let globalStorageURL = tmp.appending(path: "noosphere")
         let sphereStorageURL = tmp.appending(path: "sphere")
         
@@ -38,8 +45,8 @@ struct TestUtilities {
             gatewayURL: URL(string: "http://unavailable-gateway.fakewebsite")
         )
         
-        let receipt = try noosphere.createSphere(ownerKeyName: "bob")
-        noosphere.resetSphere(receipt.identity)
+        let receipt = try await noosphere.createSphere(ownerKeyName: "bob")
+        await noosphere.resetSphere(receipt.identity)
         
         let databaseURL = tmp.appending(
             path: "database.sqlite",
@@ -66,9 +73,16 @@ struct TestUtilities {
             database: database
         )
         
-        return DataService(
+        let data = DataService(
             noosphere: noosphere,
             database: database,
+            local: local,
+            addressBook: addressBook
+        )
+
+        return DataServiceEnvironment(
+            data: data,
+            noosphere: noosphere,
             local: local,
             addressBook: addressBook
         )

--- a/xcode/Subconscious/SubconsciousTests/Tests_CombineUtilities.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_CombineUtilities.swift
@@ -23,7 +23,6 @@ final class Tests_CombineUtilities: XCTestCase {
     func testFutureTaskAsync() throws {
         let future = Future {
             XCTAssertFalse(Thread.isMainThread, "Run in separate thread")
-            try await Task.sleep(for: .seconds(0.2))
             return 10
         }
         
@@ -75,7 +74,6 @@ final class Tests_CombineUtilities: XCTestCase {
     func testFutureDetatchedTaskAsync() throws {
         let future = Future.detatched {
             XCTAssertFalse(Thread.isMainThread, "Run in separate thread")
-            try await Task.sleep(for: .seconds(0.2))
             return 10
         }
         

--- a/xcode/Subconscious/SubconsciousTests/Tests_CombineUtilities.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_CombineUtilities.swift
@@ -1,0 +1,74 @@
+//
+//  Tests_CombineUtilities.swift
+//  SubconsciousTests
+//
+//  Created by Gordon Brander on 4/12/23.
+//
+
+import XCTest
+import Combine
+@testable import Subconscious
+
+final class Tests_CombineUtilities: XCTestCase {
+    enum TestError: Error {
+        case code(Int)
+    }
+
+    var cancellables: Set<AnyCancellable> = Set()
+    
+    override func setUp() {
+        cancellables = Set()
+    }
+    
+    func testDispatchQueueFuture() throws {
+        let future = DispatchQueue.global().future {
+            XCTAssertFalse(Thread.isMainThread, "Run in separate thread")
+            Thread.sleep(forTimeInterval: 0.2)
+            return 10
+        }
+        
+        let expectation = XCTestExpectation(
+            description: "Future succeeds"
+        )
+        
+        future.sink(
+            receiveCompletion: { completion in
+                expectation.fulfill()
+            },
+            receiveValue: { value in
+                XCTAssertEqual(value, 10)
+            }
+        )
+        .store(in: &cancellables)
+        
+        wait(for: [expectation], timeout: 0.3)
+    }
+    
+    func testDispatchQueueError() throws {
+        let future: Future<Int, Error> = DispatchQueue.global().future {
+            throw TestError.code(10)
+        }
+
+        let expectation = XCTestExpectation(
+            description: "Future succeeds"
+        )
+
+        future.sink(
+            receiveCompletion: { completion in
+                switch completion {
+                case let .failure(TestError.code(value)):
+                    XCTAssertEqual(value, 10)
+                    expectation.fulfill()
+                default:
+                    XCTFail("Incorrect completion: \(completion)")
+                }
+                return
+            },
+            receiveValue: { value in
+            }
+        )
+        .store(in: &cancellables)
+        
+        wait(for: [expectation], timeout: 0.2)
+    }
+}

--- a/xcode/Subconscious/SubconsciousTests/Tests_CombineUtilities.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_CombineUtilities.swift
@@ -71,62 +71,6 @@ final class Tests_CombineUtilities: XCTestCase {
         
         wait(for: [expectation], timeout: 0.2)
     }
-    
-    func testResolve() throws {
-        let future: Future<Int, Error> = Future.resolve {
-            10
-        }
-        
-        let expectation = XCTestExpectation(
-            description: "Future resolves"
-        )
-        
-        future.sink(
-            receiveCompletion: { completion in
-                switch completion {
-                case .finished:
-                    expectation.fulfill()
-                default:
-                    XCTFail("Incorrect completion: \(completion)")
-                }
-                return
-            },
-            receiveValue: { value in
-                XCTAssertEqual(value, 10)
-            }
-        )
-        .store(in: &cancellables)
-        
-        wait(for: [expectation], timeout: 0.2)
-    }
-    
-    func testResolveError() throws {
-        let future: Future<Int, Error> = Future.resolve {
-            throw TestError.code(10)
-        }
-        
-        let expectation = XCTestExpectation(
-            description: "Future resolves"
-        )
-        
-        future.sink(
-            receiveCompletion: { completion in
-                switch completion {
-                case let .failure(TestError.code(value)):
-                    XCTAssertEqual(value, 10)
-                    expectation.fulfill()
-                default:
-                    XCTFail("Incorrect completion: \(completion)")
-                }
-                return
-            },
-            receiveValue: { value in
-            }
-        )
-        .store(in: &cancellables)
-        
-        wait(for: [expectation], timeout: 0.2)
-    }
 
     func testRecover() throws {
         let future: Future<Int, Error> = DispatchQueue.global().future {

--- a/xcode/Subconscious/SubconsciousTests/Tests_CombineUtilities.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_CombineUtilities.swift
@@ -72,6 +72,62 @@ final class Tests_CombineUtilities: XCTestCase {
         wait(for: [expectation], timeout: 0.2)
     }
     
+    func testResolve() throws {
+        let future: Future<Int, Error> = Future.resolve {
+            10
+        }
+        
+        let expectation = XCTestExpectation(
+            description: "Future resolves"
+        )
+        
+        future.sink(
+            receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    expectation.fulfill()
+                default:
+                    XCTFail("Incorrect completion: \(completion)")
+                }
+                return
+            },
+            receiveValue: { value in
+                XCTAssertEqual(value, 10)
+            }
+        )
+        .store(in: &cancellables)
+        
+        wait(for: [expectation], timeout: 0.2)
+    }
+    
+    func testResolveError() throws {
+        let future: Future<Int, Error> = Future.resolve {
+            throw TestError.code(10)
+        }
+        
+        let expectation = XCTestExpectation(
+            description: "Future resolves"
+        )
+        
+        future.sink(
+            receiveCompletion: { completion in
+                switch completion {
+                case let .failure(TestError.code(value)):
+                    XCTAssertEqual(value, 10)
+                    expectation.fulfill()
+                default:
+                    XCTFail("Incorrect completion: \(completion)")
+                }
+                return
+            },
+            receiveValue: { value in
+            }
+        )
+        .store(in: &cancellables)
+        
+        wait(for: [expectation], timeout: 0.2)
+    }
+
     func testRecover() throws {
         let future: Future<Int, Error> = DispatchQueue.global().future {
             throw TestError.code(10)

--- a/xcode/Subconscious/SubconsciousTests/Tests_DataService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DataService.swift
@@ -106,7 +106,7 @@ final class Tests_DataService: XCTestCase {
         )
         
         // Supposed to fail
-        let synced = try await environment.noosphere.sync()
+        let synced = try? await environment.noosphere.sync()
         XCTAssertNil(synced)
         
         let detail = try await environment.data.readMemoEditorDetail(

--- a/xcode/Subconscious/SubconsciousTests/Tests_Func.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Func.swift
@@ -19,6 +19,14 @@ final class Tests_Func: XCTestCase {
         XCTAssertEqual(x, 15, "Returns value")
     }
     
+    func testRunAsync() async throws {
+        let x = try await Func.run({
+            try await Task.sleep(for: .seconds(0.1))
+            return 15
+        })
+        XCTAssertEqual(x, 15, "Returns value")
+    }
+
     enum TestError: Error {
         case error
     }

--- a/xcode/Subconscious/SubconsciousTests/Tests_NoosphereService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_NoosphereService.swift
@@ -22,49 +22,58 @@ final class Tests_NoosphereService: XCTestCase {
         return url
     }
     
-    func testSphereTraversal() throws {
+    func testSphereTraversal() async throws {
         throw XCTSkip("Sphere Traversal relies on running a gateway, this test will not pass currently.")
         
         let tmp = try TestUtilities.createTmpDir()
-        let data = try TestUtilities.createDataService(tmp: tmp)
-        let noosphere = data.noosphere
+        let globalStorageURL = tmp.appending(path: "noosphere")
+        let sphereStorageURL = tmp.appending(path: "sphere")
         
-        let bobReceipt = try noosphere.createSphere(ownerKeyName: "bob")
-        let aliceReceipt = try noosphere.createSphere(ownerKeyName: "alice")
+        let noosphere = NoosphereService(
+            globalStorageURL: globalStorageURL,
+            sphereStorageURL: sphereStorageURL,
+            gatewayURL: URL(string: "http://unavailable-gateway.fakewebsite")
+        )
+        
+        let receipt = try await noosphere.createSphere(ownerKeyName: "bob")
+        await noosphere.resetSphere(receipt.identity)
+
+        let bobReceipt = try await noosphere.createSphere(ownerKeyName: "bob")
+        let aliceReceipt = try await noosphere.createSphere(ownerKeyName: "alice")
         
         let bob = Petname("bob")!
         let alice = Petname("alice")!
 
         // Put bob in alice's address book
-        noosphere.resetSphere(aliceReceipt.identity)
-        try noosphere.setPetname(did: bobReceipt.identity, petname: bob)
-        try noosphere.save()
+        await noosphere.resetSphere(aliceReceipt.identity)
+        try await noosphere.setPetname(did: bobReceipt.identity, petname: bob)
+        try await noosphere.save()
         
-        let bobDid = try noosphere.getPetname(petname: bob)
+        let bobDid = try await noosphere.getPetname(petname: bob)
         XCTAssertEqual(bobDid, bobReceipt.identity)
         
         // Put alice in bob's address book & set bob as default sphere
-        noosphere.resetSphere(bobReceipt.identity)
-        try noosphere.setPetname(did: aliceReceipt.identity, petname: alice)
-        try noosphere.save()
+        await noosphere.resetSphere(bobReceipt.identity)
+        try await noosphere.setPetname(did: aliceReceipt.identity, petname: alice)
+        try await noosphere.save()
         
-        let aliceDid = try noosphere.getPetname(petname: alice)
+        let aliceDid = try await noosphere.getPetname(petname: alice)
         XCTAssertEqual(aliceDid, aliceReceipt.identity)
         
-        
-        _ = try noosphere.sync()
+        _ = try await noosphere.sync()
         // This should loop back around to bob
-        let destinationSphere = try noosphere
+        let destinationSphere = try await noosphere
             .traverse(petname: alice)
             .traverse(petname: bob)
 
         // Clear out Noosphere and Sphere instance
-        noosphere.reset()
+        await noosphere.reset()
         
-        XCTAssertEqual(destinationSphere.identity, bobReceipt.identity)
+        let sphereIdentity = try await destinationSphere.identity()
+        XCTAssertEqual(sphereIdentity, bobReceipt.identity)
     }
     
-    func testNoosphereReset() throws {
+    func testNoosphereReset() async throws {
         let base = UUID()
         
         let globalStorageURL = try Self.createTmpDir("\(base)/noosphere")
@@ -75,40 +84,40 @@ final class Tests_NoosphereService: XCTestCase {
             sphereStorageURL: sphereStorageURL
         )
 
-        let receipt = try noosphere.createSphere(ownerKeyName: "bob")
-        noosphere.resetSphere(receipt.identity)
+        let receipt = try await noosphere.createSphere(ownerKeyName: "bob")
+        await noosphere.resetSphere(receipt.identity)
 
-        let versionA = try noosphere.version()
+        let versionA = try await noosphere.version()
         
         let body = try "Test content".toData().unwrap()
-        try noosphere.write(
+        try await noosphere.write(
             slug: Slug("a")!,
             contentType: "text/subtext",
             additionalHeaders: [],
             body: body
         )
-        let versionB = try noosphere.save()
+        let versionB = try await noosphere.save()
         XCTAssertNotEqual(versionA, versionB)
 
-        try noosphere.write(
+        try await noosphere.write(
             slug: Slug("b")!,
             contentType: "text/subtext",
             additionalHeaders: [],
             body: body
         )
-        try noosphere.write(
+        try await noosphere.write(
             slug: Slug("c")!,
             contentType: "text/subtext",
             additionalHeaders: [],
             body: body
         )
-        let versionC = try noosphere.save()
+        let versionC = try await noosphere.save()
         XCTAssertNotEqual(versionB, versionC)
 
         // Clear out Noosphere and Sphere instance
-        noosphere.reset()
+        await noosphere.reset()
 
-        let versionZ = try noosphere.version()
+        let versionZ = try await noosphere.version()
         XCTAssertEqual(versionC, versionZ)
     }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_Sphere.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Sphere.swift
@@ -22,7 +22,7 @@ final class Tests_Sphere: XCTestCase {
         return url
     }
     
-    func testRoundtrip() throws {
+    func testRoundtrip() async throws {
         let base = UUID()
         
         let globalStoragePath = try createTmpDir(path: "\(base)/noosphere")
@@ -36,7 +36,9 @@ final class Tests_Sphere: XCTestCase {
             sphereStoragePath: sphereStoragePath
         )
         
-        let sphereReceipt = try noosphere.createSphere(ownerKeyName: "bob")
+        let sphereReceipt = try await noosphere.createSphere(
+            ownerKeyName: "bob"
+        )
         
         do {
             let sphere = try Sphere(
@@ -44,13 +46,13 @@ final class Tests_Sphere: XCTestCase {
                 identity: sphereReceipt.identity
             )
             
-            try sphere.write(
+            try await sphere.write(
                 slug: Slug("foo")!,
                 contentType: "text/subtext",
                 body: "Test".toData(encoding: .utf8)!
             )
-            _ = try sphere.save()
-            let memo = try sphere.read(slashlink: Slashlink("/foo")!)
+            _ = try await sphere.save()
+            let memo = try await sphere.read(slashlink: Slashlink("/foo")!)
             XCTAssertEqual(memo.contentType, "text/subtext")
             let content = memo.body.toString()
             XCTAssertEqual(content, "Test")
@@ -62,12 +64,12 @@ final class Tests_Sphere: XCTestCase {
                 noosphere: noosphere,
                 identity: sphereReceipt.identity
             )
-            let memo = try sphere.read(slashlink: Slashlink("/foo")!)
+            let memo = try await sphere.read(slashlink: Slashlink("/foo")!)
             XCTAssertEqual(memo.contentType, "text/subtext")
         }
     }
     
-    func testHeadersRoundtrip() throws {
+    func testHeadersRoundtrip() async throws {
         let base = UUID()
         
         let globalStoragePath = try createTmpDir(path: "\(base)/noosphere")
@@ -81,7 +83,9 @@ final class Tests_Sphere: XCTestCase {
             sphereStoragePath: sphereStoragePath
         )
         
-        let sphereReceipt = try noosphere.createSphere(ownerKeyName: "bob")
+        let sphereReceipt = try await noosphere.createSphere(
+            ownerKeyName: "bob"
+        )
         
         let sphere = try Sphere(
             noosphere: noosphere,
@@ -89,7 +93,7 @@ final class Tests_Sphere: XCTestCase {
         )
         
         let then = Date.distantPast.ISO8601Format()
-        try sphere.write(
+        try await sphere.write(
             slug: Slug("foo")!,
             contentType: "text/subtext",
             additionalHeaders: [
@@ -100,8 +104,8 @@ final class Tests_Sphere: XCTestCase {
             ],
             body: "Test".toData(encoding: .utf8)!
         )
-        _ = try sphere.save()
-        let memo = try sphere.read(slashlink: Slashlink("/foo")!)
+        _ = try await sphere.save()
+        let memo = try await sphere.read(slashlink: Slashlink("/foo")!)
         XCTAssertEqual(memo.contentType, "text/subtext")
         XCTAssertEqual(memo.body.toString(), "Test")
         
@@ -118,7 +122,7 @@ final class Tests_Sphere: XCTestCase {
         XCTAssertEqual(modified, then)
     }
     
-    func testList() throws {
+    func testList() async throws {
         let base = UUID()
         
         let globalStoragePath = try createTmpDir(path: "\(base)/noosphere")
@@ -132,7 +136,9 @@ final class Tests_Sphere: XCTestCase {
             sphereStoragePath: sphereStoragePath
         )
         
-        let sphereReceipt = try noosphere.createSphere(ownerKeyName: "bob")
+        let sphereReceipt = try await noosphere.createSphere(
+            ownerKeyName: "bob"
+        )
         
         let sphere = try Sphere(
             noosphere: noosphere,
@@ -141,38 +147,38 @@ final class Tests_Sphere: XCTestCase {
         
         let body = "Test".toData(encoding: .utf8)!
         
-        try sphere.write(
+        try await sphere.write(
             slug: Slug("foo")!,
             contentType: "text/subtext",
             body: body
         )
-        try sphere.write(
+        try await sphere.write(
             slug: Slug("bar")!,
             contentType: "text/subtext",
             body: body
         )
-        try sphere.write(
+        try await sphere.write(
             slug: Slug("baz")!,
             contentType: "text/subtext",
             body: body
         )
         
-        let slugsA = try sphere.list()
+        let slugsA = try await sphere.list()
         XCTAssertEqual(
             slugsA,
             [],
             "Lists all slugs in latest version of sphere"
         )
         
-        _ = try sphere.save()
+        _ = try await sphere.save()
         
-        let slugsB = try sphere.list()
+        let slugsB = try await sphere.list()
         XCTAssertTrue(slugsB.contains(Slug("foo")!))
         XCTAssertTrue(slugsB.contains(Slug("bar")!))
         XCTAssertTrue(slugsB.contains(Slug("baz")!))
     }
     
-    func testChanges() throws {
+    func testChanges() async throws {
         let base = UUID()
         
         let globalStoragePath = try createTmpDir(path: "\(base)/noosphere")
@@ -186,7 +192,9 @@ final class Tests_Sphere: XCTestCase {
             sphereStoragePath: sphereStoragePath
         )
         
-        let sphereReceipt = try noosphere.createSphere(ownerKeyName: "bob")
+        let sphereReceipt = try await noosphere.createSphere(
+            ownerKeyName: "bob"
+        )
         
         let sphere = try Sphere(
             noosphere: noosphere,
@@ -195,50 +203,50 @@ final class Tests_Sphere: XCTestCase {
         
         let body = "Test".toData(encoding: .utf8)!
         
-        try sphere.write(
+        try await sphere.write(
             slug: Slug("foo")!,
             contentType: "text/subtext",
             body: body
         )
         
-        let a = try sphere.save()
-        let changesA = try sphere.changes()
+        let a = try await sphere.save()
+        let changesA = try await sphere.changes()
         XCTAssertEqual(changesA.count, 1)
         XCTAssertTrue(changesA.contains(Slug("foo")!))
         
-        try sphere.write(
+        try await sphere.write(
             slug: Slug("bar")!,
             contentType: "text/subtext",
             body: body
         )
-        try sphere.write(
+        try await sphere.write(
             slug: Slug("baz")!,
             contentType: "text/subtext",
             body: body
         )
-        let b = try sphere.save()
+        let b = try await sphere.save()
         
-        let changesB = try sphere.changes(a)
+        let changesB = try await sphere.changes(a)
         XCTAssertEqual(changesB.count, 2)
         XCTAssertTrue(changesB.contains(Slug("bar")!))
         XCTAssertTrue(changesB.contains(Slug("baz")!))
         XCTAssertFalse(changesB.contains(Slug("foo")!))
         
-        try sphere.write(
+        try await sphere.write(
             slug: Slug("bing")!,
             contentType: "text/subtext",
             body: body
         )
-        _ = try sphere.save()
+        _ = try await sphere.save()
         
-        let changesC = try sphere.changes(b)
+        let changesC = try await sphere.changes(b)
         XCTAssertEqual(changesC.count, 1)
         XCTAssertTrue(changesC.contains(Slug("bing")!))
         XCTAssertFalse(changesC.contains(Slug("baz")!))
         XCTAssertFalse(changesC.contains(Slug("foo")!))
     }
     
-    func testRemove() throws {
+    func testRemove() async throws {
         let base = UUID()
         
         let globalStoragePath = try createTmpDir(path: "\(base)/noosphere")
@@ -252,7 +260,9 @@ final class Tests_Sphere: XCTestCase {
             sphereStoragePath: sphereStoragePath
         )
         
-        let sphereReceipt = try noosphere.createSphere(ownerKeyName: "bob")
+        let sphereReceipt = try await noosphere.createSphere(
+            ownerKeyName: "bob"
+        )
         
         let sphere = try Sphere(
             noosphere: noosphere,
@@ -261,31 +271,31 @@ final class Tests_Sphere: XCTestCase {
         
         let body = "Test".toData(encoding: .utf8)!
         
-        try sphere.write(
+        try await sphere.write(
             slug: Slug("foo")!,
             contentType: "text/subtext",
             body: body
         )
-        try sphere.write(
+        try await sphere.write(
             slug: Slug("bar")!,
             contentType: "text/subtext",
             body: body
         )
         
-        _ = try sphere.save()
+        _ = try await sphere.save()
         
-        try sphere.remove(slug: Slug("foo")!)
+        try await sphere.remove(slug: Slug("foo")!)
         
-        _ = try sphere.save()
+        _ = try await sphere.save()
         
-        let slugs = try sphere.list()
+        let slugs = try await sphere.list()
         
         XCTAssertEqual(slugs.count, 1)
         XCTAssertTrue(slugs.contains(Slug("bar")!))
         XCTAssertFalse(slugs.contains(Slug("foo")!))
     }
     
-    func testSaveVersion() throws {
+    func testSaveVersion() async throws {
         let base = UUID()
         
         let globalStoragePath = try createTmpDir(path: "\(base)/noosphere")
@@ -299,24 +309,26 @@ final class Tests_Sphere: XCTestCase {
             sphereStoragePath: sphereStoragePath
         )
         
-        let sphereReceipt = try noosphere.createSphere(ownerKeyName: "bob")
+        let sphereReceipt = try await noosphere.createSphere(
+            ownerKeyName: "bob"
+        )
         
         let sphere = try Sphere(
             noosphere: noosphere,
             identity: sphereReceipt.identity
         )
         
-        let versionA = try sphere.version()
+        let versionA = try await sphere.version()
         
-        try sphere.write(
+        try await sphere.write(
             slug: Slug("foo")!,
             contentType: "text/subtext",
             body: "Test".toData(encoding: .utf8)!
         )
         
-        let version = try sphere.save()
+        let version = try await sphere.save()
         
-        let versionB = try sphere.version()
+        let versionB = try await sphere.version()
         
         XCTAssertNotEqual(
             versionA,
@@ -331,7 +343,7 @@ final class Tests_Sphere: XCTestCase {
         )
     }
     
-    func testFailedSync() throws {
+    func testFailedSync() async throws {
         let base = UUID()
         
         let globalStoragePath = try createTmpDir(path: "\(base)/noosphere")
@@ -346,7 +358,9 @@ final class Tests_Sphere: XCTestCase {
             gatewayURL: "http://fake-gateway.fake"
         )
         
-        let sphereReceipt = try noosphere.createSphere(ownerKeyName: "bob")
+        let sphereReceipt = try await noosphere.createSphere(
+            ownerKeyName: "bob"
+        )
         
         let sphere = try Sphere(
             noosphere: noosphere,
@@ -354,20 +368,20 @@ final class Tests_Sphere: XCTestCase {
         )
         
         // Should fail
-        _ = try? sphere.sync()
+        _ = try? await sphere.sync()
         
-        try sphere.write(
+        try await sphere.write(
             slug: Slug("foo")!,
             contentType: "text/subtext",
             body: "Test".toData(encoding: .utf8)!
         )
         
-        try sphere.save()
+        try await sphere.save()
         
-        let foo = try sphere.read(slashlink: Slashlink("/foo")!)
+        let foo = try await sphere.read(slashlink: Slashlink("/foo")!)
         
         // Should fail
-        _ = try? sphere.sync()
+        _ = try? await sphere.sync()
         
         XCTAssertEqual(
             foo.body.toString(),
@@ -376,7 +390,7 @@ final class Tests_Sphere: XCTestCase {
         )
     }
     
-    func testWritesThenCloseThenReopenWithScopes() throws {
+    func testWritesThenCloseThenReopenWithScopes() async throws {
         let base = UUID()
         
         let globalStoragePath = try createTmpDir(path: "\(base)/noosphere")
@@ -394,7 +408,9 @@ final class Tests_Sphere: XCTestCase {
                 sphereStoragePath: sphereStoragePath
             )
             
-            let sphereReceipt = try noosphere.createSphere(ownerKeyName: "bob")
+            let sphereReceipt = try await noosphere.createSphere(
+                ownerKeyName: "bob"
+            )
             
             sphereIdentity = sphereReceipt.identity
             
@@ -403,15 +419,15 @@ final class Tests_Sphere: XCTestCase {
                 identity: sphereReceipt.identity
             )
             
-            startVersion = try sphere.version()
+            startVersion = try await sphere.version()
             
             let body = try "Test content".toData().unwrap()
             let contentType = "text/subtext"
-            try sphere.write(slug: Slug("a")!, contentType: contentType, body: body)
-            try sphere.write(slug: Slug("b")!, contentType: contentType, body: body)
-            try sphere.write(slug: Slug("c")!, contentType: contentType, body: body)
-            let version = try sphere.save()
-            endVersion = try sphere.version()
+            try await sphere.write(slug: Slug("a")!, contentType: contentType, body: body)
+            try await sphere.write(slug: Slug("b")!, contentType: contentType, body: body)
+            try await sphere.write(slug: Slug("c")!, contentType: contentType, body: body)
+            let version = try await sphere.save()
+            endVersion = try await sphere.version()
             XCTAssertEqual(version, endVersion)
             XCTAssertNotEqual(startVersion, endVersion)
         }
@@ -426,13 +442,13 @@ final class Tests_Sphere: XCTestCase {
                 noosphere: noosphere,
                 identity: sphereIdentity
             )
-            let version = try sphere.version()
+            let version = try await sphere.version()
             
             XCTAssertEqual(version, endVersion)
         }
     }
     
-    func testWritesThenCloseThenReopenWithVars() throws {
+    func testWritesThenCloseThenReopenWithVars() async throws {
         let base = UUID()
 
         let globalStoragePath = try createTmpDir(path: "\(base)/noosphere")
@@ -446,7 +462,9 @@ final class Tests_Sphere: XCTestCase {
             sphereStoragePath: sphereStoragePath
         )
 
-        let sphereReceipt = try noosphere.createSphere(ownerKeyName: "bob")
+        let sphereReceipt = try await noosphere.createSphere(
+            ownerKeyName: "bob"
+        )
         
         let sphereIdentity = sphereReceipt.identity
 
@@ -455,19 +473,31 @@ final class Tests_Sphere: XCTestCase {
             identity: sphereReceipt.identity
         )
 
-        let versionA0 = try sphere.version()
+        let versionA0 = try await sphere.version()
 
         let body = try "Test content".toData().unwrap()
         let contentType = "text/subtext"
-        try sphere.write(slug: Slug("a")!, contentType: contentType, body: body)
+        try await sphere.write(
+            slug: Slug("a")!,
+            contentType: contentType,
+            body: body
+        )
 
-        let versionA1 = try sphere.save()
+        let versionA1 = try await sphere.save()
 
-        try sphere.write(slug: Slug("b")!, contentType: contentType, body: body)
-        try sphere.write(slug: Slug("c")!, contentType: contentType, body: body)
-        let versionA2 = try sphere.save()
+        try await sphere.write(
+            slug: Slug("b")!,
+            contentType: contentType,
+            body: body
+        )
+        try await sphere.write(
+            slug: Slug("c")!,
+            contentType: contentType,
+            body: body
+        )
+        let versionA2 = try await sphere.save()
 
-        let versionAN = try sphere.version()
+        let versionAN = try await sphere.version()
 
         XCTAssertNotEqual(versionA0, versionAN)
         XCTAssertNotEqual(versionA1, versionAN)
@@ -483,7 +513,7 @@ final class Tests_Sphere: XCTestCase {
             noosphere: noosphere,
             identity: sphereIdentity
         )
-        let versionB0 = try sphere.version()
+        let versionB0 = try await sphere.version()
 
         XCTAssertEqual(versionB0, versionAN)
     }


### PR DESCRIPTION
Fixes #439 

There are a few places where we have inadvertently called Noosphere synchronously on the main thread, causing the UI to block on certain long operations, like syncing. This should never happen.

This PR fixes the issue, and makes services Swift `actor`s to make it difficult to trip over this footgun. Actors are isolated, and can only be accessed via async/await. This means you cannot accidentally call blocking synchronous APIs on an actor (as I found we were doing in a number of subtle places). You must await, or else wrap in some kind of callback or publisher. This prevents us from accidentally causing UI hangs.

## Notes

- `NoosphereService`, `Noosphere` and `Sphere` are now Swift `actor`s. That means they always run off of the main thread, and are isolated (can only be accessed from the outside via `async`/`await` or via thread-safe things like publishers).
    - Swift manages a cooperative threadpool of non-main-thread threads for all actors. The thread pool is concurrent.
- A new `SpherePublisherProtocol` exposes nonisolated publishers for Noosphere actions.
    - `NoosphereService` conforms to `SpherePublisherProtocol`
- Services have been "flattened". App Environment holds a bag of services, each of which do one job.
    - Services may depend upon each other by passing in references during construction
    - Services keep their dependencies private. This means there is no calling `data.noosphere` anymore. If you need `noosphere`, you should just call `noosphere`.
    - Services are expected to handle their own thread-safety/atomicity if needed
- This gets us most of the way to the design discussed in #462 
    - I tried exposing only protocols for services, so that components could specify only the requirements they needed. However, this had a lot of sharp edges. Swift's type system is just not up to the task of generics with protocol constraints. I ended up going back to environments made up of concrete types.