### PR TITLE
Fix Omnibox icon for various states

### DIFF
--- a/xcode/Subconscious/Shared/AppIcon.swift
+++ b/xcode/Subconscious/Shared/AppIcon.swift
@@ -18,7 +18,7 @@ extension AppIcon {
     var systemName: String {
         switch (self) {
         case .you:
-            return "face.smiling"
+            return "face.smiling.inverse"
         case .following:
             return "person.fill.checkmark"
         case .edit:

--- a/xcode/Subconscious/Shared/AppIcon.swift
+++ b/xcode/Subconscious/Shared/AppIcon.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 enum AppIcon {
-    case you
+    case you(ColorScheme)
     case following
     case edit
     case user
@@ -17,8 +17,8 @@ enum AppIcon {
 extension AppIcon {
     var systemName: String {
         switch (self) {
-        case .you:
-            return "face.smiling.inverse"
+        case .you(let colorScheme):
+            return colorScheme == .light ? "face.smiling" : "face.smiling.inverse"
         case .following:
             return "person.fill.checkmark"
         case .edit:

--- a/xcode/Subconscious/Shared/AppIcon.swift
+++ b/xcode/Subconscious/Shared/AppIcon.swift
@@ -18,7 +18,7 @@ extension AppIcon {
     var systemName: String {
         switch (self) {
         case .you:
-            return "face.smiling.inverse"
+            return "face.smiling"
         case .following:
             return "person.fill.checkmark"
         case .edit:

--- a/xcode/Subconscious/Shared/Components/Common/Byline/PetnameBylineView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Byline/PetnameBylineView.swift
@@ -19,11 +19,9 @@ struct PetnameBylineView: View {
             let first = parts[0]
             
             Text(first.markup)
-                .foregroundColor(petnameColor)
-                // Fixed size to ensure truncation trims path preferentially 
+                // Fixed size to ensure truncation trims path preferentially
                 .fixedSize(horizontal: true, vertical: false)
                 .font(.callout)
-                .fontWeight(.medium)
                 .lineLimit(1)
             
             let rest = parts[1...]
@@ -33,12 +31,12 @@ struct PetnameBylineView: View {
             if rest.count > 0 {
                 // Particular structure to ensure truncation trims the path and never the name
                 Text(".\(rest)")
-                    .foregroundColor(.secondary)
                     .font(.callout)
-                    .fontWeight(.regular)
                     .lineLimit(1)
             }
         }
+        .fontWeight(.medium)
+        .foregroundColor(petnameColor)
     }
     
     func theme(

--- a/xcode/Subconscious/Shared/Components/Common/Byline/SlashlinkBylineView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Byline/SlashlinkBylineView.swift
@@ -17,6 +17,7 @@ struct SlashlinkBylineView: View {
         HStack(spacing: 0) {
             if let petname = slashlink.petname {
                 PetnameBylineView(petname: petname)
+                    .theme(petname: petnameColor)
             }
             Text(verbatim: slashlink.slug.verbatimMarkup)
                 .foregroundColor(slugColor)

--- a/xcode/Subconscious/Shared/Components/Common/Byline/SlashlinkBylineView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Byline/SlashlinkBylineView.swift
@@ -17,7 +17,6 @@ struct SlashlinkBylineView: View {
         HStack(spacing: 0) {
             if let petname = slashlink.petname {
                 PetnameBylineView(petname: petname)
-                    .theme(petname: petnameColor)
             }
             Text(verbatim: slashlink.slug.verbatimMarkup)
                 .foregroundColor(slugColor)

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 /// Show a user card in a feed format
 struct StoryUserView: View {
+    @Environment(\.colorScheme) var colorScheme
+    
     var story: StoryUser
     var action: (MemoAddress, String) -> Void
     
@@ -42,7 +44,7 @@ struct StoryUserView: View {
                         Image.from(appIcon: .following)
                             .foregroundColor(.secondary)
                     case (_, .you):
-                        Image.from(appIcon: .you)
+                        Image.from(appIcon: .you(colorScheme))
                             .foregroundColor(.secondary)
                     case (_, _):
                         EmptyView()

--- a/xcode/Subconscious/Shared/Components/OmniboxView.swift
+++ b/xcode/Subconscious/Shared/Components/OmniboxView.swift
@@ -12,14 +12,19 @@ struct OmniboxView: View {
     var defaultAudience: Audience
 
     private func icon() -> Image {
-        if let address = address {
-            return address.isOurProfile
-            ? Image.from(appIcon: .you)
-            : Image.from(appIcon: .user)
+        guard let address = address else {
+            return Image(audience: defaultAudience)
         }
-        
-        let audience = address?.toAudience() ?? defaultAudience
-        return Image(audience: audience)
+        if address.isOurProfile {
+            return Image.from(appIcon: .you)
+        }
+        if address.isProfile {
+            return Image.from(appIcon: .user)
+        }
+        if address.isPublic() {
+            return Image(audience: .public)
+        }
+        return Image(audience: .local)
     }
     
     var body: some View {

--- a/xcode/Subconscious/Shared/Components/OmniboxView.swift
+++ b/xcode/Subconscious/Shared/Components/OmniboxView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct OmniboxView: View {
+    @Environment(\.colorScheme) var colorScheme
+    
     var address: MemoAddress?
     var defaultAudience: Audience
 
@@ -16,7 +18,7 @@ struct OmniboxView: View {
             return Image(audience: defaultAudience)
         }
         if address.isOurProfile {
-            return Image.from(appIcon: .you)
+            return Image.from(appIcon: .you(colorScheme))
         }
         if address.isProfile {
             return Image.from(appIcon: .user)


### PR DESCRIPTION
Fixes #541.

Also simplifying display style of location in bar. My sense is that petname parts should all have the same weight/color treatment, since they make up the "trust domain". This mirrors similar UI in browsers:

<img width="522" alt="Screenshot 2023-04-25 at 3 33 08 PM" src="https://user-images.githubusercontent.com/58421/234383539-ac978cf8-c321-4d53-8b1e-6e2727490fae.png">
