### PR TITLE
Fix typo `detatched` -> `detached`

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -754,7 +754,7 @@ struct AppModel: ModelProtocol {
         AppDefaults.standard.gatewayURL = gatewayURL
 
         // Reset gateway on environment
-        let fx: Fx<AppAction> = Future.detatched {
+        let fx: Fx<AppAction> = Future.detached {
             await environment.noosphere.resetGateway(url: url)
             return .succeedResetGatewayURL(url)
         }
@@ -780,7 +780,7 @@ struct AppModel: ModelProtocol {
     ) -> Update<AppModel> {
         let ownerKeyName = ownerKeyName ?? Config.default.noosphere.ownerKeyName
 
-        let fx: Fx<AppAction> = Future.detatched {
+        let fx: Fx<AppAction> = Future.detached {
             let receipt = try await environment.data.createSphere(
                 ownerKeyName: ownerKeyName
             )
@@ -903,7 +903,7 @@ struct AppModel: ModelProtocol {
         state: AppModel,
         environment: AppEnvironment
     ) -> Update<AppModel> {
-        let fx: Fx<AppAction> = Future.detatched {
+        let fx: Fx<AppAction> = Future.detached {
             await environment.noosphere.reset()
             return .succeedResetNoosphereService
         }

--- a/xcode/Subconscious/Shared/Library/CombineUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/CombineUtilities.swift
@@ -25,9 +25,9 @@ public extension Future where Failure == Never {
 }
 
 /// Create a Combine Future from an async closure that never fails.
-/// Async actions are run in a detatched task and fulfil the future's promise.
+/// Async actions are run in a detached task and fulfil the future's promise.
 public extension Future where Failure == Never {
-    static func detatched(
+    static func detached(
         priority: TaskPriority? = nil,
         perform: @escaping () async -> Output
     ) -> Self {
@@ -61,9 +61,9 @@ public extension Future where Failure == Error {
 }
 
 /// Create a Combine Future from an async throwing closure.
-/// Async actions are run in a detatched task and fulfil the future's promise.
+/// Async actions are run in a detached task and fulfil the future's promise.
 public extension Future where Failure == Error {
-    static func detatched(
+    static func detached(
         priority: TaskPriority? = nil,
         perform: @escaping () async throws -> Output
     ) -> Self {

--- a/xcode/Subconscious/Shared/Services/AddressBookService.swift
+++ b/xcode/Subconscious/Shared/Services/AddressBookService.swift
@@ -74,7 +74,7 @@ actor AddressBookService {
     nonisolated func listEntriesPublisher(
         refetch: Bool = false
     ) -> AnyPublisher<[AddressBookEntry], Error> {
-        Future.detatched {
+        Future.detached {
             try await self.listEntries(refetch: refetch)
         }
         .eraseToAnyPublisher()
@@ -96,7 +96,7 @@ actor AddressBookService {
         did: Did,
         petname: Petname
     ) -> AnyPublisher<Void, Error> {
-        Future.detatched {
+        Future.detached {
             try await self.followUser(did: did, petname: petname)
         }
         .eraseToAnyPublisher()
@@ -113,7 +113,7 @@ actor AddressBookService {
     nonisolated func unfollowUserPublisher(
         petname: Petname
     ) -> AnyPublisher<Void, Error> {
-        Future.detatched {
+        Future.detached {
             try await self.unfollowUser(petname: petname)
         }
         .eraseToAnyPublisher()
@@ -122,7 +122,7 @@ actor AddressBookService {
     nonisolated func getPetnamePublisher(
         petname: Petname
     ) -> AnyPublisher<Did?, Never> {
-        Future.detatched(priority: .utility) {
+        Future.detached(priority: .utility) {
             try? await Did(self.noosphere.getPetname(petname: petname))
         }
         .eraseToAnyPublisher()
@@ -136,7 +136,7 @@ actor AddressBookService {
         did: Did,
         petname: Petname
     ) -> AnyPublisher<Void, Error> {
-        Future.detatched {
+        Future.detached {
           try await self.setPetname(did: did, petname: petname)
         }
         .eraseToAnyPublisher()
@@ -149,7 +149,7 @@ actor AddressBookService {
     nonisolated func unsetPetnamePublisher(
         petname: Petname
     ) -> AnyPublisher<Void, Error> {
-        Future.detatched(priority: .utility) {
+        Future.detached(priority: .utility) {
           try await self.unsetPetname(petname: petname)
         }
         .eraseToAnyPublisher()

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -86,7 +86,7 @@ actor DataService {
     
     /// Migrate database off main thread, returning a publisher
     nonisolated func migratePublisher() -> AnyPublisher<Int, Error> {
-        Future.detatched(priority: .utility) {
+        Future.detached(priority: .utility) {
             try await self.database.migrate()
         }
         .eraseToAnyPublisher()
@@ -94,7 +94,7 @@ actor DataService {
     
     /// Rebuild database and re-sync everything.
     nonisolated func rebuildPublisher() -> AnyPublisher<Int, Error> {
-        Future.detatched(priority: .utility) {
+        Future.detached(priority: .utility) {
             try await self.database.rebuild()
         }
         .eraseToAnyPublisher()
@@ -129,7 +129,7 @@ actor DataService {
     }
     
     nonisolated func syncSphereWithDatabasePublisher() -> AnyPublisher<String, Error> {
-        Future.detatched(priority: .utility) {
+        Future.detached(priority: .utility) {
             try await self.syncSphereWithDatabase()
         }
         .eraseToAnyPublisher()
@@ -196,7 +196,7 @@ actor DataService {
     }
     
     nonisolated func syncLocalWithDatabasePublisher() -> AnyPublisher<[FileFingerprintChange], Error> {
-        Future.detatched(priority: .utility) {
+        Future.detached(priority: .utility) {
             try await self.syncLocalWithDatabase()
         }
         .eraseToAnyPublisher()
@@ -270,7 +270,7 @@ actor DataService {
     nonisolated func writeEntryPublisher(
         _ entry: MemoEntry
     ) -> AnyPublisher<Void, Error> {
-        Future.detatched(priority: .utility) {
+        Future.detached(priority: .utility) {
             try await self.writeEntry(entry)
         }
         .eraseToAnyPublisher()
@@ -296,7 +296,7 @@ actor DataService {
     nonisolated func deleteMemoPublisher(
         _ address: MemoAddress
     ) -> AnyPublisher<Void, Error> {
-        Future.detatched(priority: .utility) {
+        Future.detached(priority: .utility) {
             try await self.deleteMemo(address)
         }
         .eraseToAnyPublisher()
@@ -329,7 +329,7 @@ actor DataService {
         from: MemoAddress,
         to: MemoAddress
     ) -> AnyPublisher<MoveReceipt, Error> {
-        Future.detatched {
+        Future.detached {
             try await self.moveEntry(from: from, to: to)
         }
         .eraseToAnyPublisher()
@@ -362,14 +362,14 @@ actor DataService {
         parent: MemoAddress,
         child: MemoAddress
     ) -> AnyPublisher<Void, Error> {
-        Future.detatched {
+        Future.detached {
             try await self.mergeEntry(parent: parent, child: child)
         }
         .eraseToAnyPublisher()
     }
     
     nonisolated func listRecentMemosPublisher() -> AnyPublisher<[EntryStub], Error> {
-        Future.detatched {
+        Future.detached {
             try await self.database.listRecentMemos()
         }
         .eraseToAnyPublisher()
@@ -381,7 +381,7 @@ actor DataService {
     
     /// Count all entries
     nonisolated func countMemosPublisher() -> AnyPublisher<Int, Error> {
-        Future.detatched {
+        Future.detached {
             try await self.countMemos()
         }
         .eraseToAnyPublisher()
@@ -390,7 +390,7 @@ actor DataService {
     nonisolated func searchSuggestionsPublisher(
         query: String
     ) -> AnyPublisher<[Suggestion], Error> {
-        Future.detatched(priority: .userInitiated) {
+        Future.detached(priority: .userInitiated) {
             try await self.database.searchSuggestions(query: query)
         }
         .eraseToAnyPublisher()
@@ -403,7 +403,7 @@ actor DataService {
         omitting invalidSuggestions: Set<MemoAddress> = Set(),
         fallback: [LinkSuggestion] = []
     ) -> AnyPublisher<[LinkSuggestion], Error> {
-        Future.detatched(priority: .userInitiated) {
+        Future.detached(priority: .userInitiated) {
             await self.database.searchLinkSuggestions(
                 query: query,
                 omitting: invalidSuggestions,
@@ -417,7 +417,7 @@ actor DataService {
         query: String,
         current: MemoAddress
     ) -> AnyPublisher<[RenameSuggestion], Error> {
-        Future.detatched(priority: .userInitiated) {
+        Future.detached(priority: .userInitiated) {
             try await self.database.searchRenameSuggestions(
                 query: query,
                 current: current
@@ -430,7 +430,7 @@ actor DataService {
     nonisolated func createSearchHistoryItemPublisher(
         query: String
     ) -> AnyPublisher<String, Error> {
-        Future.detatched(priority: .utility) {
+        Future.detached(priority: .utility) {
             await self.database.createSearchHistoryItem(query: query)
         }
         .eraseToAnyPublisher()
@@ -472,7 +472,7 @@ actor DataService {
     nonisolated func findAddressInOursPublisher(
         slug: Slug
     ) -> AnyPublisher<MemoAddress?, Never> {
-        Future.detatched {
+        Future.detached {
             await self.findAddressInOurs(slug: slug)
         }
         .eraseToAnyPublisher()
@@ -506,7 +506,7 @@ actor DataService {
         _ text: String,
         audience: Audience
     ) -> AnyPublisher<MemoAddress?, Never> {
-        Future.detatched {
+        Future.detached {
             await self.findUniqueAddressFor(text, audience: audience)
         }
         .eraseToAnyPublisher()
@@ -584,7 +584,7 @@ actor DataService {
         address: MemoAddress,
         fallback: String
     ) -> AnyPublisher<MemoEditorDetailResponse, Error> {
-        Future.detatched {
+        Future.detached {
             try await self.readMemoEditorDetail(
                 address: address,
                 fallback: fallback
@@ -628,7 +628,7 @@ actor DataService {
     nonisolated func readMemoDetailPublisher(
         address: MemoAddress
     ) -> AnyPublisher<MemoDetailResponse?, Never> {
-        Future.detatched {
+        Future.detached {
             await self.readMemoDetail(address: address)
         }
         .eraseToAnyPublisher()
@@ -644,7 +644,7 @@ actor DataService {
 
     /// Choose a random entry and publish slug
     nonisolated func readRandomEntryLinkPublisher() -> AnyPublisher<EntryLink, Error> {
-        Future.detatched {
+        Future.detached {
             try await self.readRandomEntryLink()
         }
         .eraseToAnyPublisher()

--- a/xcode/Subconscious/Shared/Services/FeedService.swift
+++ b/xcode/Subconscious/Shared/Services/FeedService.swift
@@ -25,7 +25,7 @@ struct FeedService {
     /// We should consider other approaches, including using a tracery grammar.
     /// Eventually, we want to do something based on follows.
     func generate(max: Int) -> AnyPublisher<[Story], Error> {
-        Future.detatched {
+        Future.detached {
             let geists = geists.values
             var stories: [Story] = []
             for _ in 0..<max {

--- a/xcode/Subconscious/Shared/Services/Noosphere/Noosphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Noosphere.swift
@@ -139,7 +139,7 @@ public actor Noosphere {
     nonisolated func createSpherePublisher(
         ownerKeyName: String
     ) -> AnyPublisher<SphereReceipt, Error> {
-        Future.detatched {
+        Future.detached {
             try await self.createSphere(ownerKeyName: ownerKeyName)
         }
         .eraseToAnyPublisher()

--- a/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
@@ -183,7 +183,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
     }
 
     nonisolated public func identityPublisher() -> AnyPublisher<String, Error> {
-        Future.detatched {
+        Future.detached {
             self._identity
         }
         .eraseToAnyPublisher()
@@ -206,7 +206,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
     
     /// Get current version of sphere as a publisher
     nonisolated public func versionPublisher() -> AnyPublisher<String, Error> {
-        Future.detatched {
+        Future.detached {
             try await self.version()
         }
         .eraseToAnyPublisher()
@@ -241,7 +241,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
         slashlink: Slashlink,
         name: String
     ) -> AnyPublisher<String?, Never> {
-        Future.detatched {
+        Future.detached {
             await self.readHeaderValueFirst(slashlink: slashlink, name: name)
         }
         .eraseToAnyPublisher()
@@ -277,7 +277,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
     nonisolated public func getFileVersionPublisher(
         slashlink: Slashlink
     ) -> AnyPublisher<String?, Never> {
-        Future.detatched {
+        Future.detached {
             await self.getFileVersion(slashlink: slashlink)
         }
         .eraseToAnyPublisher()
@@ -305,7 +305,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
     nonisolated public func readHeaderNamesPublisher(
         slashlink: Slashlink
     ) -> AnyPublisher<[String], Never> {
-        Future.detatched {
+        Future.detached {
             await self.readHeaderNames(slashlink: slashlink)
         }
         .eraseToAnyPublisher()
@@ -372,7 +372,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
     nonisolated public func readPublisher(
         slashlink: Slashlink
     ) -> AnyPublisher<MemoData, Error> {
-        Future.detatched {
+        Future.detached {
             try await self.read(slashlink: slashlink)
         }
         .eraseToAnyPublisher()
@@ -429,7 +429,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
         additionalHeaders: [Header] = [],
         body: Data
     ) -> AnyPublisher<Void, Error> {
-        Future.detatched {
+        Future.detached {
             try await self.write(
                 slug: slug,
                 contentType: contentType,
@@ -475,7 +475,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
     nonisolated public func getPetnamePublisher(
         petname: Petname
     ) -> AnyPublisher<String, Error> {
-        Future.detatched {
+        Future.detached {
             try await self.getPetname(petname: petname)
         }
         .eraseToAnyPublisher()
@@ -498,7 +498,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
         did: String?,
         petname: Petname
     ) -> AnyPublisher<Void, Error> {
-        Future.detatched {
+        Future.detached {
             try await self.setPetname(did: did, petname: petname)
         }
         .eraseToAnyPublisher()
@@ -529,7 +529,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
     nonisolated public func resolvePetnamePublisher(
         petname: Petname
     ) -> AnyPublisher<String, Error> {
-        Future.detatched {
+        Future.detached {
             try await self.resolvePetname(petname: petname)
         }
         .eraseToAnyPublisher()
@@ -558,7 +558,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
     /// List all petnames in user's follows (address book)
     /// - Returns an a `AnyPublisher` for an array of `Petname`
     nonisolated public func listPetnamesPublisher() -> AnyPublisher<[Petname], Error> {
-        Future.detatched {
+        Future.detached {
             try await self.listPetnames()
         }
         .eraseToAnyPublisher()
@@ -593,7 +593,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
     nonisolated public func getPetnameChangesPublisher(
         sinceCid: String
     ) -> AnyPublisher<[Petname], Error> {
-        Future.detatched {
+        Future.detached {
             try await self.getPetnameChanges(sinceCid: sinceCid)
         }
         .eraseToAnyPublisher()
@@ -628,7 +628,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
     nonisolated public func traversePublisher(
         petname: Petname
     ) -> AnyPublisher<Sphere, Error> {
-        Future.detatched {
+        Future.detached {
             try await self.traverse(petname: petname)
         }
         .eraseToAnyPublisher()
@@ -652,7 +652,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
     /// This method is called on the write queue, and is asynchronous.
     /// - Returns a `AnyPublisher` for version CID string, or error.
     nonisolated public func savePublisher() -> AnyPublisher<String, Error> {
-        Future.detatched {
+        Future.detached {
             try await self.save()
         }
         .eraseToAnyPublisher()
@@ -671,7 +671,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
     /// Remove slug from sphere.
     /// - Returns a `AnyPublisher` for Void (success) or error.
     nonisolated public func removePublisher(slug: Slug) -> AnyPublisher<Void, Error> {
-        Future.detatched {
+        Future.detached {
             try await self.remove(slug: slug)
         }
         .eraseToAnyPublisher()
@@ -697,7 +697,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
     /// List all slugs in sphere.
     /// - Returns a `AnyPublisher` for an array of `Slug`, or error.
     nonisolated public func listPublisher() -> AnyPublisher<[Slug], Error> {
-        Future.detatched {
+        Future.detached {
             try await self.list()
         }
         .eraseToAnyPublisher()
@@ -726,7 +726,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
     /// This method runs on the write queue and is asynchronous.
     /// - Returns a `AnyPublisher` CID string for the new sphere version.
     nonisolated public func syncPublisher() -> AnyPublisher<String, Error> {
-        Future.detatched {
+        Future.detached {
             try await self.sync()
         }
         .eraseToAnyPublisher()
@@ -759,7 +759,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
     nonisolated public func changesPublisher(
         _ since: String?
     ) -> AnyPublisher<[Slug], Error> {
-        Future.detatched {
+        Future.detached {
             try await self.changes(since)
         }
         .eraseToAnyPublisher()

--- a/xcode/Subconscious/SubconsciousTests/Tests_CombineUtilities.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_CombineUtilities.swift
@@ -71,8 +71,8 @@ final class Tests_CombineUtilities: XCTestCase {
         wait(for: [expectation], timeout: 0.2)
     }
     
-    func testFutureDetatchedTaskAsync() throws {
-        let future = Future.detatched {
+    func testFutureDetachedTaskAsync() throws {
+        let future = Future.detached {
             XCTAssertFalse(Thread.isMainThread, "Run in separate thread")
             return 10
         }
@@ -94,8 +94,8 @@ final class Tests_CombineUtilities: XCTestCase {
         wait(for: [expectation], timeout: 0.3)
     }
     
-    func testFutureDetatchedTaskError() throws {
-        let future: Future<Int, Error> = Future.detatched {
+    func testFutureDetachedTaskError() throws {
+        let future: Future<Int, Error> = Future.detached {
             throw TestError.code(10)
         }
         
@@ -123,7 +123,7 @@ final class Tests_CombineUtilities: XCTestCase {
     }
 
     func testRecover() throws {
-        let future: Future<Int, Error> = Future.detatched {
+        let future: Future<Int, Error> = Future.detached {
             throw TestError.code(10)
         }
         


### PR DESCRIPTION
Tiny change, I kept getting compile errors using `Future.detached` because we had a typo!