### PR TITLE
Sort recent entries on profile by recency

### DIFF
--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -288,8 +288,8 @@ struct UserProfileDetailModel: ModelProtocol {
             var model = state
             model.user = content.profile
             model.statistics = content.statistics
-            model.recentEntries = content.entries
-            model.topEntries = content.entries
+            model.recentEntries = content.recentEntries
+            model.topEntries = content.topEntries
             model.following = content.following
             model.isFollowingUser = content.isFollowingUser
             model.loadingState = .loaded

--- a/xcode/Subconscious/SubconsciousTests/Tests_UserProfileService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_UserProfileService.swift
@@ -52,9 +52,9 @@ final class Tests_UserProfileService: XCTestCase {
         let profile = try await data.userProfile.requestOurProfile()
         
         XCTAssertEqual(profile.profile.nickname, Petname("alice")!)
-        XCTAssertEqual(profile.entries.count, 1)
+        XCTAssertEqual(profile.recentEntries.count, 1)
         // No hidden entries on profile
-        XCTAssertFalse(profile.entries.contains(where: { entry in entry.address.slug.isHidden }))
+        XCTAssertFalse(profile.recentEntries.contains(where: { entry in entry.address.slug.isHidden }))
         
         XCTAssertEqual(profile.following.count, 1)
         if let petname = profile.following.first?.user.address.petname {


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/565

The entries were not sorted at all before. We still do not have an implementation for top entries, but we can probably build it after #323 lands.