### PR TITLE
Load `_profile_` customisations from sphere

### DIFF
--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookEntryView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookEntryView.swift
@@ -9,13 +9,11 @@ import SwiftUI
 
 /// Full-sized user card, intended for listing users
 struct AddressBookEntryView: View {
-    var pfp: Image
     var petname: Petname
     var did: Did
     
     var body: some View {
         HStack(spacing: AppTheme.unit3) {
-            ProfilePic(image: pfp)
             VStack(alignment: .leading, spacing: AppTheme.unit) {
                 PetnameBylineView(petname: petname)
                 Text(verbatim: did.did)
@@ -30,7 +28,6 @@ struct AddressBookEntryView: View {
 struct AddressBookEntryView_Previews: PreviewProvider {
     static var previews: some View {
         AddressBookEntryView(
-            pfp: Image("pfp-dog"),
             petname: Petname("name")!,
             did: Did("did:key:z6x")!
         )

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookModel.swift
@@ -12,7 +12,6 @@ import ObservableStore
 import Combine
 
 struct AddressBookEntry: Equatable {
-    var pfp: Image
     var petname: Petname
     var did: Did
 }
@@ -219,7 +218,7 @@ struct AddressBookModel: ModelProtocol {
             return Update(state: state, fx: fx)
             
         case .succeedFollow(did: let did, petname: let petname):
-            let entry = AddressBookEntry(pfp: Image("sub_logo"), petname: petname, did: did)
+            let entry = AddressBookEntry(petname: petname, did: did)
             
             var model = state
             model.isFollowUserFormPresented = false

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
@@ -118,9 +118,9 @@ struct AddressBook_Previews: PreviewProvider {
         AddressBookView(
             state: AddressBookModel(
                 follows: [
-                    AddressBookEntry( petname: Petname("ben")!, did: Did(  "did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!),
-                    AddressBookEntry( petname: Petname("bob")!, did: Did("did:key:z6MkmBJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!),
-                    AddressBookEntry( petname: Petname("alice")!, did: Did("did:key:z6MjmBJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!)
+                    AddressBookEntry(petname: Petname("ben")!, did: Did(  "did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!),
+                    AddressBookEntry(petname: Petname("bob")!, did: Did("did:key:z6MkmBJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!),
+                    AddressBookEntry(petname: Petname("alice")!, did: Did("did:key:z6MjmBJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!)
                 ],
                 isFollowUserFormPresented: false // Toggle to test sheet
             ),

--- a/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
+++ b/xcode/Subconscious/Shared/Components/AddressBook/AddressBookView.swift
@@ -30,7 +30,6 @@ struct AddressBookView: View {
                         List {
                             ForEach(state.follows, id: \.did) { user in
                                 AddressBookEntryView(
-                                    pfp: user.pfp,
                                     petname: user.petname,
                                     did: user.did
                                 )
@@ -119,9 +118,9 @@ struct AddressBook_Previews: PreviewProvider {
         AddressBookView(
             state: AddressBookModel(
                 follows: [
-                    AddressBookEntry(pfp: Image("pfp-dog"), petname: Petname("ben")!, did: Did(  "did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!),
-                    AddressBookEntry(pfp: Image("sub_logo"), petname: Petname("bob")!, did: Did("did:key:z6MkmBJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!),
-                    AddressBookEntry(pfp: Image("sub_logo"), petname: Petname("alice")!, did: Did("did:key:z6MjmBJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!)
+                    AddressBookEntry( petname: Petname("ben")!, did: Did(  "did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!),
+                    AddressBookEntry( petname: Petname("bob")!, did: Did("did:key:z6MkmBJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!),
+                    AddressBookEntry( petname: Petname("alice")!, did: Did("did:key:z6MjmBJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!)
                 ],
                 isFollowUserFormPresented: false // Toggle to test sheet
             ),

--- a/xcode/Subconscious/Shared/Components/Common/BacklinkReacts.swift
+++ b/xcode/Subconscious/Shared/Components/Common/BacklinkReacts.swift
@@ -15,7 +15,7 @@ where
     Data.Element == Content
 {
     var data: Data
-    var content: (Content) -> Image
+    var content: (Content) -> URL
 
     var body: some View {
         HStack {
@@ -23,7 +23,7 @@ where
                 .foregroundColor(.secondary)
             HStack(spacing: -8) {
                 ForEach(data.prefix(6)) { element in
-                    ProfilePicSm(image: content(element))
+                    ProfilePicSm(url: content(element))
                 }
             }
             Text("\(data.count)")
@@ -47,7 +47,7 @@ struct BacklinkReacts_Previews: PreviewProvider {
                 Slug("h")!,
             ]
         ) { element in
-            Image("pfp-dog")
+            URL(string: "pfp-dog")!
         }
     }
 }

--- a/xcode/Subconscious/Shared/Components/Common/BacklinkReacts.swift
+++ b/xcode/Subconscious/Shared/Components/Common/BacklinkReacts.swift
@@ -47,7 +47,7 @@ struct BacklinkReacts_Previews: PreviewProvider {
                 Slug("h")!,
             ]
         ) { element in
-                ProfilePicVariant.image("pfp-dog")
+            ProfilePicVariant.image("pfp-dog")
         }
     }
 }

--- a/xcode/Subconscious/Shared/Components/Common/BacklinkReacts.swift
+++ b/xcode/Subconscious/Shared/Components/Common/BacklinkReacts.swift
@@ -15,7 +15,7 @@ where
     Data.Element == Content
 {
     var data: Data
-    var content: (Content) -> URL
+    var content: (Content) -> ProfilePicVariant
 
     var body: some View {
         HStack {
@@ -23,7 +23,7 @@ where
                 .foregroundColor(.secondary)
             HStack(spacing: -8) {
                 ForEach(data.prefix(6)) { element in
-                    ProfilePicSm(url: content(element))
+                    ProfilePicSm(pfp: content(element))
                 }
             }
             Text("\(data.count)")
@@ -47,7 +47,7 @@ struct BacklinkReacts_Previews: PreviewProvider {
                 Slug("h")!,
             ]
         ) { element in
-            URL(string: "pfp-dog")!
+                ProfilePicVariant.image("pfp-dog")
         }
     }
 }

--- a/xcode/Subconscious/Shared/Components/Common/Byline/BylineSmView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Byline/BylineSmView.swift
@@ -9,12 +9,12 @@ import SwiftUI
 
 /// Compact byline combines a small profile pic, username, and path
 struct BylineSmView: View {
-    var pfp: Image
+    var pfp: URL
     var slashlink: Slashlink
     
     var body: some View {
         HStack {
-            ProfilePicSm(image: pfp)
+            ProfilePicSm(url: pfp)
             SlashlinkBylineView(slashlink: slashlink)
         }
     }
@@ -23,7 +23,7 @@ struct BylineSmView: View {
 struct BylineSmView_Previews: PreviewProvider {
     static var previews: some View {
         BylineSmView(
-            pfp: Image("pfp-dog"),
+            pfp: URL(string: "pfp-dog")!,
             slashlink: Slashlink("@name/path")!
         )
     }

--- a/xcode/Subconscious/Shared/Components/Common/Byline/BylineSmView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Byline/BylineSmView.swift
@@ -9,12 +9,12 @@ import SwiftUI
 
 /// Compact byline combines a small profile pic, username, and path
 struct BylineSmView: View {
-    var pfp: URL
+    var pfp: ProfilePicVariant
     var slashlink: Slashlink
     
     var body: some View {
         HStack {
-            ProfilePicSm(url: pfp)
+            ProfilePicSm(pfp: pfp)
             SlashlinkBylineView(slashlink: slashlink)
         }
     }
@@ -23,7 +23,7 @@ struct BylineSmView: View {
 struct BylineSmView_Previews: PreviewProvider {
     static var previews: some View {
         BylineSmView(
-            pfp: URL(string: "pfp-dog")!,
+            pfp: .image("pfp-dog"),
             slashlink: Slashlink("@name/path")!
         )
     }

--- a/xcode/Subconscious/Shared/Components/Common/Byline/BylineView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Byline/BylineView.swift
@@ -9,14 +9,14 @@ import SwiftUI
 
 /// Full-sized byline, suitable for using as header of story
 struct BylineView: View {
-    var pfp: Image
+    var pfp: URL
     var name: String
     var petname: String
     var slug: String
     
     var body: some View {
         HStack(spacing: AppTheme.unit3) {
-            ProfilePic(image: pfp)
+            ProfilePic(url: pfp)
             VStack(alignment: .leading) {
                 Text(verbatim: name)
                     .foregroundColor(.buttonText)
@@ -35,7 +35,7 @@ struct BylineView: View {
 struct BylineView_Previews: PreviewProvider {
     static var previews: some View {
         BylineView(
-            pfp: Image("pfp-dog"),
+            pfp: URL(string: "pfp-dog")!,
             name: "Dog",
             petname: "@name",
             slug: "/path"

--- a/xcode/Subconscious/Shared/Components/Common/Byline/BylineView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Byline/BylineView.swift
@@ -9,14 +9,14 @@ import SwiftUI
 
 /// Full-sized byline, suitable for using as header of story
 struct BylineView: View {
-    var pfp: URL
+    var pfp: ProfilePicVariant
     var name: String
     var petname: String
     var slug: String
     
     var body: some View {
         HStack(spacing: AppTheme.unit3) {
-            ProfilePic(url: pfp)
+            ProfilePic(pfp: pfp)
             VStack(alignment: .leading) {
                 Text(verbatim: name)
                     .foregroundColor(.buttonText)
@@ -35,7 +35,7 @@ struct BylineView: View {
 struct BylineView_Previews: PreviewProvider {
     static var previews: some View {
         BylineView(
-            pfp: URL(string: "pfp-dog")!,
+            pfp: .image("pfp-dog"),
             name: "Dog",
             petname: "@name",
             slug: "/path"

--- a/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
@@ -15,6 +15,7 @@ struct ValidatedTextField: View {
     var onFocusChanged: (Bool) -> Void = { _ in}
     var caption: String
     var hasError: Bool = false
+    var axis: Axis = .horizontal
     @FocusState var focused: Bool
     
     var backgroundColor = Color.background
@@ -31,7 +32,8 @@ struct ValidatedTextField: View {
             HStack {
                 TextField(
                     placeholder,
-                    text: $text
+                    text: $text,
+                    axis: axis
                 )
                 .focused($focused)
                 .overlay(alignment: .trailing) {

--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -80,16 +80,36 @@ struct EditProfileSheetModel: ModelProtocol {
     typealias Action = EditProfileSheetAction
     typealias Environment = EditProfileSheetEnvironment
     
-    var nicknameField: FormField<String, Petname> = FormField(value: "", validate: { x in Petname(x) })
-    var bioField: FormField<String, String> = FormField(value: "", validate: { x in x.count >= 280 ? nil : x })
-    var pfpUrlField: FormField<String, URL> = FormField(value: "", validate: { x in URL(string: x) })
+    var nicknameField: FormField<String, Petname> = FormField(
+        value: "",
+        validate: { value in
+            Petname(value)
+        }
+    )
+    var bioField: FormField<String, String> = FormField(
+        value: "",
+        validate: { value in
+            value.count >= 280 ? nil : value
+        }
+    )
+    var pfpUrlField: FormField<String, URL> = FormField(
+        value: "",
+        validate: { value in
+            URL(string: value)
+        }
+    )
     
     static let logger = Logger(
         subsystem: Config.default.rdns,
         category: "EditProfileSheet"
     )
     
-    static func update(state: Self, action: Action, environment: Environment) -> Update<Self> {
+    static func update(
+        state: Self,
+        action: Action,
+        environment: Environment
+    ) -> Update<Self> {
+        
         switch action {
         case .populate(let user):
             return update(
@@ -141,103 +161,101 @@ struct EditProfileSheet: View {
     
     var body: some View {
         NavigationStack {
-            VStack {
-                Form {
-                    Section("Profile") {
-                        HStack(alignment: .firstTextBaseline) {
-                            Image(systemName: "at")
-                                .foregroundColor(.accentColor)
-                            ValidatedTextField(
-                                placeholder: "nickname",
-                                text: Binding(
-                                    get: { state.nicknameField.value },
-                                    send: send,
-                                    tag: { v in .nicknameField(.setValue(input: v))}
-                                ),
-                                onFocusChanged: { focused in
-                                    send(.nicknameField(.focusChange(focused: focused)))
-                                },
-                                caption: "How you would like to be known",
-                                hasError: state.nicknameField.hasError
-                            )
-                            .formField()
-                            .lineLimit(1)
-                            .textInputAutocapitalization(.never)
-                            .disableAutocorrection(true)
-                        }
-                        
-                        HStack(alignment: .firstTextBaseline) {
-                            Image(systemName: "photo")
-                                .foregroundColor(.accentColor)
-                            ValidatedTextField(
-                                placeholder: "http://example.org/pfp.jpg",
-                                text: Binding(
-                                    get: { state.pfpUrlField.value },
-                                    send: send,
-                                    tag: { v in .pfpUrlField(.setValue(input: v))}
-                                ),
-                                onFocusChanged: { focused in
-                                    send(.pfpUrlField(.focusChange(focused: focused)))
-                                },
-                                caption: "The image shown on your profile",
-                                hasError: !state.pfpUrlField.isValid && state.pfpUrlField.value.count > 0
-                            )
-                            .formField()
-                            .lineLimit(1)
-                            .textInputAutocapitalization(.never)
-                            .disableAutocorrection(true)
-                        }
-                        
-                        HStack(alignment: .top) {
-                            Image(systemName: "text.quote")
-                                .foregroundColor(.accentColor)
-                            ValidatedTextField(
-                                placeholder: "I am a...",
-                                text: Binding(
-                                    get: { state.bioField.value },
-                                    send: send,
-                                    tag: { v in .bioField(.setValue(input: v))}
-                                ),
-                                onFocusChanged: { focused in
-                                    send(.bioField(.focusChange(focused: focused)))
-                                },
-                                caption: "A short description of yourself (\(state.bioField.value.count)/280)",
-                                hasError: !state.bioField.isValid && state.bioField.value.count > 0,
-                                axis: .vertical
-                            )
-                            .formField()
-                            .lineLimit(3)
-                            .textInputAutocapitalization(.never)
-                            .disableAutocorrection(true)
-                        }
+            Form {
+                Section("Profile") {
+                    HStack(alignment: .firstTextBaseline) {
+                        Image(systemName: "at")
+                            .foregroundColor(.accentColor)
+                        ValidatedTextField(
+                            placeholder: "nickname",
+                            text: Binding(
+                                get: { state.nicknameField.value },
+                                send: send,
+                                tag: { v in .nicknameField(.setValue(input: v))}
+                            ),
+                            onFocusChanged: { focused in
+                                send(.nicknameField(.focusChange(focused: focused)))
+                            },
+                            caption: "How you would like to be known",
+                            hasError: state.nicknameField.hasError
+                        )
+                        .formField()
+                        .lineLimit(1)
+                        .textInputAutocapitalization(.never)
+                        .disableAutocorrection(true)
                     }
                     
-                    if let nickname = state.nicknameField.validated {
-                        let pfp: ProfilePicVariant = Func.run {
-                            if let url = state.pfpUrlField.validated {
-                                return .url(url)
-                            }
-                            
-                            return .none
-                        }
-                        
-                        let user = UserProfile(
-                            did: user.did,
-                            nickname: nickname,
-                            address: user.address,
-                            pfp: pfp,
-                            bio: state.bioField.validated ?? "",
-                            category: .you
+                    HStack(alignment: .firstTextBaseline) {
+                        Image(systemName: "photo")
+                            .foregroundColor(.accentColor)
+                        ValidatedTextField(
+                            placeholder: "http://example.org/pfp.jpg",
+                            text: Binding(
+                                get: { state.pfpUrlField.value },
+                                send: send,
+                                tag: { v in .pfpUrlField(.setValue(input: v))}
+                            ),
+                            onFocusChanged: { focused in
+                                send(.pfpUrlField(.focusChange(focused: focused)))
+                            },
+                            caption: "The image shown on your profile",
+                            hasError: !state.pfpUrlField.isValid && state.pfpUrlField.value.count > 0
                         )
-                        
-                        Section("Preview") {
-                            UserProfileHeaderView(
-                                user: user,
-                                statistics: statistics,
-                                isFollowingUser: false,
-                                hideActionButton: true
-                            )
+                        .formField()
+                        .lineLimit(1)
+                        .textInputAutocapitalization(.never)
+                        .disableAutocorrection(true)
+                    }
+                    
+                    HStack(alignment: .top) {
+                        Image(systemName: "text.quote")
+                            .foregroundColor(.accentColor)
+                        ValidatedTextField(
+                            placeholder: "I am a...",
+                            text: Binding(
+                                get: { state.bioField.value },
+                                send: send,
+                                tag: { v in .bioField(.setValue(input: v))}
+                            ),
+                            onFocusChanged: { focused in
+                                send(.bioField(.focusChange(focused: focused)))
+                            },
+                            caption: "A short description of yourself (\(state.bioField.value.count)/280)",
+                            hasError: !state.bioField.isValid && state.bioField.value.count > 0,
+                            axis: .vertical
+                        )
+                        .formField()
+                        .lineLimit(3)
+                        .textInputAutocapitalization(.never)
+                        .disableAutocorrection(true)
+                    }
+                }
+                
+                if let nickname = state.nicknameField.validated {
+                    let pfp: ProfilePicVariant = Func.run {
+                        if let url = state.pfpUrlField.validated {
+                            return .url(url)
                         }
+                        
+                        return .none
+                    }
+                    
+                    let user = UserProfile(
+                        did: user.did,
+                        nickname: nickname,
+                        address: user.address,
+                        pfp: pfp,
+                        bio: state.bioField.validated ?? "",
+                        category: .you
+                    )
+                    
+                    Section("Preview") {
+                        UserProfileHeaderView(
+                            user: user,
+                            statistics: statistics,
+                            isFollowingUser: false,
+                            hideActionButton: true
+                        )
                     }
                 }
             }

--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -212,7 +212,7 @@ struct EditProfileSheet: View {
                         }
                     }
                     
-                    if let petname = state.nicknameField.validated {
+                    if let nickname = state.nicknameField.validated {
                         let pfp: ProfilePicVariant = Func.run {
                             if let url = state.pfpUrlField.validated {
                                 return .url(url)
@@ -223,8 +223,7 @@ struct EditProfileSheet: View {
                         
                         let user = UserProfile(
                             did: user.did,
-                            petname: petname,
-                            preferredPetname: state.nicknameField.value,
+                            nickname: nickname,
                             address: user.address,
                             pfp: pfp,
                             bio: state.bioField.validated ?? "",

--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -199,7 +199,9 @@ struct EditProfileSheet: View {
                                 send(.pfpUrlField(.focusChange(focused: focused)))
                             },
                             caption: "The image shown on your profile",
-                            hasError: !state.pfpUrlField.isValid && state.pfpUrlField.value.count > 0
+                            hasError:
+                                !state.pfpUrlField.isValid &&
+                                state.pfpUrlField.value.count > 0
                         )
                         .formField()
                         .lineLimit(1)
@@ -211,7 +213,7 @@ struct EditProfileSheet: View {
                         Image(systemName: "text.quote")
                             .foregroundColor(.accentColor)
                         ValidatedTextField(
-                            placeholder: "I am a...",
+                            placeholder: "bio",
                             text: Binding(
                                 get: { state.bioField.value },
                                 send: send,
@@ -220,8 +222,11 @@ struct EditProfileSheet: View {
                             onFocusChanged: { focused in
                                 send(.bioField(.focusChange(focused: focused)))
                             },
-                            caption: "A short description of yourself (\(state.bioField.value.count)/280)",
-                            hasError: !state.bioField.isValid && state.bioField.value.count > 0,
+                            caption:
+                                "A short description of yourself (\(state.bioField.value.count)/280)",
+                            hasError:
+                                !state.bioField.isValid &&
+                                state.bioField.value.count > 0,
                             axis: .vertical
                         )
                         .formField()

--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -131,8 +131,10 @@ struct EditProfileSheet: View {
     var state: EditProfileSheetModel
     var send: (EditProfileSheetAction) -> Void
     var user: UserProfile
+    var failEditProfileMessage: String?
     var onEditProfile: () -> Void
     var onCancel: () -> Void
+    var onDismissError: () -> Void
     
     var body: some View {
         NavigationStack {
@@ -220,7 +222,17 @@ struct EditProfileSheet: View {
                 }
                 .frame(maxHeight: .infinity)
             }
-            .presentationDetents([.medium])
+            .alert(
+                isPresented: Binding(
+                    get: { failEditProfileMessage != nil },
+                    set: { _ in onDismissError() }
+                )
+            ) {
+                Alert(
+                    title: Text("Failed to Save Profile"),
+                    message: Text(failEditProfileMessage ?? "An unknown error ocurred")
+                )
+            }
             .navigationTitle("Edit Profile")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -236,7 +248,6 @@ struct EditProfileSheet: View {
                 }
             }
         }
-        
     }
 }
 

--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -1,0 +1,139 @@
+//
+//  EditProfileSheet.swift
+//  Subconscious
+//
+//  Created by Ben Follington on 24/4/2023.
+//
+
+import os
+import ObservableStore
+import SwiftUI
+import Combine
+
+enum EditProfileSheetAction: Equatable {
+    case populate(UserProfileEntry?)
+    case nicknameField(FormFieldAction<String>)
+    case bioField(FormFieldAction<String>)
+    case pfpUrlField(FormFieldAction<String>)
+}
+
+private struct NicknameFieldCursor: CursorProtocol {
+    typealias Model = EditProfileSheetModel
+    typealias ViewModel = FormField<String, String>
+
+    static func get(state: Model) -> ViewModel {
+        state.nicknameField
+    }
+    
+    static func set(state: Model, inner: ViewModel) -> Model {
+        var model = state
+        model.nicknameField = inner
+        return model
+    }
+    
+    static func tag(_ action: ViewModel.Action) -> Model.Action {
+        .nicknameField(action)
+    }
+}
+
+private struct BioFieldCursor: CursorProtocol {
+    typealias Model = EditProfileSheetModel
+    typealias ViewModel = FormField<String, String>
+
+    static func get(state: Model) -> ViewModel {
+        state.bioField
+    }
+    
+    static func set(state: Model, inner: ViewModel) -> Model {
+        var model = state
+        model.bioField = inner
+        return model
+    }
+    
+    static func tag(_ action: ViewModel.Action) -> Model.Action {
+        .bioField(action)
+    }
+}
+
+private struct PfpUrlFieldCursor: CursorProtocol {
+    typealias Model = EditProfileSheetModel
+    typealias ViewModel = FormField<String, URL>
+
+    static func get(state: Model) -> ViewModel {
+        state.pfpUrlField
+    }
+    
+    static func set(state: Model, inner: ViewModel) -> Model {
+        var model = state
+        model.pfpUrlField = inner
+        return model
+    }
+    
+    static func tag(_ action: ViewModel.Action) -> Model.Action {
+        .pfpUrlField(action)
+    }
+}
+
+struct EditProfileSheetEnvironment { }
+
+struct EditProfileSheetModel: ModelProtocol {
+    typealias Action = EditProfileSheetAction
+    typealias Environment = EditProfileSheetEnvironment
+    
+    var nicknameField: FormField<String, String> = FormField(value: "", validate: { x in x })
+    var bioField: FormField<String, String> = FormField(value: "", validate: { x in x })
+    var pfpUrlField: FormField<String, URL> = FormField(value: "", validate: { x in URL(string: x) })
+    
+    static let logger = Logger(
+        subsystem: Config.default.rdns,
+        category: "EditProfileSheet"
+    )
+    
+    static func update(state: Self, action: Action, environment: Environment) -> Update<Self> {
+        switch action {
+        case .populate(let user):
+            return update(
+                state: state,
+                actions: [
+                    .nicknameField(.setValue(input: user?.preferredName ?? "")),
+                    .bioField(.setValue(input: user?.bio ?? "")),
+                    .pfpUrlField(.setValue(input: user?.profilePictureUrl ?? ""))
+                ],
+                environment: environment
+            )
+            
+        case .nicknameField(let action):
+            return NicknameFieldCursor.update(
+                state: state,
+                action: action,
+                environment: FormFieldEnvironment()
+            )
+            
+        case .bioField(let action):
+            return BioFieldCursor.update(
+                state: state,
+                action: action,
+                environment: FormFieldEnvironment()
+            )
+            
+        case .pfpUrlField(let action):
+            return PfpUrlFieldCursor.update(
+                state: state,
+                action: action,
+                environment: FormFieldEnvironment()
+            )
+        }
+    }
+}
+
+struct EditProfileSheet: View {
+    var state: EditProfileSheetModel
+    var send: (EditProfileSheetAction) -> Void
+    var user: UserProfile
+    var onEditProfile: () -> Void
+    
+    var body: some View {
+        Text("test")
+    }
+}
+

--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -210,8 +210,23 @@ struct EditProfileSheet: View {
                 
                 VStack {
                     if let petname = state.nicknameField.validated {
+                        let pfp: ProfilePicVariant = Func.run {
+                            if let url = state.pfpUrlField.validated {
+                                return .url(url)
+                            }
+                            
+                            return .none
+                        }
+                        
                         let user = UserProfile(
-                            did: Did.dummyData(), petname: petname, preferredPetname: state.nicknameField.value, address: Slashlink.ourProfile.toPublicMemoAddress(), pfp: state.pfpUrlField.validated?.absoluteString ?? "", bio: state.bioField.validated ?? "", category: .you)
+                            did: Did.dummyData(),
+                            petname: petname,
+                            preferredPetname: state.nicknameField.value,
+                            address: Slashlink.ourProfile.toPublicMemoAddress(),
+                            pfp: pfp,
+                            bio: state.bioField.validated ?? "",
+                            category: .you
+                        )
                         
                         let story = StoryUser(user: user, isFollowingUser: false)
                         

--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -184,7 +184,7 @@ struct EditProfileSheet: View {
                         .disableAutocorrection(true)
                     }
                     
-                    HStack(alignment: .firstTextBaseline) {
+                    HStack(alignment: .top) {
                         Image(systemName: "text.quote")
                             .foregroundColor(.accentColor)
                         ValidatedTextField(
@@ -197,7 +197,7 @@ struct EditProfileSheet: View {
                             onFocusChanged: { focused in
                                 send(.bioField(.focusChange(focused: focused)))
                             },
-                            caption: "A short description of yourself  (\(state.bioField.value.count)/280)",
+                            caption: "A short description of yourself (\(state.bioField.value.count)/280)",
                             hasError: !state.bioField.isValid && state.bioField.value.count > 0,
                             axis: .vertical
                         )

--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -95,6 +95,9 @@ struct EditProfileSheetModel: ModelProtocol {
             return update(
                 state: state,
                 actions: [
+                    .nicknameField(.reset),
+                    .bioField(.reset),
+                    .pfpUrlField(.reset),
                     .nicknameField(.setValue(input: user?.nickname ?? "")),
                     .bioField(.setValue(input: user?.bio ?? "")),
                     .pfpUrlField(.setValue(input: user?.profilePictureUrl ?? "")),

--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -219,10 +219,10 @@ struct EditProfileSheet: View {
                         }
                         
                         let user = UserProfile(
-                            did: Did.dummyData(),
+                            did: user.did,
                             petname: petname,
                             preferredPetname: state.nicknameField.value,
-                            address: Slashlink.ourProfile.toPublicMemoAddress(),
+                            address: user.address,
                             pfp: pfp,
                             bio: state.bioField.validated ?? "",
                             category: .you

--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -74,8 +74,7 @@ private struct PfpUrlFieldCursor: CursorProtocol {
     }
 }
 
-struct EditProfileSheetEnvironment {
-}
+typealias EditProfileSheetEnvironment = Void
 
 struct EditProfileSheetModel: ModelProtocol {
     typealias Action = EditProfileSheetAction

--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -130,6 +130,7 @@ struct EditProfileSheet: View {
     var state: EditProfileSheetModel
     var send: (EditProfileSheetAction) -> Void
     var user: UserProfile
+    var statistics: UserProfileStatistics?
     var failEditProfileMessage: String?
     var onEditProfile: () -> Void
     var onCancel: () -> Void
@@ -139,75 +140,75 @@ struct EditProfileSheet: View {
         NavigationStack {
             VStack {
                 Form {
-                    HStack(alignment: .firstTextBaseline) {
-                        Image(systemName: "at")
-                            .foregroundColor(.accentColor)
-                        ValidatedTextField(
-                            placeholder: "nickname",
-                            text: Binding(
-                                get: { state.nicknameField.value },
-                                send: send,
-                                tag: { v in .nicknameField(.setValue(input: v))}
-                            ),
-                            onFocusChanged: { focused in
-                                send(.nicknameField(.focusChange(focused: focused)))
-                            },
-                            caption: "How you would like to be known",
-                            hasError: state.nicknameField.hasError
-                        )
-                        .formField()
-                        .lineLimit(1)
-                        .textInputAutocapitalization(.never)
-                        .disableAutocorrection(true)
+                    Section("Profile") {
+                        HStack(alignment: .firstTextBaseline) {
+                            Image(systemName: "at")
+                                .foregroundColor(.accentColor)
+                            ValidatedTextField(
+                                placeholder: "nickname",
+                                text: Binding(
+                                    get: { state.nicknameField.value },
+                                    send: send,
+                                    tag: { v in .nicknameField(.setValue(input: v))}
+                                ),
+                                onFocusChanged: { focused in
+                                    send(.nicknameField(.focusChange(focused: focused)))
+                                },
+                                caption: "How you would like to be known",
+                                hasError: state.nicknameField.hasError
+                            )
+                            .formField()
+                            .lineLimit(1)
+                            .textInputAutocapitalization(.never)
+                            .disableAutocorrection(true)
+                        }
+                        
+                        HStack(alignment: .firstTextBaseline) {
+                            Image(systemName: "photo")
+                                .foregroundColor(.accentColor)
+                            ValidatedTextField(
+                                placeholder: "http://example.org/pfp.jpg",
+                                text: Binding(
+                                    get: { state.pfpUrlField.value },
+                                    send: send,
+                                    tag: { v in .pfpUrlField(.setValue(input: v))}
+                                ),
+                                onFocusChanged: { focused in
+                                    send(.pfpUrlField(.focusChange(focused: focused)))
+                                },
+                                caption: "The image shown on your profile",
+                                hasError: !state.pfpUrlField.isValid && state.pfpUrlField.value.count > 0
+                            )
+                            .formField()
+                            .lineLimit(1)
+                            .textInputAutocapitalization(.never)
+                            .disableAutocorrection(true)
+                        }
+                        
+                        HStack(alignment: .top) {
+                            Image(systemName: "text.quote")
+                                .foregroundColor(.accentColor)
+                            ValidatedTextField(
+                                placeholder: "I am a...",
+                                text: Binding(
+                                    get: { state.bioField.value },
+                                    send: send,
+                                    tag: { v in .bioField(.setValue(input: v))}
+                                ),
+                                onFocusChanged: { focused in
+                                    send(.bioField(.focusChange(focused: focused)))
+                                },
+                                caption: "A short description of yourself (\(state.bioField.value.count)/280)",
+                                hasError: !state.bioField.isValid && state.bioField.value.count > 0,
+                                axis: .vertical
+                            )
+                            .formField()
+                            .lineLimit(3)
+                            .textInputAutocapitalization(.never)
+                            .disableAutocorrection(true)
+                        }
                     }
                     
-                    HStack(alignment: .firstTextBaseline) {
-                        Image(systemName: "photo")
-                            .foregroundColor(.accentColor)
-                        ValidatedTextField(
-                            placeholder: "http://example.org/pfp.jpg",
-                            text: Binding(
-                                get: { state.pfpUrlField.value },
-                                send: send,
-                                tag: { v in .pfpUrlField(.setValue(input: v))}
-                            ),
-                            onFocusChanged: { focused in
-                                send(.pfpUrlField(.focusChange(focused: focused)))
-                            },
-                            caption: "The image shown on your profile",
-                            hasError: !state.pfpUrlField.isValid && state.pfpUrlField.value.count > 0
-                        )
-                        .formField()
-                        .lineLimit(1)
-                        .textInputAutocapitalization(.never)
-                        .disableAutocorrection(true)
-                    }
-                    
-                    HStack(alignment: .top) {
-                        Image(systemName: "text.quote")
-                            .foregroundColor(.accentColor)
-                        ValidatedTextField(
-                            placeholder: "I am a...",
-                            text: Binding(
-                                get: { state.bioField.value },
-                                send: send,
-                                tag: { v in .bioField(.setValue(input: v))}
-                            ),
-                            onFocusChanged: { focused in
-                                send(.bioField(.focusChange(focused: focused)))
-                            },
-                            caption: "A short description of yourself (\(state.bioField.value.count)/280)",
-                            hasError: !state.bioField.isValid && state.bioField.value.count > 0,
-                            axis: .vertical
-                        )
-                        .formField()
-                        .lineLimit(3)
-                        .textInputAutocapitalization(.never)
-                        .disableAutocorrection(true)
-                    }
-                }
-                
-                VStack {
                     if let petname = state.nicknameField.validated {
                         let pfp: ProfilePicVariant = Func.run {
                             if let url = state.pfpUrlField.validated {
@@ -227,14 +228,16 @@ struct EditProfileSheet: View {
                             category: .you
                         )
                         
-                        let story = StoryUser(user: user, isFollowingUser: false)
-                        
-                        StoryUserView(story: story, action: { _, _ in })
+                        Section("Preview") {
+                            UserProfileHeaderView(
+                                user: user,
+                                statistics: statistics,
+                                isFollowingUser: false,
+                                hideActionButton: true
+                            )
+                        }
                     }
-                    
-                    Spacer()
                 }
-                .frame(maxHeight: .infinity)
             }
             .alert(
                 isPresented: Binding(

--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -96,7 +96,7 @@ struct EditProfileSheetModel: ModelProtocol {
             return update(
                 state: state,
                 actions: [
-                    .nicknameField(.setValue(input: user?.preferredName ?? "")),
+                    .nicknameField(.setValue(input: user?.nickname ?? "")),
                     .bioField(.setValue(input: user?.bio ?? "")),
                     .pfpUrlField(.setValue(input: user?.profilePictureUrl ?? "")),
                 ],

--- a/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserSheet.swift
@@ -45,8 +45,8 @@ struct FollowUserSheetModel: ModelProtocol {
                 state: state,
                 actions: [
                     .followUserForm(.didField(.setValue(input: user.did.did))),
-                    .followUserForm(.petnameField(.setValue(input: user.petname.verbatim))),
-                    .fetchPetnameCollisionStatus(user.petname)
+                    .followUserForm(.petnameField(.setValue(input: user.nickname.verbatim))),
+                    .fetchPetnameCollisionStatus(user.nickname)
                 ],
                 environment: environment
             )

--- a/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserSheet.swift
@@ -152,7 +152,9 @@ struct FollowUserSheet: View {
     
     var body: some View {
         VStack(alignment: .center, spacing: AppTheme.unit2) {
-            ProfilePic(image: Image(user.pfp))
+            if let url = URL(string: user.pfp) {
+                ProfilePic(url: url)
+            }
             
             Text(user.did.did)
                 .font(.caption.monospaced())

--- a/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserSheet.swift
@@ -152,9 +152,7 @@ struct FollowUserSheet: View {
     
     var body: some View {
         VStack(alignment: .center, spacing: AppTheme.unit2) {
-            if let url = URL(string: user.pfp) {
-                ProfilePic(url: url)
-            }
+            ProfilePic(pfp: user.pfp)
             
             Text(user.did.did)
                 .font(.caption.monospaced())

--- a/xcode/Subconscious/Shared/Components/Common/Profile/ProfilePic.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/ProfilePic.swift
@@ -8,20 +8,25 @@
 import SwiftUI
 
 struct ProfilePic: View {
-    var image: Image
+    var url: URL
     var body: some View {
+        AsyncImage(url: url) { image in
         image
             .resizable()
             .frame(width: 48, height: 48)
             .clipShape(Circle())
             .overlay(Circle().stroke(Color.separator, lineWidth: 0.5))
+        } placeholder: {
+            ProgressView()
+        }
+        
     }
 }
 
 struct ProfilePic_Previews: PreviewProvider {
     static var previews: some View {
         ProfilePic(
-            image: Image("pfp-dog")
+            url: URL(string: "pfp-dog")!
         )
     }
 }

--- a/xcode/Subconscious/Shared/Components/Common/Profile/ProfilePic.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/ProfilePic.swift
@@ -19,6 +19,7 @@ struct ProfilePicImage: View {
     var body: some View {
         image
             .resizable()
+            .aspectRatio(contentMode: .fill)
             .frame(width: 48, height: 48)
             .clipShape(Circle())
             .overlay(Circle().stroke(Color.separator, lineWidth: 0.5))
@@ -53,7 +54,7 @@ struct ProfilePic_Previews: PreviewProvider {
                 pfp: .none
             )
             ProfilePic(
-                pfp: .url(URL(string: "https://d2w9rnfcy7mm78.cloudfront.net/14547710/original_69c752e0010ef82be2792c16b1339663.gif?1641203279?bc=0")!)
+                pfp: .url(URL(string: "https://images.unsplash.com/photo-1577766729821-6003ae138e18")!)
             )
             ProfilePic(
                 pfp: .image("pfp-dog")

--- a/xcode/Subconscious/Shared/Components/Common/Profile/ProfilePic.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/ProfilePic.swift
@@ -7,26 +7,57 @@
 
 import SwiftUI
 
-struct ProfilePic: View {
-    var url: URL
+enum ProfilePicVariant: Equatable, Codable, Hashable {
+    case none
+    case url(URL)
+    case image(String)
+}
+
+struct ProfilePicImage: View {
+    var image: Image
+    
     var body: some View {
-        AsyncImage(url: url) { image in
         image
             .resizable()
             .frame(width: 48, height: 48)
             .clipShape(Circle())
             .overlay(Circle().stroke(Color.separator, lineWidth: 0.5))
-        } placeholder: {
-            ProgressView()
+    }
+}
+
+struct ProfilePic: View {
+    var pfp: ProfilePicVariant
+    var body: some View {
+        switch pfp {
+        case .none:
+            ProfilePicImage(image: Image("sub_logo"))
+        case .url(let url):
+            AsyncImage(url: url) { image in
+                ProfilePicImage(image: image)
+            } placeholder: {
+                ProgressView()
+                    .frame(width: 48, height: 48)
+                    .clipShape(Circle())
+                    .overlay(Circle().stroke(Color.separator, lineWidth: 0.5))
+            }
+        case .image(let img):
+            ProfilePicImage(image: Image(img))
         }
-        
     }
 }
 
 struct ProfilePic_Previews: PreviewProvider {
     static var previews: some View {
-        ProfilePic(
-            url: URL(string: "pfp-dog")!
-        )
+        VStack {
+            ProfilePic(
+                pfp: .none
+            )
+            ProfilePic(
+                pfp: .url(URL(string: "https://d2w9rnfcy7mm78.cloudfront.net/14547710/original_69c752e0010ef82be2792c16b1339663.gif?1641203279?bc=0")!)
+            )
+            ProfilePic(
+                pfp: .image("pfp-dog")
+            )
+        }
     }
 }

--- a/xcode/Subconscious/Shared/Components/Common/Profile/ProfilePicSm.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/ProfilePicSm.swift
@@ -7,30 +7,60 @@
 
 import SwiftUI
 
+struct ProfilePicSmImage: View {
+    var image: Image
+    var border: Color
+    
+    var body: some View {
+        image
+            .resizable()
+            .frame(width: 24, height: 24)
+            .overlay(
+                Circle()
+                    .stroke(border, lineWidth: 1)
+            )
+            .clipShape(Circle())
+    }
+}
+
 struct ProfilePicSm: View {
-    var url: URL
+    var pfp: ProfilePicVariant
     var border = Color.background
 
     var body: some View {
-        AsyncImage(url: url) { image in
-            image
-                .resizable()
-                .frame(width: 24, height: 24)
-                .overlay(
-                    Circle()
-                        .stroke(border, lineWidth: 1)
-                )
-                .clipShape(Circle())
-        } placeholder: {
-            ProgressView()
+        switch pfp {
+        case .none:
+            ProfilePicSmImage(image: Image("sub_logo"), border: border)
+        case .url(let url):
+            AsyncImage(url: url) { image in
+                ProfilePicSmImage(image: image, border: border)
+            } placeholder: {
+                ProgressView()
+                    .frame(width: 24, height: 24)
+                    .overlay(
+                        Circle()
+                            .stroke(border, lineWidth: 1)
+                    )
+                    .clipShape(Circle())
+            }
+        case .image(let img):
+            ProfilePicSmImage(image: Image(img), border: border)
         }
     }
 }
 
 struct ProfilePicSm_Previews: PreviewProvider {
     static var previews: some View {
-        ProfilePicSm(
-            url: URL(string: "pfp-dog")!
-        )
+        HStack {
+            ProfilePicSm(
+                pfp: .none
+            )
+            ProfilePicSm(
+                pfp: .url(URL(string: "https://d2w9rnfcy7mm78.cloudfront.net/14547710/original_69c752e0010ef82be2792c16b1339663.gif?1641203279?bc=0")!)
+            )
+            ProfilePicSm(
+                pfp: .image("pfp-dog")
+            )
+        }
     }
 }

--- a/xcode/Subconscious/Shared/Components/Common/Profile/ProfilePicSm.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/ProfilePicSm.swift
@@ -14,6 +14,7 @@ struct ProfilePicSmImage: View {
     var body: some View {
         image
             .resizable()
+            .aspectRatio(contentMode: .fill)
             .frame(width: 24, height: 24)
             .overlay(
                 Circle()
@@ -56,7 +57,7 @@ struct ProfilePicSm_Previews: PreviewProvider {
                 pfp: .none
             )
             ProfilePicSm(
-                pfp: .url(URL(string: "https://d2w9rnfcy7mm78.cloudfront.net/14547710/original_69c752e0010ef82be2792c16b1339663.gif?1641203279?bc=0")!)
+                pfp: .url(URL(string: "https://images.unsplash.com/photo-1577766729821-6003ae138e18")!)
             )
             ProfilePicSm(
                 pfp: .image("pfp-dog")

--- a/xcode/Subconscious/Shared/Components/Common/Profile/ProfilePicSm.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/ProfilePicSm.swift
@@ -8,25 +8,29 @@
 import SwiftUI
 
 struct ProfilePicSm: View {
-    var image: Image
+    var url: URL
     var border = Color.background
 
     var body: some View {
-        image
-            .resizable()
-            .frame(width: 24, height: 24)
-            .overlay(
-                Circle()
-                    .stroke(border, lineWidth: 1)
-            )
-            .clipShape(Circle())
+        AsyncImage(url: url) { image in
+            image
+                .resizable()
+                .frame(width: 24, height: 24)
+                .overlay(
+                    Circle()
+                        .stroke(border, lineWidth: 1)
+                )
+                .clipShape(Circle())
+        } placeholder: {
+            ProgressView()
+        }
     }
 }
 
 struct ProfilePicSm_Previews: PreviewProvider {
     static var previews: some View {
         ProfilePicSm(
-            image: Image("pfp-dog")
+            url: URL(string: "pfp-dog")!
         )
     }
 }

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
@@ -23,10 +23,11 @@ struct UserProfileHeaderView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.unit3) {
             HStack(alignment: .center, spacing: AppTheme.unit3) {
-                ProfilePic(image: Image(user.pfp))
+                if let url = URL(string: user.pfp) {
+                    ProfilePic(url: url)
+                }
             
-                // TODO: when we have _profile_.json we should load the preferred petname from there
-                PetnameBylineView(petname: user.petname)
+                PetnameBylineView(petname: Petname(user.preferredPetname ?? "") ?? user.petname)
                 
                 Spacer()
                 
@@ -78,6 +79,7 @@ struct BylineLgView_Previews: PreviewProvider {
                 user: UserProfile(
                     did: Did("did:key:123")!,
                     petname: Petname("ben")!,
+                    preferredPetname: nil,
                     address: Slashlink(petname: Petname("ben")!).toPublicMemoAddress(),
                     pfp: "pfp-dog",
                     bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber in a traddlewaddle.",
@@ -89,6 +91,7 @@ struct BylineLgView_Previews: PreviewProvider {
                 user: UserProfile(
                     did: Did("did:key:123")!,
                     petname: Petname("ben")!,
+                    preferredPetname: nil,
                     address: Slashlink(petname: Petname("ben")!).toPublicMemoAddress(),
                     pfp: "pfp-dog",
                     bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber in a traddlewaddle.",
@@ -101,6 +104,7 @@ struct BylineLgView_Previews: PreviewProvider {
                 user: UserProfile(
                     did: Did("did:key:123")!,
                     petname: Petname("ben")!,
+                    preferredPetname: nil,
                     address: Slashlink.ourProfile.toLocalMemoAddress(),
                     pfp: "pfp-dog",
                     bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber in a traddlewaddle.",

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
@@ -19,6 +19,7 @@ struct UserProfileHeaderView: View {
     
     var isFollowingUser: Bool
     var action: (UserProfileAction) -> Void = { _ in }
+    var hideActionButton: Bool = false
     
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.unit3) {
@@ -29,30 +30,32 @@ struct UserProfileHeaderView: View {
                 
                 Spacer()
                 
-                Button(
-                    action: {
-                        switch (user.category, isFollowingUser) {
-                        case (.you, _):
-                            action(.editOwnProfile)
-                        case (_, true):
-                            action(.requestUnfollow)
-                        case (_, false):
-                            action(.requestFollow)
+                if !hideActionButton {
+                    Button(
+                        action: {
+                            switch (user.category, isFollowingUser) {
+                            case (.you, _):
+                                action(.editOwnProfile)
+                            case (_, true):
+                                action(.requestUnfollow)
+                            case (_, false):
+                                action(.requestFollow)
+                            }
+                        },
+                        label: {
+                            switch (user.category, isFollowingUser) {
+                            case (.you, _):
+                                Label("Edit Profile", systemImage: AppIcon.edit.systemName)
+                            case (_, true):
+                                Label("Following", systemImage: AppIcon.following.systemName)
+                            case (_, false):
+                                Text("Follow")
+                            }
                         }
-                    },
-                    label: {
-                        switch (user.category, isFollowingUser) {
-                        case (.you, _):
-                            Label("Edit Profile", systemImage: AppIcon.edit.systemName)
-                        case (_, true):
-                            Label("Following", systemImage: AppIcon.following.systemName)
-                        case (_, false):
-                            Text("Follow")
-                        }
-                    }
-                )
-                .buttonStyle(GhostPillButtonStyle(size: .small))
-                .frame(maxWidth: 160)
+                    )
+                    .buttonStyle(GhostPillButtonStyle(size: .small))
+                    .frame(maxWidth: 160)
+                }
             }
             
             if let statistics = statistics {
@@ -66,7 +69,9 @@ struct UserProfileHeaderView: View {
                 .foregroundColor(.primary)
             }
             
-            Text(verbatim: user.bio)
+            if user.bio.count > 0 {
+                Text(verbatim: user.bio)
+            }
         }
     }
 }

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
@@ -26,7 +26,7 @@ struct UserProfileHeaderView: View {
             HStack(alignment: .center, spacing: AppTheme.unit3) {
                 ProfilePic(pfp: user.pfp)
             
-                PetnameBylineView(petname: Petname(user.preferredPetname ?? "") ?? user.petname)
+                PetnameBylineView(petname: user.nickname)
                 
                 Spacer()
                 
@@ -82,8 +82,7 @@ struct BylineLgView_Previews: PreviewProvider {
             UserProfileHeaderView(
                 user: UserProfile(
                     did: Did("did:key:123")!,
-                    petname: Petname("ben")!,
-                    preferredPetname: nil,
+                    nickname: Petname("ben")!,
                     address: Slashlink(petname: Petname("ben")!).toPublicMemoAddress(),
                     pfp: .image("pfp-dog"),
                     bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber in a traddlewaddle.",
@@ -94,8 +93,7 @@ struct BylineLgView_Previews: PreviewProvider {
             UserProfileHeaderView(
                 user: UserProfile(
                     did: Did("did:key:123")!,
-                    petname: Petname("ben")!,
-                    preferredPetname: nil,
+                    nickname: Petname("ben")!,
                     address: Slashlink(petname: Petname("ben")!).toPublicMemoAddress(),
                     pfp: .image("pfp-dog"),
                     bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber in a traddlewaddle.",
@@ -107,8 +105,7 @@ struct BylineLgView_Previews: PreviewProvider {
             UserProfileHeaderView(
                 user: UserProfile(
                     did: Did("did:key:123")!,
-                    petname: Petname("ben")!,
-                    preferredPetname: nil,
+                    nickname: Petname("ben")!,
                     address: Slashlink.ourProfile.toLocalMemoAddress(),
                     pfp: .image("pfp-dog"),
                     bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber in a traddlewaddle.",

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
@@ -58,7 +58,8 @@ struct UserProfileHeaderView: View {
             if let statistics = statistics {
                 HStack(spacing: AppTheme.unit2) {
                     ProfileStatisticView(label: "Notes", count: statistics.noteCount)
-                    ProfileStatisticView(label: "Backlinks", count: statistics.backlinkCount)
+                    // TODO: put this back when we have backlink count
+                    // ProfileStatisticView(label: "Backlinks", count: statistics.backlinkCount)
                     ProfileStatisticView(label: "Following", count: statistics.followingCount)
                 }
                 .font(.caption)

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
@@ -23,9 +23,7 @@ struct UserProfileHeaderView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.unit3) {
             HStack(alignment: .center, spacing: AppTheme.unit3) {
-                if let url = URL(string: user.pfp) {
-                    ProfilePic(url: url)
-                }
+                ProfilePic(pfp: user.pfp)
             
                 PetnameBylineView(petname: Petname(user.preferredPetname ?? "") ?? user.petname)
                 
@@ -81,7 +79,7 @@ struct BylineLgView_Previews: PreviewProvider {
                     petname: Petname("ben")!,
                     preferredPetname: nil,
                     address: Slashlink(petname: Petname("ben")!).toPublicMemoAddress(),
-                    pfp: "pfp-dog",
+                    pfp: .image("pfp-dog"),
                     bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber in a traddlewaddle.",
                     category: .human
                 ),
@@ -93,7 +91,7 @@ struct BylineLgView_Previews: PreviewProvider {
                     petname: Petname("ben")!,
                     preferredPetname: nil,
                     address: Slashlink(petname: Petname("ben")!).toPublicMemoAddress(),
-                    pfp: "pfp-dog",
+                    pfp: .image("pfp-dog"),
                     bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber in a traddlewaddle.",
                     category: .geist
                 ),
@@ -106,7 +104,7 @@ struct BylineLgView_Previews: PreviewProvider {
                     petname: Petname("ben")!,
                     preferredPetname: nil,
                     address: Slashlink.ourProfile.toLocalMemoAddress(),
-                    pfp: "pfp-dog",
+                    pfp: .image("pfp-dog"),
                     bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber in a traddlewaddle.",
                     category: .you
                 ),

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -299,6 +299,9 @@ private struct EditProfileSheetModifier: ViewModifier {
                         user: user,
                         onEditProfile: {
                             send(.requestEditProfile)
+                        },
+                        onCancel: {
+                            send(.presentEditProfile(false))
                         }
                     )
                 }

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -108,28 +108,17 @@ struct UserProfileView: View {
                 Text("Not found")
             }
         }
-        .navigationTitle(state.user?.petname.verbatim ?? "")
+        .navigationTitle(state.user?.nickname.verbatim ?? "")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar(content: {
             if let user = state.user {
-                switch (user.category) {
-                case .human, .geist:
-                    DetailToolbarContent(
-                        address: Slashlink(petname: user.petname).toPublicMemoAddress(),
-                        defaultAudience: .public,
-                        onTapOmnibox: {
-                            send(.presentMetaSheet(true))
-                        }
-                    )
-                case .you:
-                    DetailToolbarContent(
-                        address: Slashlink.ourProfile.toPublicMemoAddress(),
-                        defaultAudience: .public,
-                        onTapOmnibox: {
-                            send(.presentMetaSheet(true))
-                        }
-                    )
-                }
+                DetailToolbarContent(
+                    address: user.address,
+                    defaultAudience: .public,
+                    onTapOmnibox: {
+                        send(.presentMetaSheet(true))
+                    }
+                )
             } else {
                 DetailToolbarContent(
                     defaultAudience: .public,
@@ -264,7 +253,7 @@ private struct UnfollowModifier: ViewModifier {
               )
       ) {
           Button(
-              "Unfollow \(state.user?.petname.markup ?? "user")?",
+              "Unfollow \(state.user?.nickname.markup ?? "user")?",
               role: .destructive
           ) {
               send(.attemptUnfollow)

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -297,11 +297,15 @@ private struct EditProfileSheetModifier: ViewModifier {
                             tag: EditProfileSheetCursor.tag
                         ),
                         user: user,
+                        failEditProfileMessage: state.failEditProfileMessage,
                         onEditProfile: {
                             send(.requestEditProfile)
                         },
                         onCancel: {
                             send(.presentEditProfile(false))
+                        },
+                        onDismissError: {
+                            send(.dismissEditProfileError)
                         }
                     )
                 }

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -142,6 +142,7 @@ struct UserProfileView: View {
         .metaSheet(state: state, send: send)
         .follow(state: state, send: send)
         .unfollow(state: state, send: send)
+        .editProfile(state: state, send: send)
     }
 }
 
@@ -167,9 +168,16 @@ private extension View {
     ) -> some View {
       self.modifier(MetaSheetModifier(state: state, send: send))
     }
+    
+    func editProfile(
+        state: UserProfileDetailModel,
+        send: @escaping (UserProfileDetailAction) -> Void
+    ) -> some View {
+      self.modifier(EditProfileSheetModifier(state: state, send: send))
+    }
 }
 
-struct MetaSheetModifier: ViewModifier {
+private struct MetaSheetModifier: ViewModifier {
     let state: UserProfileDetailModel
     let send: (UserProfileDetailAction) -> Void
     
@@ -195,7 +203,7 @@ struct MetaSheetModifier: ViewModifier {
     }
 }
 
-struct FollowModifier: ViewModifier {
+private struct FollowModifier: ViewModifier {
     let state: UserProfileDetailModel
     let send: (UserProfileDetailAction) -> Void
     
@@ -230,7 +238,7 @@ struct FollowModifier: ViewModifier {
 }
 
 
-struct UnfollowModifier: ViewModifier {
+private struct UnfollowModifier: ViewModifier {
   let state: UserProfileDetailModel
   let send: (UserProfileDetailAction) -> Void
 
@@ -265,6 +273,37 @@ struct UnfollowModifier: ViewModifier {
           Text("You cannot undo this action")
       }
   }
+}
+
+
+private struct EditProfileSheetModifier: ViewModifier {
+    let state: UserProfileDetailModel
+    let send: (UserProfileDetailAction) -> Void
+    
+    func body(content: Content) -> some View {
+        content
+            .sheet(
+                isPresented: Binding(
+                    get: { state.isEditProfileSheetPresented },
+                    send: send,
+                    tag: UserProfileDetailAction.presentEditProfile
+                )
+            ) {
+                if let user = state.user {
+                    EditProfileSheet(
+                        state: state.editProfileSheet,
+                        send: Address.forward(
+                            send: send,
+                            tag: EditProfileSheetCursor.tag
+                        ),
+                        user: user,
+                        onEditProfile: {
+                            send(.requestEditProfile)
+                        }
+                    )
+                }
+            }
+    }
 }
 
 struct UserProfileView_Previews: PreviewProvider {

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -297,6 +297,7 @@ private struct EditProfileSheetModifier: ViewModifier {
                             tag: EditProfileSheetCursor.tag
                         ),
                         user: user,
+                        statistics: state.statistics,
                         failEditProfileMessage: state.failEditProfileMessage,
                         onEditProfile: {
                             send(.requestEditProfile)

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
@@ -23,10 +23,12 @@ struct StoryEntryView: View {
         ) {
             VStack(alignment: .leading, spacing: 0) {
                 HStack(alignment: .lastTextBaseline, spacing: AppTheme.unit) {
-                    BylineSmView(
-                        pfp: Image(story.author.pfp),
-                        slashlink: story.entry.address.toSlashlink()
-                    )
+                    if let url = URL(string: story.author.pfp) {
+                        BylineSmView(
+                            pfp: url,
+                            slashlink: story.entry.address.toSlashlink()
+                        )
+                    }
                     Group {
                         Text(
                             NiceDateFormatter.shared.string(

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
@@ -23,12 +23,10 @@ struct StoryEntryView: View {
         ) {
             VStack(alignment: .leading, spacing: 0) {
                 HStack(alignment: .lastTextBaseline, spacing: AppTheme.unit) {
-                    if let url = URL(string: story.author.pfp) {
-                        BylineSmView(
-                            pfp: url,
-                            slashlink: story.entry.address.toSlashlink()
-                        )
-                    }
+                    BylineSmView(
+                        pfp: story.author.pfp,
+                        slashlink: story.entry.address.toSlashlink()
+                    )
                     Group {
                         Text(
                             NiceDateFormatter.shared.string(

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryPromptView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryPromptView.swift
@@ -37,7 +37,7 @@ struct StoryPromptView: View {
                     },
                     label: {
                         TranscludeView(
-                            pfp: Image("pfp-dog"),
+                            pfp: URL(string: "pfp-dog")!,
                             slashlink: story.entry.address.toSlashlink(),
                             excerpt: story.entry.excerpt
                         )

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryPromptView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryPromptView.swift
@@ -37,7 +37,7 @@ struct StoryPromptView: View {
                     },
                     label: {
                         TranscludeView(
-                            pfp: URL(string: "pfp-dog")!,
+                            pfp: .image("pfp-dog"),
                             slashlink: story.entry.address.toSlashlink(),
                             excerpt: story.entry.excerpt
                         )

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
@@ -20,8 +20,7 @@ struct StoryUserView: View {
         Button(
             action: {
                 action(
-                    Slashlink(petname: story.user.petname)
-                        .toPublicMemoAddress(),
+                    story.user.address,
                     story.user.bio
                 )
             }
@@ -29,7 +28,7 @@ struct StoryUserView: View {
             VStack(alignment: .leading, spacing: AppTheme.unit3) {
                 HStack(alignment: .center, spacing: AppTheme.unit2) {
                     ProfilePicSm(pfp: story.user.pfp)
-                    PetnameBylineView(petname: story.user.petname)
+                    PetnameBylineView(petname: story.user.nickname)
                     
                     Spacer()
                     
@@ -62,8 +61,7 @@ struct StoryUserView_Previews: PreviewProvider {
                 story: StoryUser(
                     user: UserProfile(
                         did: Did("did:key:123")!,
-                        petname: Petname("ben.gordon.chris.bob")!,
-                        preferredPetname: nil,
+                        nickname: Petname("ben.gordon.chris.bob")!,
                         address: Slashlink(petname: Petname("ben.gordon.chris.bob")!).toPublicMemoAddress(),
                         pfp: .image("pfp-dog"),
                         bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber.",
@@ -77,8 +75,7 @@ struct StoryUserView_Previews: PreviewProvider {
                 story: StoryUser(
                     user: UserProfile(
                         did: Did("did:key:123")!,
-                        petname: Petname("ben.gordon.chris.bob")!,
-                        preferredPetname: nil,
+                        nickname: Petname("ben.gordon.chris.bob")!,
                         address: Slashlink(petname: Petname("ben.gordon.chris.bob")!).toPublicMemoAddress(),
                         pfp: .image("pfp-dog"),
                         bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber.",
@@ -92,8 +89,7 @@ struct StoryUserView_Previews: PreviewProvider {
                 story: StoryUser(
                     user: UserProfile(
                         did: Did("did:key:123")!,
-                        petname: Petname("ben.gordon.chris.bob")!,
-                        preferredPetname: nil,
+                        nickname: Petname("ben.gordon.chris.bob")!,
                         address: Slashlink(petname: Petname("ben.gordon.chris.bob")!).toPublicMemoAddress(),
                         pfp: .image("pfp-dog"),
                         bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber.",

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
@@ -28,14 +28,8 @@ struct StoryUserView: View {
         ) {
             VStack(alignment: .leading, spacing: AppTheme.unit3) {
                 HStack(alignment: .center, spacing: AppTheme.unit2) {
-                    ProfilePicSm(url: URL(string: story.user.pfp)!)
-                    
-                    switch (story.user.category) {
-                    case .human, .geist:
-                        PetnameBylineView(petname: story.user.petname)
-                    case .you:
-                        PetnameBylineView(petname: story.user.petname)
-                    }
+                    ProfilePicSm(pfp: story.user.pfp)
+                    PetnameBylineView(petname: story.user.petname)
                     
                     Spacer()
                     
@@ -71,7 +65,7 @@ struct StoryUserView_Previews: PreviewProvider {
                         petname: Petname("ben.gordon.chris.bob")!,
                         preferredPetname: nil,
                         address: Slashlink(petname: Petname("ben.gordon.chris.bob")!).toPublicMemoAddress(),
-                        pfp: "pfp-dog",
+                        pfp: .image("pfp-dog"),
                         bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber.",
                         category: .human
                     ),
@@ -86,7 +80,7 @@ struct StoryUserView_Previews: PreviewProvider {
                         petname: Petname("ben.gordon.chris.bob")!,
                         preferredPetname: nil,
                         address: Slashlink(petname: Petname("ben.gordon.chris.bob")!).toPublicMemoAddress(),
-                        pfp: "pfp-dog",
+                        pfp: .image("pfp-dog"),
                         bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber.",
                         category: .human
                     ),
@@ -101,7 +95,7 @@ struct StoryUserView_Previews: PreviewProvider {
                         petname: Petname("ben.gordon.chris.bob")!,
                         preferredPetname: nil,
                         address: Slashlink(petname: Petname("ben.gordon.chris.bob")!).toPublicMemoAddress(),
-                        pfp: "pfp-dog",
+                        pfp: .image("pfp-dog"),
                         bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber.",
                         category: .you
                     ),

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
@@ -28,7 +28,7 @@ struct StoryUserView: View {
         ) {
             VStack(alignment: .leading, spacing: AppTheme.unit3) {
                 HStack(alignment: .center, spacing: AppTheme.unit2) {
-                    ProfilePicSm(image: Image(story.user.pfp))
+                    ProfilePicSm(url: URL(string: story.user.pfp)!)
                     
                     switch (story.user.category) {
                     case .human, .geist:
@@ -69,6 +69,7 @@ struct StoryUserView_Previews: PreviewProvider {
                     user: UserProfile(
                         did: Did("did:key:123")!,
                         petname: Petname("ben.gordon.chris.bob")!,
+                        preferredPetname: nil,
                         address: Slashlink(petname: Petname("ben.gordon.chris.bob")!).toPublicMemoAddress(),
                         pfp: "pfp-dog",
                         bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber.",
@@ -83,6 +84,7 @@ struct StoryUserView_Previews: PreviewProvider {
                     user: UserProfile(
                         did: Did("did:key:123")!,
                         petname: Petname("ben.gordon.chris.bob")!,
+                        preferredPetname: nil,
                         address: Slashlink(petname: Petname("ben.gordon.chris.bob")!).toPublicMemoAddress(),
                         pfp: "pfp-dog",
                         bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber.",
@@ -97,6 +99,7 @@ struct StoryUserView_Previews: PreviewProvider {
                     user: UserProfile(
                         did: Did("did:key:123")!,
                         petname: Petname("ben.gordon.chris.bob")!,
+                        preferredPetname: nil,
                         address: Slashlink(petname: Petname("ben.gordon.chris.bob")!).toPublicMemoAddress(),
                         pfp: "pfp-dog",
                         bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber.",

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct TranscludeView: View {
-    var pfp: URL
+    var pfp: ProfilePicVariant
     var slashlink: Slashlink
     var excerpt: String
 
@@ -34,7 +34,7 @@ struct TranscludeView: View {
 struct TranscludeView_Previews: PreviewProvider {
     static var previews: some View {
         TranscludeView(
-            pfp: URL(string: "pfp-dog")!,
+            pfp: .image("pfp-dog"),
             slashlink: Slashlink("@doge/thoughts")!,
             excerpt: "Thoughts of Doge. Food food park park park run run play run fetch ball run water shlorp shlorp shlorp dog bork bork bork home sleep sleep dream sleep"
         )

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct TranscludeView: View {
-    var pfp: Image
+    var pfp: URL
     var slashlink: Slashlink
     var excerpt: String
 
@@ -34,7 +34,7 @@ struct TranscludeView: View {
 struct TranscludeView_Previews: PreviewProvider {
     static var previews: some View {
         TranscludeView(
-            pfp: Image("pfp-dog"),
+            pfp: URL(string: "pfp-dog")!,
             slashlink: Slashlink("@doge/thoughts")!,
             excerpt: "Thoughts of Doge. Food food park park park run run play run fetch ball run water shlorp shlorp shlorp dog bork bork bork home sleep sleep dream sleep"
         )

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailMetaSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailMetaSheet.swift
@@ -77,7 +77,7 @@ struct UserProfileDetailMetaSheet: View {
         .presentationDragIndicator(.hidden)
         .presentationDetents([.medium])
         .confirmationDialog(
-            "Are you sure you want to unfollow \(profile.user?.petname.verbatim ?? "unknown")",
+            "Are you sure you want to unfollow \(profile.user?.nickname.verbatim ?? "unknown")",
             isPresented: Binding(
                 get: { state.isDeleteConfirmationDialogPresented },
                 send: send,
@@ -88,14 +88,14 @@ struct UserProfileDetailMetaSheet: View {
             Button(
                 role: .destructive,
                 action: {
-                    guard let petname = profile.user?.petname else {
+                    guard let did = profile.user?.did else {
                         return
                     }
                     
-                    send(.requestUnfollow(petname: petname))
+                    send(.requestUnfollow(did: did))
                 }
             ) {
-                Text("Unfollow @\(profile.user?.petname.verbatim ?? "unknown")")
+                Text("Unfollow @\(profile.user?.nickname.verbatim ?? "unknown")")
             }
         }
     }
@@ -134,7 +134,7 @@ enum UserProfileDetailMetaSheetAction: Hashable {
     case requestFollow(did: Did)
     /// Request to unfollow this user
     /// Should be handled by parent component.
-    case requestUnfollow(petname: Petname)
+    case requestUnfollow(did: Did)
     
     case presentDetailsTable(Bool)
 }

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -408,7 +408,7 @@ struct UserProfileDetailModel: ModelProtocol {
             
             let profile = UserProfileEntry(
                 version: UserProfileEntry.currentVersion,
-                preferredName: state.user?.preferredPetname,
+                nickname: state.user?.preferredPetname,
                 bio: state.user?.bio,
                 profilePictureUrl: pfp?.absoluteString
             )
@@ -421,7 +421,7 @@ struct UserProfileDetailModel: ModelProtocol {
         case .requestEditProfile:
             let profile = UserProfileEntry(
                 version: UserProfileEntry.currentVersion,
-                preferredName: state.editProfileSheet.nicknameField.validated?.verbatim,
+                nickname: state.editProfileSheet.nicknameField.validated?.verbatim,
                 bio: state.editProfileSheet.bioField.validated,
                 profilePictureUrl: state.editProfileSheet.pfpUrlField.validated?.absoluteString
             )

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -407,7 +407,6 @@ struct UserProfileDetailModel: ModelProtocol {
             }
             
             let profile = UserProfileEntry(
-                version: UserProfileEntry.currentVersion,
                 nickname: state.user?.preferredPetname,
                 bio: state.user?.bio,
                 profilePictureUrl: pfp?.absoluteString
@@ -420,7 +419,6 @@ struct UserProfileDetailModel: ModelProtocol {
             
         case .requestEditProfile:
             let profile = UserProfileEntry(
-                version: UserProfileEntry.currentVersion,
                 nickname: state.editProfileSheet.nicknameField.validated?.verbatim,
                 bio: state.editProfileSheet.bioField.validated,
                 profilePictureUrl: state.editProfileSheet.pfpUrlField.validated?.absoluteString

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -276,7 +276,7 @@ struct UserProfileDetailModel: ModelProtocol {
             model.isFollowSheetPresented = presented
             return Update(state: model)
             
-            // MARK: Following status
+        // MARK: Following status
         case .fetchFollowingStatus(let did):
             let fx: Fx<UserProfileDetailAction> =
             environment.addressBook
@@ -297,7 +297,7 @@ struct UserProfileDetailModel: ModelProtocol {
             model.isFollowingUser = following
             return Update(state: model)
             
-            // MARK: Following
+        // MARK: Following
         case .requestFollow:
             return update(state: state, action: .presentFollowSheet(true), environment: environment)
             
@@ -342,7 +342,7 @@ struct UserProfileDetailModel: ModelProtocol {
             model.failFollowErrorMessage = nil
             return Update(state: model)
             
-            // MARK: Unfollowing
+        // MARK: Unfollowing
         case .presentUnfollowConfirmation(let presented):
             var model = state
             model.isUnfollowConfirmationPresented = presented

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -134,7 +134,7 @@ struct UserProfile: Equatable, Codable, Hashable {
     let petname: Petname
     let preferredPetname: String?
     let address: MemoAddress
-    let pfp: String
+    let pfp: ProfilePicVariant
     let bio: String
     let category: UserCategory
 }
@@ -396,11 +396,21 @@ struct UserProfileDetailModel: ModelProtocol {
         case .presentEditProfile(let presented):
             var model = state
             model.isEditProfileSheetPresented = presented
+            
+            let pfp: URL? = Func.run {
+                switch (state.user?.pfp) {
+                case .some(.url(let url)):
+                    return url
+                case _:
+                    return nil
+                }
+            }
+            
             let profile = UserProfileEntry(
                 version: UserProfileEntry.currentVersion,
                 preferredName: state.user?.preferredPetname,
                 bio: state.user?.bio,
-                profilePictureUrl: state.user?.pfp
+                profilePictureUrl: pfp?.absoluteString
             )
             return update(
                 state: model,

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -393,12 +393,22 @@ struct UserProfileDetailModel: ModelProtocol {
         case .presentEditProfile(let presented):
             var model = state
             model.isEditProfileSheetPresented = presented
-            return Update(state: model)
+            let profile = UserProfileEntry(
+                version: UserProfileEntry.currentVersion,
+                preferredName: state.user?.preferredPetname,
+                bio: state.user?.bio,
+                profilePictureUrl: state.user?.pfp
+            )
+            return update(
+                state: model,
+                action: .editProfileSheet(.populate(profile)),
+                environment: environment
+            )
             
         case .requestEditProfile:
             let profile = UserProfileEntry(
                 version: UserProfileEntry.currentVersion,
-                preferredName: state.editProfileSheet.nicknameField.validated,
+                preferredName: state.editProfileSheet.nicknameField.validated?.verbatim,
                 bio: state.editProfileSheet.bioField.validated,
                 profilePictureUrl: state.editProfileSheet.pfpUrlField.validated?.absoluteString
             )

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -125,6 +125,7 @@ enum UserCategory: Equatable, Codable, Hashable, CaseIterable {
 struct UserProfile: Equatable, Codable, Hashable {
     let did: Did
     let petname: Petname
+    let preferredPetname: String?
     let address: MemoAddress
     let pfp: String
     let bio: String

--- a/xcode/Subconscious/Shared/Components/Form/FollowUserFormView.swift
+++ b/xcode/Subconscious/Shared/Components/Form/FollowUserFormView.swift
@@ -104,21 +104,21 @@ struct FollowUserView: View {
                         }
                     }
                 }
-            }
-            .navigationTitle("Follow User")
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") {
-                        send(.requestFollow)
+                .navigationTitle("Follow User")
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Done") {
+                            send(.requestFollow)
+                        }
+                    }
+                    ToolbarItem(placement: .navigation) {
+                        Button("Cancel", role: .cancel) {
+                            send(.presentFollowUserForm(false))
+                        }
                     }
                 }
-                ToolbarItem(placement: .navigation) {
-                    Button("Cancel", role: .cancel) {
-                        send(.presentFollowUserForm(false))
-                    }
-                }
+                .navigationBarTitleDisplayMode(.inline)
             }
-            .navigationBarTitleDisplayMode(.inline)
             .alert(
                 isPresented: Binding(
                     get: { state.failFollowErrorMessage != nil },

--- a/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
@@ -72,8 +72,7 @@ extension StoryUser: DummyData {
         return StoryUser(
             user: UserProfile(
                 did: Did.dummyData(),
-                petname: petname,
-                preferredPetname: nil,
+                nickname: petname,
                 address: Slashlink(petname: petname).toPublicMemoAddress(),
                 pfp: .image(String.dummyProfilePicture()),
                 bio: String.dummyDataMedium(),
@@ -87,8 +86,7 @@ extension StoryUser: DummyData {
         StoryUser(
             user: UserProfile(
                 did: Did.dummyData(),
-                petname: petname,
-                preferredPetname: nil,
+                nickname: petname,
                 address: Slashlink(petname: petname).toPublicMemoAddress(),
                 pfp: .image(String.dummyProfilePicture()),
                 bio: String.dummyDataMedium(),
@@ -153,8 +151,7 @@ extension UserProfile: DummyData {
         let petname = Petname.dummyData()
         return UserProfile(
             did: Did.dummyData(),
-            petname: petname,
-            preferredPetname: nil,
+            nickname: petname,
             address: Slashlink(petname: petname).toPublicMemoAddress(),
             pfp: .image(String.dummyProfilePicture()),
             bio: String.dummyDataMedium(),

--- a/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
@@ -75,7 +75,7 @@ extension StoryUser: DummyData {
                 petname: petname,
                 preferredPetname: nil,
                 address: Slashlink(petname: petname).toPublicMemoAddress(),
-                pfp: String.dummyProfilePicture(),
+                pfp: .image(String.dummyProfilePicture()),
                 bio: String.dummyDataMedium(),
                 category: [UserCategory.human, UserCategory.geist].randomElement()!
             ),
@@ -90,7 +90,7 @@ extension StoryUser: DummyData {
                 petname: petname,
                 preferredPetname: nil,
                 address: Slashlink(petname: petname).toPublicMemoAddress(),
-                pfp: String.dummyProfilePicture(),
+                pfp: .image(String.dummyProfilePicture()),
                 bio: String.dummyDataMedium(),
                 category: [UserCategory.human, UserCategory.geist].randomElement()!
             ),
@@ -156,7 +156,7 @@ extension UserProfile: DummyData {
             petname: petname,
             preferredPetname: nil,
             address: Slashlink(petname: petname).toPublicMemoAddress(),
-            pfp: String.dummyProfilePicture(),
+            pfp: .image(String.dummyProfilePicture()),
             bio: String.dummyDataMedium(),
             category: .human
         )

--- a/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
@@ -73,6 +73,7 @@ extension StoryUser: DummyData {
             user: UserProfile(
                 did: Did.dummyData(),
                 petname: petname,
+                preferredPetname: nil,
                 address: Slashlink(petname: petname).toPublicMemoAddress(),
                 pfp: String.dummyProfilePicture(),
                 bio: String.dummyDataMedium(),
@@ -87,6 +88,7 @@ extension StoryUser: DummyData {
             user: UserProfile(
                 did: Did.dummyData(),
                 petname: petname,
+                preferredPetname: nil,
                 address: Slashlink(petname: petname).toPublicMemoAddress(),
                 pfp: String.dummyProfilePicture(),
                 bio: String.dummyDataMedium(),
@@ -152,6 +154,7 @@ extension UserProfile: DummyData {
         return UserProfile(
             did: Did.dummyData(),
             petname: petname,
+            preferredPetname: nil,
             address: Slashlink(petname: petname).toPublicMemoAddress(),
             pfp: String.dummyProfilePicture(),
             bio: String.dummyDataMedium(),

--- a/xcode/Subconscious/Shared/Models/FormField.swift
+++ b/xcode/Subconscious/Shared/Models/FormField.swift
@@ -21,7 +21,7 @@ enum FormFieldAction<Input: Equatable>: Equatable {
     case setValue(input: Input)
 }
 
-struct FormFieldEnvironment {}
+typealias FormFieldEnvironment = Void
 
 struct FormField<Input: Equatable, Output>: ModelProtocol {
     static func == (lhs: FormField<Input, Output>, rhs: FormField<Input, Output>) -> Bool {

--- a/xcode/Subconscious/Shared/Models/Slug.swift
+++ b/xcode/Subconscious/Shared/Models/Slug.swift
@@ -68,8 +68,8 @@ public struct Slug:
     }
     
     /// Excludes "internal" slugs like `Slug.profile`
-    public var isListable: Bool {
-        !verbatim.hasPrefix("_")
+    public var isHidden: Bool {
+        verbatim.hasPrefix("_")
     }
     
     /// Losslessly create a slug from a string.

--- a/xcode/Subconscious/Shared/Models/Slug.swift
+++ b/xcode/Subconscious/Shared/Models/Slug.swift
@@ -67,6 +67,11 @@ public struct Slug:
         self == Slug.profile
     }
     
+    /// Excludes "internal" slugs like `Slug.profile`
+    public var isListable: Bool {
+        !verbatim.hasPrefix("_")
+    }
+    
     /// Losslessly create a slug from a string.
     /// This requires that the string already be formatted like a
     /// valid slug.

--- a/xcode/Subconscious/Shared/Models/StoryEntry.swift
+++ b/xcode/Subconscious/Shared/Models/StoryEntry.swift
@@ -20,7 +20,7 @@ struct StoryEntry:
 
     var description: String {
         """
-        @\(author.petname.description)
+        @\(author.nickname.description)
         \(String(describing: entry))
         """
     }

--- a/xcode/Subconscious/Shared/Models/StoryUser.swift
+++ b/xcode/Subconscious/Shared/Models/StoryUser.swift
@@ -22,7 +22,7 @@ struct StoryUser:
 
     var description: String {
         """
-        \(String(describing: user.petname))
+        \(String(describing: user.nickname))
         Following? \(isFollowingUser)
         
         \(user.bio)

--- a/xcode/Subconscious/Shared/Services/AddressBookService.swift
+++ b/xcode/Subconscious/Shared/Services/AddressBookService.swift
@@ -77,7 +77,6 @@ actor AddressBook<Sphere: SphereProtocol> {
                 .unwrap()
             addressBook.append(
                 AddressBookEntry(
-                    pfp: AppTheme.brandMark,
                     petname: petname,
                     did: did
                 )

--- a/xcode/Subconscious/Shared/Services/AddressBookService.swift
+++ b/xcode/Subconscious/Shared/Services/AddressBookService.swift
@@ -258,7 +258,7 @@ actor AddressBookService {
         Future.detached {
             try await self.addressBook.listEntries(refetch: refetch)
         }
-        .eraseToAnyPublisher()    
+        .eraseToAnyPublisher()
     }
     
     /// Associates the passed DID with the passed petname within the sphere, clears the cache,

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -367,12 +367,16 @@ actor DataService {
         .eraseToAnyPublisher()
     }
     
+    func listRecentMemos() async throws -> [EntryStub] {
+        let recent = try self.database.listRecentMemos()
+        return recent.filter { entry in
+            !entry.address.slug.isHidden
+        }
+    }
+    
     nonisolated func listRecentMemosPublisher() -> AnyPublisher<[EntryStub], Error> {
         Future.detached {
-            let recent = try await self.database.listRecentMemos()
-            return recent.filter { entry in
-                !entry.address.slug.isHidden
-            }
+            return try await self.listRecentMemos()
         }
         .eraseToAnyPublisher()
     }

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -369,7 +369,10 @@ actor DataService {
     
     nonisolated func listRecentMemosPublisher() -> AnyPublisher<[EntryStub], Error> {
         Future.detached {
-            try await self.database.listRecentMemos()
+            let recent = try await self.database.listRecentMemos()
+            return recent.filter { entry in
+                entry.address.slug.isListable
+            }
         }
         .eraseToAnyPublisher()
     }

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -371,7 +371,7 @@ actor DataService {
         Future.detached {
             let recent = try await self.database.listRecentMemos()
             return recent.filter { entry in
-                entry.address.slug.isListable
+                !entry.address.slug.isHidden
             }
         }
         .eraseToAnyPublisher()

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -376,7 +376,7 @@ actor DataService {
     
     nonisolated func listRecentMemosPublisher() -> AnyPublisher<[EntryStub], Error> {
         Future.detached {
-            return try await self.listRecentMemos()
+            try await self.listRecentMemos()
         }
         .eraseToAnyPublisher()
     }

--- a/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
@@ -691,7 +691,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
         .eraseToAnyPublisher()
     }
     
-    /// List all slugs in sphere excluding those prefixed with `_`
+    /// List all slugs in sphere
     /// - Returns an array of `Slug`
     public func list() throws -> [Slug] {
         let slugs = try Noosphere.callWithError(

--- a/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
@@ -691,7 +691,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
         .eraseToAnyPublisher()
     }
     
-    /// List all slugs in sphere
+    /// List all slugs in sphere excluding those prefixed with `_`
     /// - Returns an array of `Slug`
     public func list() throws -> [Slug] {
         let slugs = try Noosphere.callWithError(
@@ -703,8 +703,12 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
             ns_string_array_free(slugs)
         }
         
-        return try slugs.toStringArray().map({ string in
-            try Slug(string).unwrap(SphereError.parseError(string))
+        return try slugs.toStringArray().compactMap({ string in
+            guard !string.hasPrefix("_") else {
+                return nil
+            }
+            
+            return try Slug(string).unwrap(SphereError.parseError(string))
         })
     }
     

--- a/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
@@ -703,11 +703,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
             ns_string_array_free(slugs)
         }
         
-        return try slugs.toStringArray().compactMap({ string in
-            guard !string.hasPrefix("_") else {
-                return nil
-            }
-            
+        return try slugs.toStringArray().map({ string in
             return try Slug(string).unwrap(SphereError.parseError(string))
         })
     }

--- a/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
@@ -704,7 +704,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
         }
         
         return try slugs.toStringArray().map({ string in
-            return try Slug(string).unwrap(SphereError.parseError(string))
+            try Slug(string).unwrap(SphereError.parseError(string))
         })
     }
     

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -182,6 +182,10 @@ actor UserProfileService {
         var entries: [EntryStub] = []
         
         for slug in notes {
+            guard slug.isListable else {
+                continue
+            }
+            
             let slashlink = Slashlink(slug: slug)
             let memo = try await noosphere.read(slashlink: slashlink)
             

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -190,7 +190,7 @@ actor UserProfileService {
         var entries: [EntryStub] = []
         
         for slug in notes {
-            guard slug.isListable else {
+            guard !slug.isHidden else {
                 continue
             }
             

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -126,7 +126,15 @@ actor UserProfileService {
             body: data
         )
         
-        _ = try await self.noosphere.sync()
+        let _ = try await self.noosphere.save()
+        
+        do {
+            _ = try await self.noosphere.sync()
+        } catch {
+            // Swallow this error in the event syncing fails
+            // Editing the profile still succeeded
+            logger.warning("Failed to sync after updating profile: \(error.localizedDescription)")
+        }
     }
     
     /// Attempt to read & deserialize a user `_profile_.json` at the given address.

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -187,12 +187,21 @@ actor UserProfileService {
         let address = Slashlink.ourProfile.toPublicMemoAddress()
         let userProfileData = await readProfile(address: address)
         
+        let pfp: ProfilePicVariant = Func.run {
+            if let url = URL(string: userProfileData?.profilePictureUrl ?? "") {
+                return .url(url)
+            }
+            
+            return .none
+        }
+        
+        
         let profile = UserProfile(
             did: did,
             petname: Petname(userProfileData?.preferredName ?? "") ?? petname,
             preferredPetname: userProfileData?.preferredName,
             address: address,
-            pfp: userProfileData?.profilePictureUrl ?? "sub_logo",
+            pfp: pfp,
             bio: userProfileData?.bio ?? "",
             category: .you
         )
@@ -262,12 +271,20 @@ actor UserProfileService {
         let address = Slashlink(petname: petname).toPublicMemoAddress()
         let userProfileData = await readProfile(address: address)
         
+        let pfp: ProfilePicVariant = Func.run {
+            if let url = URL(string: userProfileData?.profilePictureUrl ?? "") {
+                return .url(url)
+            }
+            
+            return .none
+        }
+        
         let profile = UserProfile(
             did: did,
             petname: petname,
             preferredPetname: userProfileData?.preferredName,
             address: address,
-            pfp: userProfileData?.profilePictureUrl ?? "sub_logo",
+            pfp: pfp,
             bio: userProfileData?.bio ?? "",
             category: .human
         )
@@ -318,12 +335,20 @@ actor UserProfileService {
                 : Slashlink(petname: petname).toPublicMemoAddress()
             let userProfileData = await readProfile(address: address)
             
+            let pfp: ProfilePicVariant = Func.run {
+                if let url = URL(string: userProfileData?.profilePictureUrl ?? "") {
+                    return .url(url)
+                }
+                
+                return .none
+            }
+            
             let user = UserProfile(
                 did: did,
                 petname: petname,
                 preferredPetname: userProfileData?.preferredName,
                 address: address,
-                pfp: userProfileData?.profilePictureUrl ?? "sub_logo",
+                pfp: pfp,
                 bio: userProfileData?.bio ?? "",
                 category: isOurs ? .you : .human
             )

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -87,7 +87,7 @@ actor UserProfileService {
         category: "UserProfileService"
     )
     
-    private static let profileContentType = "application/json"
+    private static let profileContentType = "application/vnd.subconscious.profile+json"
     
     init(
         noosphere: NoosphereService,

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -175,7 +175,7 @@ actor UserProfileService {
             address: address,
             pfp: pfp,
             bio: userProfileData?.bio ?? "",
-            category: .you
+            category: address.isOurProfile ? .you : .human
         )
         
         return profile

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -33,12 +33,12 @@ extension UserProfileServiceError: LocalizedError {
             )
         case .unexpectedProfileContentType(let contentType):
             return String(
-                localized: "Unexpected content type \(contentType) encountered reading profile memo",
+                localized: "Unexpected content type \(contentType) found reading profile memo",
                 comment: "UserProfileService error description"
             )
         case .unexpectedProfileSchemaVersion(let versionString):
             return String(
-                localized: "Unexpected version string \"\(versionString)\" encountered reading profile",
+                localized: "Unexpected version string \"\(versionString)\" found reading profile",
                 comment: "UserProfileService error description"
             )
         case .failedToDeserializeProfile(let error, let data):

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -65,7 +65,7 @@ struct UserProfileContentResponse: Equatable, Hashable {
     var isFollowingUser: Bool
 }
 
-struct UserProfileEntry: Codable {
+struct UserProfileEntry: Codable, Equatable {
     static let currentVersion = "0.0"
     
     let version: String

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -69,9 +69,8 @@ struct UserProfileEntry: Codable, Equatable {
     static let currentVersion = "0.0"
     
     let version: String
-    let preferredName: String?
+    let nickname: String?
     let bio: String?
-    // TODO: should we store the pfp in a memo?
     let profilePictureUrl: String?
 }
 
@@ -149,7 +148,7 @@ actor UserProfileService {
     /// Retrieve all the content for the App User's profile view, fetching their profile, notes and address book.
     func requestOwnProfile() async throws -> UserProfileContentResponse {
         guard let nickname = AppDefaults.standard.nickname,
-              let petname = Petname(nickname) else {
+              let nickname = Petname(nickname) else {
                   throw UserProfileServiceError.missingPreferredPetname
         }
         
@@ -198,8 +197,8 @@ actor UserProfileService {
         
         let profile = UserProfile(
             did: did,
-            petname: Petname(userProfileData?.preferredName ?? "") ?? petname,
-            preferredPetname: userProfileData?.preferredName,
+            petname: Petname(userProfileData?.nickname ?? "") ?? nickname,
+            preferredPetname: userProfileData?.nickname,
             address: address,
             pfp: pfp,
             bio: userProfileData?.bio ?? "",
@@ -282,7 +281,7 @@ actor UserProfileService {
         let profile = UserProfile(
             did: did,
             petname: petname,
-            preferredPetname: userProfileData?.preferredName,
+            preferredPetname: userProfileData?.nickname,
             address: address,
             pfp: pfp,
             bio: userProfileData?.bio ?? "",
@@ -346,7 +345,7 @@ actor UserProfileService {
             let user = UserProfile(
                 did: did,
                 petname: petname,
-                preferredPetname: userProfileData?.preferredName,
+                preferredPetname: userProfileData?.nickname,
                 address: address,
                 pfp: pfp,
                 bio: userProfileData?.bio ?? "",

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		B51EEAA129F0C37B0055887B /* AppIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51EEAA029F0C37B0055887B /* AppIcon.swift */; };
 		B532F8C329B1752E00CE9256 /* TranscludeBlockLayoutFragment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532F8C229B1752E00CE9256 /* TranscludeBlockLayoutFragment.swift */; };
 		B54187B829EF5CA00056E4A9 /* FollowUserFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54187B729EF5CA00056E4A9 /* FollowUserFormView.swift */; };
+		B5432B8329F8BAED003BBB23 /* Tests_UserProfileService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5432B8229F8BAED003BBB23 /* Tests_UserProfileService.swift */; };
 		B54B922828E669D6003ACA1F /* MementoGeist.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B922728E669D6003ACA1F /* MementoGeist.swift */; };
 		B550E04029AF219100050F19 /* Did.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D8D30029AF1F9B0011D820 /* Did.swift */; };
 		B569971629B6A0DF003204FC /* FollowUserViaQRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B569971429B6A0DF003204FC /* FollowUserViaQRCodeView.swift */; };
@@ -411,6 +412,7 @@
 		B51EEAA029F0C37B0055887B /* AppIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIcon.swift; sourceTree = "<group>"; };
 		B532F8C229B1752E00CE9256 /* TranscludeBlockLayoutFragment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscludeBlockLayoutFragment.swift; sourceTree = "<group>"; };
 		B54187B729EF5CA00056E4A9 /* FollowUserFormView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FollowUserFormView.swift; sourceTree = "<group>"; };
+		B5432B8229F8BAED003BBB23 /* Tests_UserProfileService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_UserProfileService.swift; sourceTree = "<group>"; };
 		B54B922728E669D6003ACA1F /* MementoGeist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MementoGeist.swift; sourceTree = "<group>"; };
 		B569971429B6A0DF003204FC /* FollowUserViaQRCodeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FollowUserViaQRCodeView.swift; sourceTree = "<group>"; };
 		B569971529B6A0DF003204FC /* DidQrCodeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DidQrCodeView.swift; sourceTree = "<group>"; };
@@ -825,6 +827,7 @@
 				B8D328B929A69D2D00850A37 /* Tests_URLUtilities.swift */,
 				B8E62AE729D61E69008F7E74 /* Tests_UserDefaultProperty.swift */,
 				B5908BEA29DAB05B00225B1A /* TestUtilities.swift */,
+				B5432B8229F8BAED003BBB23 /* Tests_UserProfileService.swift */,
 			);
 			path = SubconsciousTests;
 			sourceTree = "<group>";
@@ -1492,6 +1495,7 @@
 				B8F27EE42970CD8F00A33E78 /* Tests_Sphere.swift in Sources */,
 				B82BB7FE28243F32000C9FCC /* Tests_Parser.swift in Sources */,
 				B84AD8E82811C827006B3153 /* Tests_URLComponentsUtilities.swift in Sources */,
+				B5432B8329F8BAED003BBB23 /* Tests_UserProfileService.swift in Sources */,
 				B87288E0299B05B500EF7E07 /* Tests_DataService.swift in Sources */,
 				B8AAAADB28CBDED800DBC8A9 /* Tests_Search.swift in Sources */,
 				B886A9B829A7E41700BFF9A2 /* Tests_MemoAddress.swift in Sources */,

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		B57D63C029B574C3008BBB62 /* CodeScanner in Frameworks */ = {isa = PBXBuildFile; productRef = B57D63BF29B574C3008BBB62 /* CodeScanner */; };
 		B584813F29AC32410033F434 /* AddressBookView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B584813E29AC32410033F434 /* AddressBookView.swift */; };
 		B584814229AC335B0033F434 /* AddressBookEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B584814129AC335B0033F434 /* AddressBookEntryView.swift */; };
+		B58862C829F612CE006C2EE4 /* EditProfileSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58862C729F612CE006C2EE4 /* EditProfileSheet.swift */; };
+		B58862C929F612CE006C2EE4 /* EditProfileSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58862C729F612CE006C2EE4 /* EditProfileSheet.swift */; };
 		B58A46AF29D3C62B00491E43 /* StoryEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58A46AE29D3C62B00491E43 /* StoryEntryView.swift */; };
 		B58A46B129D3C6B300491E43 /* StoryEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58A46B029D3C6B300491E43 /* StoryEntry.swift */; };
 		B58A46B329D3CE6100491E43 /* StoryUserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58A46B229D3CE6100491E43 /* StoryUserView.swift */; };
@@ -423,6 +425,7 @@
 		B57D63BC29B56699008BBB62 /* AddressBookModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookModel.swift; sourceTree = "<group>"; };
 		B584813E29AC32410033F434 /* AddressBookView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressBookView.swift; sourceTree = "<group>"; };
 		B584814129AC335B0033F434 /* AddressBookEntryView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressBookEntryView.swift; sourceTree = "<group>"; };
+		B58862C729F612CE006C2EE4 /* EditProfileSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileSheet.swift; sourceTree = "<group>"; };
 		B58A46AE29D3C62B00491E43 /* StoryEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryEntryView.swift; sourceTree = "<group>"; };
 		B58A46B029D3C6B300491E43 /* StoryEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryEntry.swift; sourceTree = "<group>"; };
 		B58A46B229D3CE6100491E43 /* StoryUserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryUserView.swift; sourceTree = "<group>"; };
@@ -762,6 +765,7 @@
 				B58C73A629DBB3B500B00EA1 /* UserProfileView.swift */,
 				B58A46B629D3D09500491E43 /* UserProfileHeaderView.swift */,
 				B5CFC7FD29E5403900178631 /* FollowUserSheet.swift */,
+				B58862C729F612CE006C2EE4 /* EditProfileSheet.swift */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
@@ -1591,6 +1595,7 @@
 				B57C0AE929D2782C00D352E3 /* PetnameBylineView.swift in Sources */,
 				B8A617202971D3000054D410 /* Slashlink.swift in Sources */,
 				B81EACD827B724A000B3B8DC /* ThickDividerView.swift in Sources */,
+				B58862C829F612CE006C2EE4 /* EditProfileSheet.swift in Sources */,
 				B8D7F04227A4AE590042C7CF /* SuggestionViewModifier.swift in Sources */,
 				B58A46AF29D3C62B00491E43 /* StoryEntryView.swift in Sources */,
 				B8E00A2D299294A0003B40C1 /* UserDefaultsProperty.swift in Sources */,
@@ -1805,6 +1810,7 @@
 				B8D328B829A671DA00850A37 /* Transclude2View.swift in Sources */,
 				B8CE40E828D2707D00819064 /* QueryPromptGeist.swift in Sources */,
 				B8B6BCB629CCDDF6000DB410 /* ResourceStatus.swift in Sources */,
+				B58862C929F612CE006C2EE4 /* EditProfileSheet.swift in Sources */,
 				B84AD8EB2811C863006B3153 /* URLComponentsUtilities.swift in Sources */,
 				B8B4251328FDE7780081B8D5 /* Mapping.swift in Sources */,
 				B8DA32B629CB999500EA166E /* AppUpgradeView.swift in Sources */,

--- a/xcode/Subconscious/SubconsciousTests/TestUtilities.swift
+++ b/xcode/Subconscious/SubconsciousTests/TestUtilities.swift
@@ -30,8 +30,9 @@ struct TestUtilities {
         var noosphere: NoosphereService
         var local: HeaderSubtextMemoStore
         var addressBook: AddressBookService
+        var userProfile: UserProfileService
     }
-
+    
     /// Set up and return a data service instance
     static func createDataServiceEnvironment(
         tmp: URL
@@ -79,12 +80,19 @@ struct TestUtilities {
             local: local,
             addressBook: addressBook
         )
+        
+        let userProfile = UserProfileService(
+            noosphere: noosphere,
+            database: database,
+            addressBook: addressBook
+        )
 
         return DataServiceEnvironment(
             data: data,
             noosphere: noosphere,
             local: local,
-            addressBook: addressBook
+            addressBook: addressBook,
+            userProfile: userProfile
         )
     }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_FormField.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_FormField.swift
@@ -19,7 +19,7 @@ class Tests_FormField: XCTestCase {
         return nil
     }
     
-    let environment = FormFieldEnvironment()
+    let environment: () = FormFieldEnvironment()
     
     func testDetectsFirstFocus() throws {
         let state = FormField(value: "", validate: Self.validateStringIsHello)

--- a/xcode/Subconscious/SubconsciousTests/Tests_UserProfileService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_UserProfileService.swift
@@ -13,6 +13,8 @@ final class Tests_UserProfileService: XCTestCase {
         let tmp = try TestUtilities.createTmpDir()
         let data = try await TestUtilities.createDataServiceEnvironment(tmp: tmp)
         
+        AppDefaults.standard.nickname = "test"
+        
         let memoA = Memo(
             contentType: ContentType.subtext.rawValue,
             created: Date.now,

--- a/xcode/Subconscious/SubconsciousTests/Tests_UserProfileService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_UserProfileService.swift
@@ -1,0 +1,55 @@
+//
+//  Tests_UserProfileService.swift
+//  SubconsciousTests
+//
+//  Created by Ben Follington on 26/4/2023.
+//
+
+import XCTest
+@testable import Subconscious
+
+final class Tests_UserProfileService: XCTestCase {
+    func testCanRequestOwnProfile() async throws {
+        let tmp = try TestUtilities.createTmpDir()
+        let data = try await TestUtilities.createDataServiceEnvironment(tmp: tmp)
+        
+        let memoA = Memo(
+            contentType: ContentType.subtext.rawValue,
+            created: Date.now,
+            modified: Date.now,
+            fileExtension: ContentType.subtext.fileExtension,
+            additionalHeaders: [],
+            body: "More content"
+        )
+        
+        let addressA = Slashlink(slug: Slug("hello")!).toPublicMemoAddress()
+        try await data.data.writeMemo(address: addressA, memo: memoA)
+        
+        let memoC = Memo(
+            contentType: ContentType.subtext.rawValue,
+            created: Date.now,
+            modified: Date.now,
+            fileExtension: ContentType.subtext.fileExtension,
+            additionalHeaders: [],
+            body: "Even more content"
+        )
+        
+        let addressC = Slashlink.ourProfile.toPublicMemoAddress()
+        try await data.data.writeMemo(address: addressC, memo: memoC)
+        
+        try await data.userProfile.writeOurProfile(
+            profile: UserProfileEntry(
+                nickname: "alice",
+                bio: nil,
+                profilePictureUrl: nil
+            )
+        )
+        
+        let profile = try await data.userProfile.requestOurProfile()
+        
+        XCTAssertEqual(profile.profile.nickname, Petname("alice")!)
+        XCTAssertEqual(profile.entries.count, 1)
+        // No hidden entries on profile
+        XCTAssertFalse(profile.entries.contains(where: { entry in entry.address.slug.isHidden }))
+    }
+}


### PR DESCRIPTION
Resolves #480, #527, #526, #524

# Demo

https://user-images.githubusercontent.com/5009316/234460823-edd806f3-2373-42a5-8c45-98d3d930593e.mov

- [x] hide _ prefixed notes when listing contents
- [x] clean up version number storage
- [x] update mimetype to `application/vnd.subconscious.profile+json`