### PR TITLE
Use only the first line to generate entry title

### DIFF
--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -481,8 +481,10 @@ actor DataService {
         _ text: String,
         audience: Audience
     ) async -> MemoAddress? {
+        let excerpt = Subtext.excerpt(markup: text, fallback: text)
+        
         // If we can't derive slug from text, exit early.
-        guard let slug = Slug(formatting: text) else {
+        guard let slug = Slug(formatting: excerpt) else {
             return nil
         }
         // If slug does not exist in any address space, return it.


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/553

This does not address the capitalisation of the slug, I'm not sure where we landed on that?

If the first line starts with a capital this will generate a slug with a capital letter but it seems like leaving and reloading the note causes it to become lowercase?