### PR TITLE
Provision Gateway during onboarding

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -865,8 +865,6 @@ struct AppModel: ModelProtocol {
         environment: AppEnvironment,
         text: String
     ) -> Update<AppModel> {
-        /// First pass down setValue to form field,
-        /// then persist the nickname by reading the updated model.
         return update(
             state: state,
             actions: [

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -718,14 +718,22 @@ struct AppModel: ModelProtocol {
                 }
                 .eraseToAnyPublisher()
             
-            return Update(state: state, fx: fx)
+            var model = state
+            model.gatewayProvisioningStatus = .pending
+            
+            return Update(state: model, fx: fx)
+            
         case .succeedProvisionGateway(let url):
             var model = state
             model.gatewayURL = url
+            model.gatewayProvisioningStatus = .succeeded
             return Update(state: model)
+            
         case .failProvisionGateway(let error):
             logger.error("Failed to provision gateway: \(error)")
-            return Update(state: state)
+            var model = state
+            model.gatewayProvisioningStatus = .failed(error)
+            return Update(state: model)
         }
     }
 

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -1513,9 +1513,16 @@ struct AppModel: ModelProtocol {
         url: URL
     ) -> Update<AppModel> {
         var model = state
-        model.gatewayURL = url.absoluteString
         model.gatewayProvisioningStatus = .succeeded
-        return Update(state: model)
+        
+        return update(
+            state: model,
+            actions: [
+                .submitGatewayURL(url.absoluteString),
+                .syncSphereWithGateway
+            ],
+            environment: environment
+        )
     }
     
     static func failProvisionGateway(

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -1383,6 +1383,8 @@ struct AppEnvironment {
     var addressBook: AddressBookService
     var userProfile: UserProfileService
     
+    var gatewayProvisioningService: GatewayProvisioningService
+    
     var pasteboard = UIPasteboard.general
     
     /// Create a long polling publisher that never completes
@@ -1461,6 +1463,7 @@ struct AppEnvironment {
         )
         
         self.feed = FeedService()
+        self.gatewayProvisioningService = GatewayProvisioningService()
     }
 }
 

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -1489,8 +1489,7 @@ struct AppModel: ModelProtocol {
         
         let fx: Fx<AppAction> = environment.gatewayProvisioningService
             .waitForGatewayProvisioningPublisher(
-                gatewayId: gatewayId,
-                maxAttempts: 20 // 210 seconds with linear backoff
+                gatewayId: gatewayId
             )
             .map { url in
                 guard let url = url else {

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -700,7 +700,7 @@ struct AppModel: ModelProtocol {
             return Update(state: state)
             
         case .requestProvisionGateway:
-            return provisionGateway(
+            return requestProvisionGateway(
                 state: state,
                 environment: environment
             )
@@ -1449,7 +1449,7 @@ struct AppModel: ModelProtocol {
         return Update(state: state, fx: fx)
     }
     
-    static func provisionGateway(
+    static func requestProvisionGateway(
         state: AppModel,
         environment: AppEnvironment
     ) -> Update<AppModel> {

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -1490,7 +1490,7 @@ struct AppModel: ModelProtocol {
         let fx: Fx<AppAction> = environment.gatewayProvisioningService
             .waitForGatewayProvisioningPublisher(
                 gatewayId: gatewayId,
-                maxAttempts: 5
+                maxAttempts: 20 // 210 seconds with linear backoff
             )
             .map { url in
                 guard let url = url else {

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -30,7 +30,7 @@ struct AppView: View {
                 }
             }
             .zIndex(0)
-            if (!store.state.isAppUpgraded) {
+            if !store.state.isAppUpgraded {
                 AppUpgradeView(
                     state: store.state.appUpgrade,
                     send: Address.forward(
@@ -43,7 +43,7 @@ struct AppView: View {
                 )
                 .zIndex(2)
             }
-            if (store.state.shouldPresentFirstRun) {
+            if store.state.shouldPresentFirstRun {
                 FirstRunView(app: store)
                     .animation(
                         .default,
@@ -81,7 +81,7 @@ struct AppView: View {
 typealias InviteCodeFormField = FormField<String, InviteCode>
 typealias NicknameFormField = FormField<String, Petname>
 
-//  MARK: Action
+// MARK: Action
 enum AppAction: CustomLogStringConvertible {
     /// Sent immediately upon store creation
     case start
@@ -221,7 +221,7 @@ enum AppAction: CustomLogStringConvertible {
     }
 }
 
-//  MARK: Cursors
+// MARK: Cursors
 
 struct AppRecoveryPhraseCursor: CursorProtocol {
     static func get(state: AppModel) -> RecoveryPhraseModel {
@@ -318,7 +318,7 @@ enum AppDatabaseState {
     case ready
 }
 
-//  MARK: Model
+// MARK: Model
 struct AppModel: ModelProtocol {
     /// Is Noosphere enabled?
     ///
@@ -434,7 +434,7 @@ struct AppModel: ModelProtocol {
         category: "app"
     )
     
-    //  MARK: Update
+    // MARK: Update
     /// Main update function
     static func update(
         state: AppModel,
@@ -757,7 +757,7 @@ struct AppModel: ModelProtocol {
                 ),
                 .setNickname(
                     AppDefaults.standard.nickname ?? state.nickname
-                ),
+                )
             ],
             environment: environment
         ).mergeFx(fx)
@@ -863,7 +863,7 @@ struct AppModel: ModelProtocol {
         return update(
             state: state,
             actions: [
-                .inviteCodeFormField(.setValue(input: text)),
+                .inviteCodeFormField(.setValue(input: text))
             ],
             environment: environment
         )
@@ -1495,7 +1495,7 @@ struct AppModel: ModelProtocol {
     }
 }
 
-//  MARK: Environment
+// MARK: Environment
 /// A place for constants and services
 struct AppEnvironment {
     /// Default environment constant

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
@@ -34,7 +34,7 @@ struct FirstRunView: View {
                         send: app.send,
                         tag: AppAction.setInviteCode
                     ),
-                    caption: "Don't have a code? Join the waitlist",
+                    caption: "Look for this in your welcome email.",
                     hasError: app.state.inviteCodeFormField.hasError
                 )
                 .textFieldStyle(.roundedBorder)
@@ -55,6 +55,26 @@ struct FirstRunView: View {
                 )
                 .buttonStyle(PillButtonStyle())
                 .disabled(!app.state.inviteCodeFormField.isValid)
+                    
+                // MARK: Use Offline
+                VStack(spacing: AppTheme.unit) {
+                    Text("No invite code?")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    
+                    NavigationLink(
+                        destination: {
+                            FirstRunProfileView(
+                                app: app
+                            )
+                        },
+                        label: {
+                            
+                            Text("Use offline")
+                                .font(.caption)
+                        }
+                    )
+                }
             }
             .navigationTitle("Welcome")
             .navigationBarTitleDisplayMode(.inline)

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
@@ -12,20 +12,37 @@ struct FirstRunView: View {
 
     var body: some View {
         NavigationStack {
-            VStack {
+            VStack(spacing: AppTheme.padding * 2) {
                 Spacer()
                 Image("sub_logo")
                     .resizable()
                     .frame(width: 128, height: 128)
-                Spacer()
                 VStack(alignment: .leading, spacing: AppTheme.unit3) {
+                    Text("Welcome to the Subconscious Beta.")
+                    
                     Text("Subconscious is a place to garden thoughts and share with others.")
                     
                     Text("It's powered by a decentralized note graph, so your data belongs to you.")
                 }
                 .foregroundColor(.secondary)
                 .font(.callout)
+                
+                ValidatedTextField(
+                    placeholder: "Enter your invite code",
+                    text: Binding(
+                        get: { app.state.inviteCodeFormField.value },
+                        send: app.send,
+                        tag: AppAction.setInviteCode
+                    ),
+                    caption: "Don't have a code? Join the waitlist",
+                    hasError: app.state.inviteCodeFormField.hasError
+                )
+                .textFieldStyle(.roundedBorder)
+                .textInputAutocapitalization(.never)
+                .disableAutocorrection(true)
+                
                 Spacer()
+                
                 NavigationLink(
                     destination: {
                         FirstRunProfileView(
@@ -37,6 +54,7 @@ struct FirstRunView: View {
                     }
                 )
                 .buttonStyle(PillButtonStyle())
+                .disabled(!app.state.inviteCodeFormField.isValid)
             }
             .navigationTitle("Welcome")
             .navigationBarTitleDisplayMode(.inline)

--- a/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
@@ -8,6 +8,64 @@
 import SwiftUI
 import ObservableStore
 
+struct GatewayProvisionLabel: View {
+    var status: ResourceStatus
+    @State var spin = false
+    
+    func label(status: ResourceStatus) -> String {
+        switch status {
+        case .initial:
+            return "Provision Gateway"
+        case .pending:
+            return "Provisioning..."
+        case .failed:
+            return "Provisioning Failed"
+        case .succeeded:
+            return "Gateway Created"
+        }
+    }
+    
+    private func labelColor(status: ResourceStatus) -> Color {
+        switch status {
+        case .failed:
+            return .red
+        default:
+            return .accentColor
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Label(title: {
+                Text(label(status: status))
+                    .foregroundColor(labelColor(status: status))
+            }, icon: {
+                switch (status) {
+                case .initial:
+                    Image(systemName: "icloud.and.arrow.up")
+                        .foregroundColor(.secondary)
+                case .pending:
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .foregroundColor(.accentColor)
+                        .rotationEffect(.degrees(spin ? 360 : 0))
+                        .animation(Animation.linear
+                            .repeatForever(autoreverses: false)
+                            .speed(0.4), value: spin)
+                        .onAppear() {
+                            self.spin = true
+                        }
+                case .succeeded:
+                    Image(systemName: "checkmark.icloud")
+                        .foregroundColor(.secondary)
+                case .failed:
+                    Image(systemName: "exclamationmark.icloud")
+                        .foregroundColor(.red)
+                }
+            })
+        }
+    }
+}
+
 struct GatewayURLSettingsView: View {
     @ObservedObject var app: Store<AppModel>
 
@@ -55,13 +113,8 @@ struct GatewayURLSettingsView: View {
                             app.send(.provisionGateway)
                         },
                         label: {
-                            Label(
-                                title: {
-                                    Text("Provision Gateway")
-                                },
-                                icon: {
-                                    Image(systemName: "icloud.and.arrow.up")
-                                }
+                            GatewayProvisionLabel(
+                                status: app.state.gatewayProvisioningStatus
                             )
                         }
                     )

--- a/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
@@ -120,7 +120,7 @@ struct GatewayURLSettingsView: View {
                     )
                     .disabled(
                         !app.state.inviteCodeFormField.isValid
-                        || app.state.lastGatewaySyncStatus == .pending
+                        || app.state.gatewayProvisioningStatus == .pending
                     )
                 },
                 header: {

--- a/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
@@ -119,8 +119,8 @@ struct GatewayURLSettingsView: View {
                         }
                     )
                     .disabled(
-                        !app.state.inviteCodeFormField.isValid
-                        || app.state.gatewayProvisioningStatus == .pending
+                        !app.state.inviteCodeFormField.isValid ||
+                        app.state.gatewayProvisioningStatus == .pending
                     )
                 },
                 header: {

--- a/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
@@ -40,7 +40,7 @@ struct GatewayProvisionLabel: View {
                 Text(label(status: status))
                     .foregroundColor(labelColor(status: status))
             }, icon: {
-                switch (status) {
+                switch status {
                 case .initial:
                     Image(systemName: "icloud.and.arrow.up")
                         .foregroundColor(.secondary)
@@ -127,7 +127,7 @@ struct GatewayURLSettingsView: View {
                     Text("Provision Gateway")
                 },
                 footer: {
-                    switch (app.state.gatewayProvisioningStatus) {
+                    switch app.state.gatewayProvisioningStatus {
                     case let .failed(message):
                         Text(message)
                     default:

--- a/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
@@ -110,7 +110,7 @@ struct GatewayURLSettingsView: View {
                     
                     Button(
                         action: {
-                            app.send(.provisionGateway)
+                            app.send(.requestProvisionGateway)
                         },
                         label: {
                             GatewayProvisionLabel(

--- a/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
@@ -30,6 +30,58 @@ struct GatewayURLSettingsView: View {
             .onDisappear {
                 app.send(.submitGatewayURL(app.state.gatewayURLTextField))
             }
+            
+            Section(
+                content: {
+                    ValidatedTextField(
+                        placeholder: "Enter your invite code",
+                        text: Binding(
+                            get: { app.state.inviteCodeFormField.value },
+                            send: app.send,
+                            tag: AppAction.setInviteCode
+                        ),
+                        caption: "Look for this in your welcome email.",
+                        hasError: app.state.inviteCodeFormField.hasError
+                    )
+                    .formField()
+                    .autocapitalization(.none)
+                    .autocorrectionDisabled(true)
+                    .onDisappear {
+                        app.send(.setInviteCode(app.state.inviteCodeFormField.value))
+                    }
+                    
+                    Button(
+                        action: {
+                            app.send(.provisionGateway)
+                        },
+                        label: {
+                            Label(
+                                title: {
+                                    Text("Provision Gateway")
+                                },
+                                icon: {
+                                    Image(systemName: "icloud.and.arrow.up")
+                                }
+                            )
+                        }
+                    )
+                    .disabled(
+                        !app.state.inviteCodeFormField.isValid
+                        || app.state.lastGatewaySyncStatus == .pending
+                    )
+                },
+                header: {
+                    Text("Provision Gateway")
+                },
+                footer: {
+                    switch (app.state.gatewayProvisioningStatus) {
+                    case let .failed(message):
+                        Text(message)
+                    default:
+                        EmptyView()
+                    }
+                }
+            )
         }
         .navigationTitle("Gateway URL")
     }

--- a/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
@@ -82,18 +82,20 @@ struct SettingsView: View {
                             label: {
                                 LabeledContent(
                                     "Nickname",
-                                    value: app.state.nickname ?? ""
+                                    value: app.state.nickname
                                 )
                                 .lineLimit(1)
                                 .textSelection(.enabled)
                             }
                         )
+                        
                         LabeledContent(
                             "Sphere",
                             value: app.state.sphereIdentity ?? unknown
                         )
                         .lineLimit(1)
                         .textSelection(.enabled)
+                        
                         LabeledContent(
                             "Version",
                             value: app.state.sphereVersion ?? unknown
@@ -115,6 +117,7 @@ struct SettingsView: View {
                                     .lineLimit(1)
                                 }
                             )
+                            
                             Button(
                                 action: {
                                     app.send(.syncSphereWithGateway)

--- a/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
@@ -40,7 +40,7 @@ struct GatewaySyncLabel: View {
                 Text(label(status: status))
                     .foregroundColor(labelColor(status: status))
             }, icon: {
-                switch (status) {
+                switch status {
                 case .initial:
                     Image(systemName: "arrow.triangle.2.circlepath")
                         .foregroundColor(.secondary)
@@ -132,7 +132,7 @@ struct SettingsView: View {
                         }, header: {
                             Text("Gateway")
                         }, footer: {
-                            switch (app.state.lastGatewaySyncStatus) {
+                            switch app.state.lastGatewaySyncStatus {
                             case let .failed(message):
                                 Text(message)
                             default:

--- a/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
@@ -35,42 +35,33 @@ struct GatewaySyncLabel: View {
     }
 
     var body: some View {
-        HStack {
-            VStack(alignment: .leading) {
+        VStack(alignment: .leading) {
+            Label(title: {
                 Text(label(status: status))
                     .foregroundColor(labelColor(status: status))
-                
-                if case .failed(let message) = status {
-                    Text("\(message)")
-                        .font(.caption2)
+            }, icon: {
+                switch (status) {
+                case .initial:
+                    Image(systemName: "arrow.triangle.2.circlepath")
                         .foregroundColor(.secondary)
+                case .pending:
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .foregroundColor(.accentColor)
+                        .rotationEffect(.degrees(spin ? 360 : 0))
+                        .animation(Animation.linear
+                            .repeatForever(autoreverses: false)
+                            .speed(0.4), value: spin)
+                        .onAppear() {
+                            self.spin = true
+                        }
+                case .succeeded:
+                    Image(systemName: "checkmark.circle")
+                        .foregroundColor(.secondary)
+                case .failed:
+                    Image(systemName: "exclamationmark.arrow.triangle.2.circlepath")
+                        .foregroundColor(.red)
                 }
-            }
-            
-            Spacer()
-            
-            switch (status) {
-            case .initial:
-                Image(systemName: "arrow.triangle.2.circlepath")
-                    .foregroundColor(.secondary)
-            case .pending:
-                Image(systemName: "arrow.triangle.2.circlepath")
-                    .foregroundColor(.accentColor)
-                    .rotationEffect(.degrees(spin ? 360 : 0))
-                    .animation(Animation.linear
-                        .repeatForever(autoreverses: false)
-                        .speed(0.4), value: spin)
-                    .onAppear() {
-                        self.spin = true
-                    }
-            case .succeeded:
-                Image(systemName: "checkmark.circle")
-                    .foregroundColor(.secondary)
-            case .failed:
-                Image(systemName: "exclamationmark.arrow.triangle.2.circlepath")
-                    .foregroundColor(.red)
-            }
-            
+            })
         }
     }
 }
@@ -110,31 +101,42 @@ struct SettingsView: View {
                         .lineLimit(1)
                         .textSelection(.enabled)
                     }
-
-                    Section(header: Text("Gateway")) {
-                        NavigationLink(
-                            destination: {
-                                GatewayURLSettingsView(app: app)
-                            },
-                            label: {
-                                LabeledContent(
-                                    "Gateway",
-                                    value: app.state.gatewayURL
-                                )
-                                .lineLimit(1)
+                    Section(
+                        content: {
+                            NavigationLink(
+                                destination: {
+                                    GatewayURLSettingsView(app: app)
+                                },
+                                label: {
+                                    LabeledContent(
+                                        "Gateway",
+                                        value: app.state.gatewayURL
+                                    )
+                                    .lineLimit(1)
+                                }
+                            )
+                            Button(
+                                action: {
+                                    app.send(.syncSphereWithGateway)
+                                },
+                                label: {
+                                    GatewaySyncLabel(
+                                        status: app.state.lastGatewaySyncStatus
+                                    )
+                                }
+                            )
+                            .disabled(app.state.gatewayURL.count == 0)
+                        }, header: {
+                            Text("Gateway")
+                        }, footer: {
+                            switch (app.state.lastGatewaySyncStatus) {
+                            case let .failed(message):
+                                Text(message)
+                            default:
+                                EmptyView()
                             }
-                        )
-                        Button(
-                            action: {
-                                app.send(.syncSphereWithGateway)
-                            },
-                            label: {
-                                GatewaySyncLabel(
-                                    status: app.state.lastGatewaySyncStatus
-                                )
-                            }
-                        )
-                    }
+                        }
+                    )
                 }
                 Section {
                     NavigationLink("Developer Settings") {

--- a/xcode/Subconscious/Shared/Config.swift
+++ b/xcode/Subconscious/Shared/Config.swift
@@ -17,9 +17,7 @@ struct Config: Equatable, Codable {
     var appTabs = false
     var addByQRCode = true
     var userProfile: Bool {
-        get {
-            AppDefaults.standard.isNoosphereEnabled
-        }
+        AppDefaults.standard.isNoosphereEnabled
     }
     
     #if targetEnvironment(simulator)
@@ -33,11 +31,9 @@ struct Config: Equatable, Codable {
     /// What value should the DID QR code scanner return in the simulator?
     /// Only returns test data when Config.debug is enabled
     var fallbackSimulatorQrCodeScanResult: String {
-        get {
-            Self.isSimulator
-                ? "did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7"
-                : ""
-        }
+        Self.isSimulator
+            ? "did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7"
+            : ""
     }
     var subconsciousGeistDid: Did = Did("did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!
     var subconsciousGeistPetname: Petname = Petname("subconscious")!

--- a/xcode/Subconscious/Shared/Config.swift
+++ b/xcode/Subconscious/Shared/Config.swift
@@ -41,6 +41,8 @@ struct Config: Equatable, Codable {
     }
     var subconsciousGeistDid: Did = Did("did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!
     var subconsciousGeistPetname: Petname = Petname("subconscious")!
+    
+    var cloudCtlUrl: URL = URL(string: "https://cloudctl.sphere.test.subconscious.cloud")!
 
     /// Standard interval at which to run long-polling services
     var pollingInterval: Double = 15

--- a/xcode/Subconscious/Shared/Models/InviteCode.swift
+++ b/xcode/Subconscious/Shared/Models/InviteCode.swift
@@ -12,31 +12,14 @@ public struct InviteCode:
     Hashable,
     Equatable,
     Identifiable,
-    Comparable,
     Codable,
-    LosslessStringConvertible
-{
+    LosslessStringConvertible {
+    
     private static let inviteCodeRegex = /^\w+\s\w+\s\w+\s\w+$/
-    
-    public static func < (lhs: Self, rhs: Self) -> Bool {
-        lhs.id < rhs.id
-    }
-    
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.id == rhs.id
-    }
 
     public let description: String
     public let verbatim: String
     public var id: String { description }
-    
-    public var markup: String {
-        "@\(self.description)"
-    }
-    
-    public var verbatimMarkup: String {
-        "@\(self.verbatim)"
-    }
 
     public init?(_ description: String) {
         guard description.wholeMatch(of: Self.inviteCodeRegex) != nil else {

--- a/xcode/Subconscious/Shared/Models/InviteCode.swift
+++ b/xcode/Subconscious/Shared/Models/InviteCode.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-/// A type representing a valid petname (`@petname`)
+/// A type representing a valid invite code (`four words like this`)
 public struct InviteCode:
     Hashable,
     Equatable,

--- a/xcode/Subconscious/Shared/Models/InviteCode.swift
+++ b/xcode/Subconscious/Shared/Models/InviteCode.swift
@@ -1,0 +1,48 @@
+//
+//  InviteCode.swift
+//  Subconscious (iOS)
+//
+//  Created by Ben Follington on 3/5/2023.
+//
+
+import Foundation
+
+/// A type representing a valid petname (`@petname`)
+public struct InviteCode:
+    Hashable,
+    Equatable,
+    Identifiable,
+    Comparable,
+    Codable,
+    LosslessStringConvertible
+{
+    private static let inviteCodeRegex = /^\w+\s\w+\s\w+\s\w+$/
+    
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.id < rhs.id
+    }
+    
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    public let description: String
+    public let verbatim: String
+    public var id: String { description }
+    
+    public var markup: String {
+        "@\(self.description)"
+    }
+    
+    public var verbatimMarkup: String {
+        "@\(self.verbatim)"
+    }
+
+    public init?(_ description: String) {
+        guard description.wholeMatch(of: Self.inviteCodeRegex) != nil else {
+            return nil
+        }
+        self.description = description.lowercased()
+        self.verbatim = description
+    }
+}

--- a/xcode/Subconscious/Shared/Services/GatewayProvisioningService.swift
+++ b/xcode/Subconscious/Shared/Services/GatewayProvisioningService.swift
@@ -60,7 +60,7 @@ actor GatewayProvisioningService {
     }
     
     func provisionGateway(
-        inviteCode: String,
+        inviteCode: InviteCode,
         sphere: Did
     ) async throws -> ProvisionGatewayResponse {
         
@@ -68,7 +68,10 @@ actor GatewayProvisioningService {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         
-        let body = ProvisionGatewayRequest(invite_code: inviteCode, sphere: sphere.description)
+        let body = ProvisionGatewayRequest(
+            invite_code: inviteCode.description,
+            sphere: sphere.description
+        )
         request.httpBody = try jsonEncoder.encode(body)
         
         let (data, response) = try await URLSession.shared.data(for: request)
@@ -99,7 +102,7 @@ actor GatewayProvisioningService {
     }
     
     nonisolated func provisionGatewayPublisher(
-        inviteCode: String,
+        inviteCode: InviteCode,
         sphere: Did
     ) -> AnyPublisher<ProvisionGatewayResponse, Error> {
         Future.detached {

--- a/xcode/Subconscious/Shared/Services/GatewayProvisioningService.swift
+++ b/xcode/Subconscious/Shared/Services/GatewayProvisioningService.swift
@@ -158,9 +158,9 @@ actor GatewayProvisioningService {
     }
     
     func waitForGatewayProvisioning(
-        gatewayId: String,
-        maxAttempts: Int
+        gatewayId: String
     ) async throws -> URL? {
+        let maxAttempts = 10 // 1+2+4+8+16+32+32+32+32+32 = 191 seconds
         return try await Func.retryWithBackoff(maxAttempts: maxAttempts) { attempts in
             Self.logger.log("""
             Check provisioning status, \
@@ -186,13 +186,11 @@ actor GatewayProvisioningService {
     }
     
     nonisolated func waitForGatewayProvisioningPublisher(
-        gatewayId: String,
-        maxAttempts: Int
+        gatewayId: String
     ) -> AnyPublisher<URL?, Error> {
         Future.detached {
             try await self.waitForGatewayProvisioning(
-                gatewayId: gatewayId,
-                maxAttempts: maxAttempts
+                gatewayId: gatewayId
             )
         }
         .eraseToAnyPublisher()

--- a/xcode/Subconscious/Shared/Services/GatewayProvisioningService.swift
+++ b/xcode/Subconscious/Shared/Services/GatewayProvisioningService.swift
@@ -1,0 +1,92 @@
+//
+//  GatewayProvisioningService.swift
+//  Subconscious
+//
+//  Created by Ben Follington on 1/5/2023.
+//
+
+import Foundation
+import os
+
+struct ProvisionGatewayRequest: Codable {
+    var invite_code: String
+    var sphere: String
+}
+
+struct ProvisionGatewayErrorResponse: Codable {
+    var error: String?
+}
+
+struct ProvisionGatewayResponse: Codable {
+    var gateway_url: URL
+    var gateway_did: Did
+}
+
+enum GatewayProvisioningServiceError: Error {
+    case failedToProvisionGateway(String)
+}
+
+actor GatewayProvisioningService {
+    private static let provisionGatewayEndpoint =
+        Config.default.cloudCtlUrl.appending(
+            path: "api/v0/public/provision_gateway"
+        )
+    
+    private var jsonEncoder: JSONEncoder
+    private var jsonDecoder: JSONDecoder
+    
+    static let logger = Logger(
+        subsystem: Config.default.rdns,
+        category: "GatewayProvisioningService"
+    )
+    
+    init() {
+        self.jsonEncoder = JSONEncoder()
+        self.jsonDecoder = JSONDecoder()
+    }
+    
+    func provisionGateway(
+        inviteCode: String,
+        sphere: Did
+    ) async throws -> ProvisionGatewayResponse {
+        
+        var request = URLRequest(url: Self.provisionGatewayEndpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        let body = ProvisionGatewayRequest(invite_code: inviteCode, sphere: sphere.description)
+        request.httpBody = try jsonEncoder.encode(body)
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let response = response as? HTTPURLResponse else {
+            throw GatewayProvisioningServiceError.failedToProvisionGateway(
+                "Could not read response"
+            )
+        }
+        
+        guard response.success else {
+            let responseBody = try self.jsonDecoder.decode(
+                ProvisionGatewayErrorResponse.self,
+                from: data
+            )
+            
+            if let error = responseBody.error {
+                throw GatewayProvisioningServiceError.failedToProvisionGateway(
+                    "HTTP \(response.statusCode): \(error)"
+                )
+            } else {
+                throw GatewayProvisioningServiceError.failedToProvisionGateway(
+                    "Unexpected status code \(response.statusCode)"
+                )
+            }
+        }
+        
+        return try self.jsonDecoder.decode(ProvisionGatewayResponse.self, from: data)
+    }
+}
+
+extension HTTPURLResponse {
+    var success: Bool {
+        return (200 ... 299).contains(statusCode)
+    }
+}

--- a/xcode/Subconscious/Shared/Services/GatewayProvisioningService.swift
+++ b/xcode/Subconscious/Shared/Services/GatewayProvisioningService.swift
@@ -39,7 +39,6 @@ extension GatewayProvisioningServiceError: LocalizedError {
     }
 }
 
-
 actor GatewayProvisioningService {
     private static let provisionGatewayEndpoint =
         Config.default.cloudCtlUrl.appending(

--- a/xcode/Subconscious/Shared/Services/GatewayProvisioningService.swift
+++ b/xcode/Subconscious/Shared/Services/GatewayProvisioningService.swift
@@ -19,8 +19,8 @@ struct ProvisionGatewayErrorResponse: Codable {
 }
 
 struct ProvisionGatewayResponse: Codable {
-    var gateway_url: URL
-    var gateway_did: Did
+    var gateway_url: String
+    var gateway_did: String
 }
 
 enum GatewayProvisioningServiceError: Error {

--- a/xcode/Subconscious/Shared/Services/GatewayProvisioningService.swift
+++ b/xcode/Subconscious/Shared/Services/GatewayProvisioningService.swift
@@ -168,13 +168,13 @@ actor GatewayProvisioningService {
             return url
         } catch {
             let attempts = attempts + 1
-            guard attempts >= maxAttempts else {
+            guard attempts < maxAttempts else {
                 return nil
             }
             
             Self.logger.log("Waiting... Attempts=\(attempts)")
             
-            sleep(UInt32(attempts * 1000))
+            sleep(UInt32(attempts))
             
             return try await self.waitForGatewayProvisioning(
                 gatewayId: gatewayId,

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		B5690C3D29FB4DEF00067580 /* DidQrCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B569971529B6A0DF003204FC /* DidQrCodeView.swift */; };
 		B569971629B6A0DF003204FC /* FollowUserViaQRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B569971429B6A0DF003204FC /* FollowUserViaQRCodeView.swift */; };
 		B569971729B6A0DF003204FC /* DidQrCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B569971529B6A0DF003204FC /* DidQrCodeView.swift */; };
+		B56C3D3E2A01E5020071EF70 /* InviteCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56C3D3D2A01E5020071EF70 /* InviteCode.swift */; };
 		B575834528ED8D9100F6EE88 /* combo.json in Resources */ = {isa = PBXBuildFile; fileRef = B575834428ED8D9100F6EE88 /* combo.json */; };
 		B57C0AE929D2782C00D352E3 /* PetnameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57C0AE829D2782C00D352E3 /* PetnameView.swift */; };
 		B57C0AEE29D280BB00D352E3 /* ThreeColumnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57C0AED29D280BB00D352E3 /* ThreeColumnView.swift */; };
@@ -429,6 +430,7 @@
 		B54B922728E669D6003ACA1F /* MementoGeist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MementoGeist.swift; sourceTree = "<group>"; };
 		B569971429B6A0DF003204FC /* FollowUserViaQRCodeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FollowUserViaQRCodeView.swift; sourceTree = "<group>"; };
 		B569971529B6A0DF003204FC /* DidQrCodeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DidQrCodeView.swift; sourceTree = "<group>"; };
+		B56C3D3D2A01E5020071EF70 /* InviteCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteCode.swift; sourceTree = "<group>"; };
 		B575834428ED8D9100F6EE88 /* combo.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = combo.json; sourceTree = "<group>"; };
 		B57C0AE829D2782C00D352E3 /* PetnameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PetnameView.swift; sourceTree = "<group>"; };
 		B57C0AED29D280BB00D352E3 /* ThreeColumnView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeColumnView.swift; sourceTree = "<group>"; };
@@ -1038,6 +1040,8 @@
 				B8A59D6828B692900010DB2F /* StoryPrompt.swift */,
 				B58A46B429D3CE9700491E43 /* StoryUser.swift */,
 				B8B54F3C271F7C6B00B9B507 /* Suggestion.swift */,
+				B81A1A6C29DF267200B4CD1C /* LoadingState.swift */,
+				B56C3D3D2A01E5020071EF70 /* InviteCode.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1636,6 +1640,7 @@
 				B5F6ADC929C02F4A00690DE4 /* AddressBookService.swift in Sources */,
 				B8879EAC26F944DA00A0B4FF /* MemoEditorDetail.swift in Sources */,
 				B8925B2F29C23017001F9503 /* MemoViewerDetailView.swift in Sources */,
+				B56C3D3E2A01E5020071EF70 /* InviteCode.swift in Sources */,
 				B51EEAA129F0C37B0055887B /* AppIcon.swift in Sources */,
 				B8A1621429B2AB3A008322EB /* CloseButtonView.swift in Sources */,
 				B80890A72A056A130087E091 /* SlashlinkDisplayView.swift in Sources */,

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -47,7 +47,6 @@
 		B59D556329BBFF56007915E2 /* FormField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59D556229BBFF56007915E2 /* FormField.swift */; };
 		B5CA12A029FF732A00860E9E /* GatewayProvisioningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CA129F29FF732A00860E9E /* GatewayProvisioningService.swift */; };
 		B5CA12A129FF732A00860E9E /* GatewayProvisioningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CA129F29FF732A00860E9E /* GatewayProvisioningService.swift */; };
-		B5CA12A329FF751700860E9E /* Tests_GatewayProvisioningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CA12A229FF751700860E9E /* Tests_GatewayProvisioningService.swift */; };
 		B5CA448929D6A1C7002FD83C /* DummyDataUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CA448829D6A1C7002FD83C /* DummyDataUtilities.swift */; };
 		B5CA448A29D6A1C7002FD83C /* DummyDataUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CA448829D6A1C7002FD83C /* DummyDataUtilities.swift */; };
 		B5CFC7FE29E5403900178631 /* FollowUserSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CFC7FD29E5403900178631 /* FollowUserSheet.swift */; };
@@ -453,7 +452,6 @@
 		B5908BEA29DAB05B00225B1A /* TestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUtilities.swift; sourceTree = "<group>"; };
 		B59D556229BBFF56007915E2 /* FormField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormField.swift; sourceTree = "<group>"; };
 		B5CA129F29FF732A00860E9E /* GatewayProvisioningService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayProvisioningService.swift; sourceTree = "<group>"; };
-		B5CA12A229FF751700860E9E /* Tests_GatewayProvisioningService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_GatewayProvisioningService.swift; sourceTree = "<group>"; };
 		B5CA448829D6A1C7002FD83C /* DummyDataUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyDataUtilities.swift; sourceTree = "<group>"; };
 		B5CFC7FD29E5403900178631 /* FollowUserSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowUserSheet.swift; sourceTree = "<group>"; };
 		B5D769CA29F770440015385A /* GenerativeProfilePic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerativeProfilePic.swift; sourceTree = "<group>"; };
@@ -1542,7 +1540,6 @@
 				B884565329D2102D00DBCD39 /* Tests_App.swift in Sources */,
 				B84AD8DF280F3659006B3153 /* Tests_EntryLink.swift in Sources */,
 				B8B604E9291476E9006FCB77 /* Tests_Migrations.swift in Sources */,
-				B5CA12A329FF751700860E9E /* Tests_GatewayProvisioningService.swift in Sources */,
 				B8A617222971E4860054D410 /* Tests_Slashlink.swift in Sources */,
 				B8B3194F2909F36800A1E62A /* Tests_FileFingerprint.swift in Sources */,
 				B8682DCB2804BF04001CD8DD /* Tests_Subtext.swift in Sources */,

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -44,6 +44,9 @@
 		B58FE48E28DEDAEA00E000CC /* StoryComboView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58FE48D28DEDAEA00E000CC /* StoryComboView.swift */; };
 		B5908BEB29DAB05B00225B1A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5908BEA29DAB05B00225B1A /* TestUtilities.swift */; };
 		B59D556329BBFF56007915E2 /* FormField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59D556229BBFF56007915E2 /* FormField.swift */; };
+		B5CA12A029FF732A00860E9E /* GatewayProvisioningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CA129F29FF732A00860E9E /* GatewayProvisioningService.swift */; };
+		B5CA12A129FF732A00860E9E /* GatewayProvisioningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CA129F29FF732A00860E9E /* GatewayProvisioningService.swift */; };
+		B5CA12A329FF751700860E9E /* Tests_GatewayProvisioningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CA12A229FF751700860E9E /* Tests_GatewayProvisioningService.swift */; };
 		B5CA448929D6A1C7002FD83C /* DummyDataUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CA448829D6A1C7002FD83C /* DummyDataUtilities.swift */; };
 		B5CA448A29D6A1C7002FD83C /* DummyDataUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CA448829D6A1C7002FD83C /* DummyDataUtilities.swift */; };
 		B5CFC7FE29E5403900178631 /* FollowUserSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CFC7FD29E5403900178631 /* FollowUserSheet.swift */; };
@@ -447,6 +450,8 @@
 		B58FE48D28DEDAEA00E000CC /* StoryComboView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryComboView.swift; sourceTree = "<group>"; };
 		B5908BEA29DAB05B00225B1A /* TestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUtilities.swift; sourceTree = "<group>"; };
 		B59D556229BBFF56007915E2 /* FormField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormField.swift; sourceTree = "<group>"; };
+		B5CA129F29FF732A00860E9E /* GatewayProvisioningService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayProvisioningService.swift; sourceTree = "<group>"; };
+		B5CA12A229FF751700860E9E /* Tests_GatewayProvisioningService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_GatewayProvisioningService.swift; sourceTree = "<group>"; };
 		B5CA448829D6A1C7002FD83C /* DummyDataUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyDataUtilities.swift; sourceTree = "<group>"; };
 		B5CFC7FD29E5403900178631 /* FollowUserSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowUserSheet.swift; sourceTree = "<group>"; };
 		B5D769CA29F770440015385A /* GenerativeProfilePic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerativeProfilePic.swift; sourceTree = "<group>"; };
@@ -832,6 +837,7 @@
 				B5432B8229F8BAED003BBB23 /* Tests_UserProfileService.swift */,
 				B5908BEA29DAB05B00225B1A /* TestUtilities.swift */,
 				B80890A92A0693C40087E091 /* Tests_HeaderSubtext.swift */,
+				B5CA12A229FF751700860E9E /* Tests_GatewayProvisioningService.swift */,
 			);
 			path = SubconsciousTests;
 			sourceTree = "<group>";
@@ -939,6 +945,7 @@
 				B8CA8F1F288F1875005F8802 /* RandomPromptGeist.swift */,
 				B8CBAFA8299580E50079107E /* StoreProtocol.swift */,
 				B508956F29E79BE70048106B /* UserProfileService.swift */,
+				B5CA129F29FF732A00860E9E /* GatewayProvisioningService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1531,6 +1538,7 @@
 				B884565329D2102D00DBCD39 /* Tests_App.swift in Sources */,
 				B84AD8DF280F3659006B3153 /* Tests_EntryLink.swift in Sources */,
 				B8B604E9291476E9006FCB77 /* Tests_Migrations.swift in Sources */,
+				B5CA12A329FF751700860E9E /* Tests_GatewayProvisioningService.swift in Sources */,
 				B8A617222971E4860054D410 /* Tests_Slashlink.swift in Sources */,
 				B8B3194F2909F36800A1E62A /* Tests_FileFingerprint.swift in Sources */,
 				B8682DCB2804BF04001CD8DD /* Tests_Subtext.swift in Sources */,
@@ -1687,6 +1695,7 @@
 				B82C3A5326F528B000833CC8 /* DatabaseService.swift in Sources */,
 				B8A41D512811F87C0096D2E7 /* SlashlinkBarView.swift in Sources */,
 				B8879EA026F90C5100A0B4FF /* NotebookNavigationView.swift in Sources */,
+				B5CA12A029FF732A00860E9E /* GatewayProvisioningService.swift in Sources */,
 				B8EB2A2326F27797006E97C3 /* AppView.swift in Sources */,
 				B89E30772911B51A00A4721F /* Migration.swift in Sources */,
 				B8B4D7EC27EA890B00633B5F /* ShadowStyle.swift in Sources */,
@@ -1838,6 +1847,7 @@
 				B8A41D4F2811E81E0096D2E7 /* WikilinkBarView.swift in Sources */,
 				B86DFF2927BF02F0002E57ED /* CollectionUtilities.swift in Sources */,
 				B8879EA126F90C5100A0B4FF /* NotebookNavigationView.swift in Sources */,
+				B5CA12A129FF732A00860E9E /* GatewayProvisioningService.swift in Sources */,
 				B8B6BCBC29CE1FCF000DB410 /* ProgressTorusView.swift in Sources */,
 				B5690C3D29FB4DEF00067580 /* DidQrCodeView.swift in Sources */,
 				B8EB2A2426F27797006E97C3 /* AppView.swift in Sources */,

--- a/xcode/Subconscious/SubconsciousTests/Tests_Func.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Func.swift
@@ -39,4 +39,34 @@ final class Tests_Func: XCTestCase {
             "Propagates error"
         )
     }
+    
+    func testRetryMultipleTimes() async throws {
+        let result = try await Func.retryWithBackoff(
+            maxAttempts: 5,
+            maxWaitSeconds: 1
+        ) { attempt in
+            guard attempt > 3 else {
+                throw TestError.error
+            }
+            
+            return "hello world"
+        }
+        
+        XCTAssertEqual(result, "hello world")
+    }
+    
+    func testGiveUpAfterMaxRetries() async throws {
+        let result = try await Func.retryWithBackoff(
+            maxAttempts: 5,
+            maxWaitSeconds: 1
+        ) { attempt in
+            // Always fails
+            guard attempt > 10 else {
+                throw TestError.error
+            }
+            return 123
+        }
+        
+        XCTAssertNil(result)
+    }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_GatewayProvisioningService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_GatewayProvisioningService.swift
@@ -1,0 +1,8 @@
+//
+//  Tests_GatewayProvisioningService.swift
+//  SubconsciousTests
+//
+//  Created by Ben Follington on 1/5/2023.
+//
+
+import Foundation

--- a/xcode/Subconscious/SubconsciousTests/Tests_GatewayProvisioningService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_GatewayProvisioningService.swift
@@ -1,8 +1,0 @@
-//
-//  Tests_GatewayProvisioningService.swift
-//  SubconsciousTests
-//
-//  Created by Ben Follington on 1/5/2023.
-//
-
-import Foundation


### PR DESCRIPTION
Resolves https://github.com/subconsciousnetwork/subconscious/issues/468
Resolves #533 

# Images

<img width="192" alt="Screenshot 2023-05-03 at 7 02 48 pm" src="https://user-images.githubusercontent.com/5009316/235874737-20ba8c18-24f8-4597-8b02-6ef91a9394bf.png"> <img width="192" alt="image" src="https://user-images.githubusercontent.com/5009316/235874807-df44f45e-0e51-4b26-b094-b056ef858891.png"> <img width="192" alt="image" src="https://user-images.githubusercontent.com/5009316/235874920-48316e76-9793-47dc-b493-d5eaf5e56696.png">


Call out to `cloudctl` to attempt to provision a gateway from within the app.

- [x] Add field to capture invite code
- [x] Add retry option in settings
- [x] "Skip" or "Use offline" secondary button on First Run
- [x] Update & display provisioning status in settings
    - Different icons for different states, extract component?