### PR TITLE
Fix redundant unwrap

### DIFF
--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailMetaSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailMetaSheet.swift
@@ -35,9 +35,10 @@ struct UserProfileDetailMetaSheet: View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
                 VStack(alignment: .leading, spacing: AppTheme.unit2) {
-                    if let user = profile.user,
-                       let slashlink = user.address.toSlashlink() {
-                        SlashlinkBylineView(slashlink: slashlink).theme(
+                    if let user = profile.user {
+                        SlashlinkBylineView(
+                            slashlink: user.address.toSlashlink()
+                        ).theme(
                             petname: Color.primary,
                             slug: Color.secondary
                         )


### PR DESCRIPTION
`MemoAddress.toSlashlink()` is no longer an optional return value since https://github.com/subconsciousnetwork/subconscious/commit/db855e99657fbfbcaca3e04dd8b413d6694e52d2#diff-00211e56380835626ac7bd8af84a29b28e53c12b1d0298acef9588b2a942b83fR74.