### PR TITLE
Introduce Swiftlint

### DIFF
--- a/.github/workflows/swiftlint.yaml
+++ b/.github/workflows/swiftlint.yaml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
             set-safe-directory: '/github/workspace'
+      - name: Fetch PR's target branch
+        run: git fetch --no-tags --prune --depth=1 origin ${{ github.base_ref }}
       - name: GitHub Action for SwiftLint
         uses: norio-nomura/action-swiftlint@master
         env:

--- a/.github/workflows/swiftlint.yaml
+++ b/.github/workflows/swiftlint.yaml
@@ -1,17 +1,11 @@
 on:
-  workflow_dispatch:
-  push:
-    branches: [main]
-  pull_request:
-
-name: SwiftLint
-
-on:
   pull_request:
     paths:
       - '.github/workflows/swiftlint.yml'
       - '.swiftlint.yml'
       - '**/*.swift'
+
+name: SwiftLint
 
 jobs:
   SwiftLint:

--- a/.github/workflows/swiftlint.yaml
+++ b/.github/workflows/swiftlint.yaml
@@ -16,8 +16,6 @@ jobs:
             set-safe-directory: '/github/workspace'
       - name: Fetch PR's target branch
         run: git fetch --no-tags --prune --depth=1 origin ${{ github.base_ref }}
-      - name: Fix permissions
-        run: sudo chown -R "$(whoami)" /github/workspace
       - name: GitHub Action for SwiftLint
         uses: norio-nomura/action-swiftlint@master
         with:

--- a/.github/workflows/swiftlint.yaml
+++ b/.github/workflows/swiftlint.yaml
@@ -9,7 +9,7 @@ name: SwiftLint
 
 jobs:
   SwiftLint:
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/swiftlint.yaml
+++ b/.github/workflows/swiftlint.yaml
@@ -20,5 +20,7 @@ jobs:
         run: sudo chown -R "$(whoami)" /github/workspace
       - name: GitHub Action for SwiftLint
         uses: norio-nomura/action-swiftlint@master
+        with:
+          args: --force-exclude
         env:
           DIFF_BASE: ${{ github.base_ref }}

--- a/.github/workflows/swiftlint.yaml
+++ b/.github/workflows/swiftlint.yaml
@@ -9,11 +9,11 @@ name: SwiftLint
 
 jobs:
   SwiftLint:
-    runs-on: ubuntu-latest
+    runs-on: macos-12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
-            set-safe-directory: '*'
+            set-safe-directory: '/github/workspace'
       - name: GitHub Action for SwiftLint
         uses: norio-nomura/action-swiftlint@master
         env:

--- a/.github/workflows/swiftlint.yaml
+++ b/.github/workflows/swiftlint.yaml
@@ -1,0 +1,22 @@
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+
+name: SwiftLint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/swiftlint.yml'
+      - '.swiftlint.yml'
+      - '**/*.swift'
+
+jobs:
+  SwiftLint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: GitHub Action for SwiftLint
+        uses: norio-nomura/action-swiftlint@master

--- a/.github/workflows/swiftlint.yaml
+++ b/.github/workflows/swiftlint.yaml
@@ -12,13 +12,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-            set-safe-directory: '/github/workspace'
-      - name: Fetch PR's target branch
-        run: git fetch --no-tags --prune --depth=1 origin ${{ github.base_ref }}
       - name: GitHub Action for SwiftLint
         uses: norio-nomura/action-swiftlint@master
-        with:
-          args: --force-exclude
-        env:
-          DIFF_BASE: ${{ github.base_ref }}

--- a/.github/workflows/swiftlint.yaml
+++ b/.github/workflows/swiftlint.yaml
@@ -16,6 +16,8 @@ jobs:
             set-safe-directory: '/github/workspace'
       - name: Fetch PR's target branch
         run: git fetch --no-tags --prune --depth=1 origin ${{ github.base_ref }}
+      - name: Fix permissions
+        run: sudo chown -R "$(whoami)" /github/workspace
       - name: GitHub Action for SwiftLint
         uses: norio-nomura/action-swiftlint@master
         env:

--- a/.github/workflows/swiftlint.yaml
+++ b/.github/workflows/swiftlint.yaml
@@ -11,7 +11,9 @@ jobs:
   SwiftLint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+            set-safe-directory: '*'
       - name: GitHub Action for SwiftLint
         uses: norio-nomura/action-swiftlint@master
         env:

--- a/.github/workflows/swiftlint.yaml
+++ b/.github/workflows/swiftlint.yaml
@@ -14,3 +14,5 @@ jobs:
       - uses: actions/checkout@v1
       - name: GitHub Action for SwiftLint
         uses: norio-nomura/action-swiftlint@master
+        env:
+          DIFF_BASE: ${{ github.base_ref }}

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,13 +1,19 @@
-disabled_rules:
-  - file_length
-  - trailing_whitespace
-  - identifier_name
-  - type_body_length
-  - function_body_length
-  - type_name
-  - todo
-  - redundant_optional_initialization
-  - cyclomatic_complexity
-  - force_try
+only_rules:
+  - line_length
+  - vertical_whitespace
+  - redundant_discardable_let
+  - unused_closure_parameter
+  - mark
+  - implicit_getter
+  - trailing_comma
+  - orphaned_doc_comment
+  - control_statement
+  - multiple_closures_with_trailing_closure
+  - opening_brace
+  - empty_enum_arguments
+  - for_where
+  - redundant_string_enum_value
+  - colon
+  - syntactic_sugar
 
 line_length: 100

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,5 +7,7 @@ disabled_rules:
   - type_name
   - todo
   - redundant_optional_initialization
+  - cyclomatic_complexity
+  - force_try
 
 line_length: 100

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,11 @@
+disabled_rules:
+  - file_length
+  - trailing_whitespace
+  - identifier_name
+  - type_body_length
+  - function_body_length
+  - type_name
+  - todo
+  - redundant_optional_initialization
+
+line_length: 100


### PR DESCRIPTION
Trying out a basic set of rules for catching mistakes like line length etc. everything is configured as a warning rather than an error right now so the build will never fail for lint reasons. I started with all the rules on and removed anything that was obviously in conflict with our existing style / rules.

We have ~500 lint warnings in the codebase atm and it would be good to fix them because github actions can only display a maximum of 10 linting errors per run (yeah, I know). So lint errors introduced in a PR won't actually show up in the UI until we clear the backlog of underlying lint issues. 

The github action I used (made by the author of Swiftlint) purports to be able to scope the linting to only files changed in the PR but I get errors whenever I try to configure it as per their example.

---

Swiftlint can fix basic issues by running `swiftlint --fix` but we need to pick our moment carefully to avoid conflicts with in-flight work.

You can also choose to integrate swiftlint into Xcode as a build action (see this draft PR https://github.com/subconsciousnetwork/subconscious/pull/573). If we gain enough confidence in rules I would be tempted to add a pre-commit hook that autofixes.