### PR TITLE
Use Config.noosphere.ownerKeyName constant

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -120,7 +120,7 @@ enum AppAction: CustomLogStringConvertible {
     case succeedResetGatewayURL(_ url: URL)
 
     /// Create a new sphere given an owner key name
-    case createSphere(_ ownerKeyName: String?)
+    case createSphere
     case succeedCreateSphere(SphereReceipt)
     case failCreateSphere(_ message: String)
 
@@ -448,11 +448,10 @@ struct AppModel: ModelProtocol {
                 environment: environment,
                 url: url
             )
-        case let .createSphere(ownerKeyName):
+        case .createSphere:
             return createSphere(
                 state: state,
-                environment: environment,
-                ownerKeyName: ownerKeyName
+                environment: environment
             )
         case let .succeedCreateSphere(receipt):
             return succeedCreateSphere(
@@ -775,10 +774,11 @@ struct AppModel: ModelProtocol {
 
     static func createSphere(
         state: AppModel,
-        environment: AppEnvironment,
-        ownerKeyName: String?
+        environment: AppEnvironment
     ) -> Update<AppModel> {
-        let ownerKeyName = ownerKeyName ?? Config.default.noosphere.ownerKeyName
+        // We always use the default owner key name for the user's default
+        // sphere.
+        let ownerKeyName = Config.default.noosphere.ownerKeyName
 
         let fx: Fx<AppAction> = Future.detached {
             let receipt = try await environment.data.createSphere(

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
@@ -41,7 +41,7 @@ struct FirstRunProfileView: View {
                 )
                 .buttonStyle(PillButtonStyle())
                 .simultaneousGesture(TapGesture().onEnded {
-                    app.send(.createSphere(app.state.nickname))
+                    app.send(.createSphere)
                 })
                 .disabled(!app.state.isNicknameTextFieldValid)
             }

--- a/xcode/Subconscious/Shared/Config.swift
+++ b/xcode/Subconscious/Shared/Config.swift
@@ -56,7 +56,7 @@ struct NoosphereConfig: Equatable, Codable {
     /// NOTE: In future, we might support multiple spheres. If so, this
     /// flag will be deprecated in favor of multiple spheres
     var sphereStoragePath = "sphere"
-    /// Default owner key name for spheres on this device
-    var ownerKeyName = "User"
+    /// Owner key name for key that owns default sphere on this device.
+    var ownerKeyName = "Subconscious"
     var defaultGatewayURL = "http://127.0.0.1:4433"
 }

--- a/xcode/Subconscious/Shared/Services/AppDefaults.swift
+++ b/xcode/Subconscious/Shared/Services/AppDefaults.swift
@@ -15,9 +15,6 @@ struct AppDefaults {
     @UserDefaultsProperty(forKey: "isNoosphereEnabled")
     var isNoosphereEnabled = false
 
-    @UserDefaultsProperty(forKey: "ownerKeyName")
-    var ownerKeyName: String? = nil
-    
     /// The user/sphere nickname.
     @UserDefaultsProperty(forKey: "nickname")
     var nickname: String? = nil

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -78,7 +78,6 @@ actor DataService {
         // Instead, we return the receipt so that mnemonic can be displayed
         // and discarded.
         AppDefaults.standard.sphereIdentity = sphereReceipt.identity
-        AppDefaults.standard.ownerKeyName = ownerKeyName
         // Set sphere identity on NoosphereService
         await noosphere.resetSphere(sphereReceipt.identity)
         return sphereReceipt

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -25,7 +25,6 @@ struct DatabaseMigrationInfo: Hashable {
 enum DatabaseMetaKeys: String {
     case sphereIdentity = "sphere_identity"
     case sphereVersion = "sphere_version"
-    case ownerKeyName = "owner_key_name"
 }
 
 enum DatabaseServiceError: Error, LocalizedError {


### PR DESCRIPTION
...instead of user-provided nickname, when designating an owner key name. This value is not network-facing, and just needs to be something constistent across runs. Hard-coding avoids user input errors for value, and also avoids having to track changes to owner key name.

Fixes #540.