### PR TITLE
Render transclude blocks in MemoDetailViewer

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -2046,7 +2046,7 @@ struct AppEnvironment {
         
         self.feed = FeedService()
         self.gatewayProvisioningService = GatewayProvisioningService()
-        self.transclude = TranscludeService(database: database)
+        self.transclude = TranscludeService(database: database, noosphere: noosphere)
     }
 }
 

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -1958,6 +1958,7 @@ struct AppEnvironment {
     var database: DatabaseService
     var data: DataService
     var feed: FeedService
+    var transclude: TranscludeService
     
     var recoveryPhrase: RecoveryPhraseEnvironment = RecoveryPhraseEnvironment()
     
@@ -2045,6 +2046,7 @@ struct AppEnvironment {
         
         self.feed = FeedService()
         self.gatewayProvisioningService = GatewayProvisioningService()
+        self.transclude = TranscludeService(database: database)
     }
 }
 

--- a/xcode/Subconscious/Shared/Components/Common/Byline/PetnameView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Byline/PetnameView.swift
@@ -21,7 +21,7 @@ extension UserProfile {
             self.nickname,
             self.address.petname?.leaf
         ) {
-        case (.you, _, .some(let selfNickname), _):
+        case (.ourself, _, .some(let selfNickname), _):
             return NameVariant.petname(Slashlink.ourProfile, selfNickname)
         case (_, .following(let petname), _, _):
             return NameVariant.petname(self.address, petname)

--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -134,7 +134,7 @@ struct EditProfileSheet: View {
             address: user.address,
             pfp: pfp,
             bio: UserProfileBio(state.bioField.validated?.text ?? ""),
-            category: .you,
+            category: .ourself,
             resolutionStatus: .resolved(Cid("fake-for-preview")),
             ourFollowStatus: .notFollowing
         )

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
@@ -40,7 +40,7 @@ struct UserProfileHeaderView: View {
                     Button(
                         action: {
                             switch (user.category, user.ourFollowStatus) {
-                            case (.you, _):
+                            case (.ourself, _):
                                 action(.editOwnProfile)
                             case (_, .following(_)):
                                 action(.requestUnfollow)
@@ -50,7 +50,7 @@ struct UserProfileHeaderView: View {
                         },
                         label: {
                             switch (user.category, user.ourFollowStatus) {
-                            case (.you, _):
+                            case (.ourself, _):
                                 Label("Edit Profile", systemImage: AppIcon.edit.systemName)
                             case (_, .following(_)):
                                 Label("Following", systemImage: AppIcon.following.systemName)
@@ -60,7 +60,7 @@ struct UserProfileHeaderView: View {
                         }
                     )
                     .buttonStyle(GhostPillButtonStyle(size: .small))
-                    .frame(maxWidth: user.category == .you ? 120 : 100)
+                    .frame(maxWidth: user.category == .ourself ? 120 : 100)
                 }
             }
             
@@ -123,7 +123,7 @@ struct BylineLgView_Previews: PreviewProvider {
                     address: Slashlink.ourProfile,
                     pfp: .image("pfp-dog"),
                     bio: UserProfileBio("Ploofy snooflewhumps burbled, outflonking the zibber-zabber in a traddlewaddle."),
-                    category: .you,
+                    category: .ourself,
                     resolutionStatus: .resolved(Cid("ok")),
                     ourFollowStatus: .notFollowing
                 )

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -247,7 +247,7 @@ struct UserProfileView: View {
                     status: state.loadingState
                 )
                 if let user = state.user,
-                   user.category == .you {
+                   user.category == .ourself {
                     ToolbarItem(placement: .confirmationAction) {
                         Button(
                             action: {

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
@@ -69,7 +69,7 @@ struct StoryUserView: View {
                         case (.following(_), _):
                             Image.from(appIcon: .following)
                                 .foregroundColor(.secondary)
-                        case (_, .you):
+                        case (_, .ourself):
                             Image.from(appIcon: .you(colorScheme))
                                 .foregroundColor(.secondary)
                         case (_, _):
@@ -113,7 +113,7 @@ struct StoryUserView: View {
                             .background(.background)
                             .foregroundColor(.secondary)
                     }
-                ).disabled(story.user.category == .you)
+                ).disabled(story.user.category == .ourself)
             }
             .padding(AppTheme.tightPadding)
             .frame(height: AppTheme.unit * 13)
@@ -181,7 +181,7 @@ struct StoryUserView_Previews: PreviewProvider {
                         address: Slashlink(petname: Petname("ben.gordon.chris.bob")!),
                         pfp: .image("pfp-dog"),
                         bio: UserProfileBio("Ploofy snooflewhumps burbled, outflonking the zibber-zabber."),
-                        category: .you,
+                        category: .ourself,
                         resolutionStatus: .resolved(Cid("ok")),
                         ourFollowStatus: .notFollowing
                     )
@@ -196,7 +196,7 @@ struct StoryUserView_Previews: PreviewProvider {
                         address: Slashlink(petname: Petname("ben.gordon.chris.bob")!),
                         pfp: .image("pfp-dog"),
                         bio: UserProfileBio.empty,
-                        category: .you,
+                        category: .ourself,
                         resolutionStatus: .pending,
                         ourFollowStatus: .notFollowing
                     )

--- a/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
@@ -16,18 +16,28 @@ struct SubtextView: View {
     var body: some View {
         VStack(alignment: .leading) {
             ForEach(subtext.blocks, id: \.self) { block in
-                if let link = block
-                        .slashlinks
-                        .get(0)?
-                        .toSlashlink(),
-                   let entry = transcludes[link] {
-                    Transclude2View(
-                        address: entry.address,
-                        excerpt: entry.excerpt,
-                        action: { onViewTransclude(link) }
-                    )
-                } else {
-                    Text(Self.renderer.render(block.description))
+                Text(Self.renderer.render(block.description))
+                
+                let entries: [EntryStub] =
+                    block.slashlinks
+                    .compactMap { link in
+                        guard let slashlink = link.toSlashlink() else {
+                            return nil
+                        }
+                        
+                        return transcludes[slashlink]
+                    }
+                
+                if entries.count > 0 {
+                    ForEach(entries, id: \.self) { entry in
+                        Transclude2View(
+                            address: entry.address,
+                            excerpt: entry.excerpt,
+                            action: {
+                                onViewTransclude(entry.address)
+                            }
+                        )
+                    }
                 }
             }
         }
@@ -59,7 +69,7 @@ struct SubtextView_Previews: PreviewProvider {
                     
                     Brief were my days among you, and briefer still the words I have spoken.
                     
-                    But should my voice fade in your ears, and my love vanish in your memory, then I will come again,
+                    But should my /voice fade in your ears, and my love vanish in your /memory, then I will come again,
                     
                     And with a richer heart and lips more yielding to the spirit will I speak.
                     
@@ -67,7 +77,9 @@ struct SubtextView_Previews: PreviewProvider {
                     """
                 ),
                 transcludes: [
-                    Slashlink("/wanderer-your-footsteps-are-the-road")!: EntryStub(address: Slashlink("/wanderer-your-footsteps-are-the-road")!.toPublicMemoAddress(), excerpt: "hello world", modified: Date.now)
+                    Slashlink("/wanderer-your-footsteps-are-the-road")!: EntryStub(address: Slashlink("/wanderer-your-footsteps-are-the-road")!, excerpt: "hello world", modified: Date.now),
+                    Slashlink("/voice")!: EntryStub(address: Slashlink("/voice")!, excerpt: "hello world", modified: Date.now),
+                    Slashlink("/memory")!: EntryStub(address: Slashlink("/memory")!, excerpt: "hello world", modified: Date.now)
                 ],
                 onViewTransclude: { _ in }
             )

--- a/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
@@ -10,11 +10,25 @@ import SwiftUI
 struct SubtextView: View {
     private static var renderer = SubtextAttributedStringRenderer()
     var subtext: Subtext
+    var transcludes: Dictionary<Slashlink, EntryStub>
+    var onViewTransclude: (Slashlink) -> Void
 
     var body: some View {
         VStack(alignment: .leading) {
             ForEach(subtext.blocks, id: \.self) { block in
-                Text(Self.renderer.render(block.description))
+                if let link = block
+                        .slashlinks
+                        .get(0)?
+                        .toSlashlink(),
+                   let entry = transcludes[link] {
+                    Transclude2View(
+                        address: entry.address,
+                        excerpt: entry.excerpt,
+                        action: { onViewTransclude(link) }
+                    )
+                } else {
+                    Text(Self.renderer.render(block.description))
+                }
             }
         }
         .expandAlignedLeading()
@@ -51,7 +65,11 @@ struct SubtextView_Previews: PreviewProvider {
                     
                     Yea, I shall return with the tide,
                     """
-                )
+                ),
+                transcludes: [
+                    Slashlink("/wanderer-your-footsteps-are-the-road")!: EntryStub(address: Slashlink("/wanderer-your-footsteps-are-the-road")!.toPublicMemoAddress(), excerpt: "hello world", modified: Date.now)
+                ],
+                onViewTransclude: { _ in }
             )
         }
     }

--- a/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SubtextView: View {
     private static var renderer = SubtextAttributedStringRenderer()
     var subtext: Subtext
-    var transcludes: Dictionary<Slashlink, EntryStub>
+    var transcludes: [Slashlink: EntryStub]
     var onViewTransclude: (Slashlink) -> Void
 
     var body: some View {

--- a/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SubtextView: View {
     private static var renderer = SubtextAttributedStringRenderer()
     var subtext: Subtext
-    var transcludes: [Slashlink: EntryStub]
+    var transcludePreviews: [Slashlink: EntryStub]
     var onViewTransclude: (Slashlink) -> Void
     
     private func entries(for block: Subtext.Block) -> [EntryStub] {
@@ -20,7 +20,7 @@ struct SubtextView: View {
                     return nil
                 }
                 
-                return transcludes[slashlink]
+                return transcludePreviews[slashlink]
             }
             .filter { entry in
                 // Avoid empty transclude blocks
@@ -78,7 +78,7 @@ struct SubtextView_Previews: PreviewProvider {
                     Yea, I shall return with the tide,
                     """
                 ),
-                transcludes: [
+                transcludePreviews: [
                     Slashlink("/wanderer-your-footsteps-are-the-road")!: EntryStub(address: Slashlink("/wanderer-your-footsteps-are-the-road")!, excerpt: "hello mother", modified: Date.now),
                     Slashlink("/voice")!: EntryStub(address: Slashlink("/voice")!, excerpt: "hello father", modified: Date.now),
                     Slashlink("/memory")!: EntryStub(address: Slashlink("/memory")!, excerpt: "hello world", modified: Date.now)

--- a/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
@@ -27,6 +27,10 @@ struct SubtextView: View {
                         
                         return transcludes[slashlink]
                     }
+                    .filter { entry in
+                        // Avoid empty transclude blocks
+                        entry.excerpt.count > 0
+                    }
                 
                 if entries.count > 0 {
                     ForEach(entries, id: \.self) { entry in
@@ -77,8 +81,8 @@ struct SubtextView_Previews: PreviewProvider {
                     """
                 ),
                 transcludes: [
-                    Slashlink("/wanderer-your-footsteps-are-the-road")!: EntryStub(address: Slashlink("/wanderer-your-footsteps-are-the-road")!, excerpt: "hello world", modified: Date.now),
-                    Slashlink("/voice")!: EntryStub(address: Slashlink("/voice")!, excerpt: "hello world", modified: Date.now),
+                    Slashlink("/wanderer-your-footsteps-are-the-road")!: EntryStub(address: Slashlink("/wanderer-your-footsteps-are-the-road")!, excerpt: "hello mother", modified: Date.now),
+                    Slashlink("/voice")!: EntryStub(address: Slashlink("/voice")!, excerpt: "hello father", modified: Date.now),
                     Slashlink("/memory")!: EntryStub(address: Slashlink("/memory")!, excerpt: "hello world", modified: Date.now)
                 ],
                 onViewTransclude: { _ in }

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -316,24 +316,11 @@ struct MemoViewerDetailModel: ModelProtocol {
                 environment: environment,
                 isPresented: isPresented
             )
-            
         case .fetchTranscludes:
-            let links = state.dom.slashlinks
-                .map { value in value.toSlashlink() }
-                .compactMap { value in value }
-            
-            let fx: Fx<MemoViewerDetailAction> =
-                environment.transclude
-                .fetchTranscludesPublisher(slashlinks: links)
-                .map { entries in
-                    MemoViewerDetailAction.succeedFetchTranscludes(entries)
-                }
-                .recover { error in
-                    MemoViewerDetailAction.failFetchTranscludes(error.localizedDescription)
-                }
-                .eraseToAnyPublisher()
-            
-            return Update(state: state, fx: fx)
+            return fetchTranscludes(
+                state: state,
+                environment: environment
+            )
         case .succeedFetchTranscludes(let transcludes):
             var model = state
             model.transcludes = transcludes
@@ -409,6 +396,28 @@ struct MemoViewerDetailModel: ModelProtocol {
             action: .fetchTranscludes,
             environment: environment
         )
+    }
+    
+    static func fetchTranscludes(
+        state: MemoViewerDetailModel,
+        environment: MemoViewerDetailModel.Environment
+    ) -> Update<MemoViewerDetailModel> {
+        let links = state.dom.slashlinks
+            .map { value in value.toSlashlink() }
+            .compactMap { value in value }
+        
+        let fx: Fx<MemoViewerDetailAction> =
+        environment.transclude
+            .fetchTranscludesPublisher(slashlinks: links)
+            .map { entries in
+                MemoViewerDetailAction.succeedFetchTranscludes(entries)
+            }
+            .recover { error in
+                MemoViewerDetailAction.failFetchTranscludes(error.localizedDescription)
+            }
+            .eraseToAnyPublisher()
+        
+        return Update(state: state, fx: fx)
     }
     
     static func presentMetaSheet(

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -363,8 +363,7 @@ struct MemoViewerDetailModel: ModelProtocol {
             state: model,
             // Set meta sheet address as well
             actions: [
-                .setMetaSheetAddress(description.address),
-                .fetchTranscludes
+                .setMetaSheetAddress(description.address)
             ],
             environment: environment
         ).mergeFx(fx)
@@ -405,7 +404,11 @@ struct MemoViewerDetailModel: ModelProtocol {
     ) -> Update<Self> {
         var model = state
         model.dom = dom
-        return Update(state: model)
+        return update(
+            state: model,
+            action: .fetchTranscludes,
+            environment: environment
+        )
     }
     
     static func presentMetaSheet(

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -465,7 +465,7 @@ struct MemoViewerDetailView_Previews: PreviewProvider {
             ),
             transcludes: [
                 Slashlink("/infinity-paths")!: EntryStub(
-                    address: Slashlink("/infinity-paths")!.toPublicMemoAddress(),
+                    address: Slashlink("/infinity-paths")!,
                     excerpt: "Say not, \"I have discovered the soul's destination,\" but rather, \"I have glimpsed the soul's journey, ever unfolding along the way.\"",
                     modified: Date.now
                 )

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -279,7 +279,6 @@ struct MemoViewerDetailModel: ModelProtocol {
     var isMetaSheetPresented = false
     var metaSheet = MemoViewerDetailMetaSheetModel()
     
-    /// Transclude block preview cache
     var transcludePreviews: [Slashlink: EntryStub] = [:]
     
     static func update(

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -232,7 +232,7 @@ enum MemoViewerDetailAction: Hashable {
     case presentMetaSheet(_ isPresented: Bool)
     
     case fetchTranscludes
-    case succeedFetchTranscludes(Dictionary<Slashlink, EntryStub>)
+    case succeedFetchTranscludes([Slashlink: EntryStub])
     case failFetchTranscludes(_ error: String)
     
     /// Synonym for `.metaSheet(.setAddress(_))`
@@ -275,7 +275,7 @@ struct MemoViewerDetailModel: ModelProtocol {
     var metaSheet = MemoViewerDetailMetaSheetModel()
     
     /// Transclude block preview cache
-    var transcludes: Dictionary<Slashlink, EntryStub> = Dictionary()
+    var transcludes: [Slashlink: EntryStub] = [:]
     
     static func update(
         state: Self,

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -164,11 +164,14 @@ struct MemoViewerDetailLoadedView: View {
     private func onViewTransclude(
         address: Slashlink
     ) {
-        if address.isOurs {
-            notify(.requestDetail(.editor(MemoEditorDetailDescription(address: address))))
-        } else {
-            notify(.requestDetail(.viewer(MemoViewerDetailDescription(address: address))))
-        }
+        notify(
+            .requestDetail(
+                MemoDetailDescription.from(
+                    address: address,
+                    fallback: address.description
+                )
+            )
+        )
     }
     
 

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -284,8 +284,6 @@ struct MemoViewerDetailModel: ModelProtocol {
     
     var transcludePreviews: [Slashlink: EntryStub] = [:]
     
-    
-    
     static func update(
         state: Self,
         action: Action,
@@ -463,7 +461,6 @@ struct MemoViewerDetailModel: ModelProtocol {
                         .userProfile
                         .requestOurProfile()
                         .profile
-   
                 }
                 
                 return try await environment

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -168,7 +168,7 @@ struct UserProfileStatistics: Equatable, Codable, Hashable {
 enum UserCategory: Equatable, Codable, Hashable, CaseIterable {
     case human
     case geist
-    case you
+    case ourself
 }
 
 struct UserProfile: Equatable, Codable, Hashable {
@@ -698,7 +698,7 @@ struct UserProfileDetailModel: ModelProtocol {
         // Refresh our profile & show the following list if we followed someone new
         // This matters if we used the manual "Follow User" form
         if let user = state.user {
-            if user.category == .you {
+            if user.category == .ourself {
                 actions.append(.tabIndexSelected(Self.followingTabIndex))
             }
         }

--- a/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
@@ -284,7 +284,7 @@ extension NotebookAction {
         case let .requestNavigateToProfile(user):
             let user = Func.run {
                 switch (user.category, user.ourFollowStatus) {
-                case (.you, _):
+                case (.ourself, _):
                     // Loop back to our profile
                     return user.overrideAddress(Slashlink.ourProfile)
                 case (_, .following(let name)):

--- a/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
@@ -25,8 +25,9 @@ struct NotebookNavigationView: View {
                     onEntryPress: { entry in
                         store.send(
                             .pushDetail(
-                                MemoViewerDetailDescription(
-                                    address: entry.address
+                                MemoEditorDetailDescription(
+                                    address: entry.address,
+                                    fallback: entry.excerpt
                                 )
                             )
                         )

--- a/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
@@ -25,9 +25,8 @@ struct NotebookNavigationView: View {
                     onEntryPress: { entry in
                         store.send(
                             .pushDetail(
-                                MemoEditorDetailDescription(
-                                    address: entry.address,
-                                    fallback: entry.excerpt
+                                MemoViewerDetailDescription(
+                                    address: entry.address
                                 )
                             )
                         )

--- a/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
@@ -180,6 +180,22 @@ extension UserProfile: DummyData {
             ourFollowStatus: .notFollowing
         )
     }
+    
+    static func dummyData(category: UserCategory) -> UserProfile {
+        let nickname = Petname.Name.dummyData()
+        return UserProfile(
+            did: Did.dummyData(),
+            nickname: nickname,
+            address: category == .ourself
+                ? Slashlink.ourProfile
+                : Slashlink(petname: nickname.toPetname()),
+            pfp: .image(String.dummyProfilePicture()),
+            bio: UserProfileBio.dummyData(),
+            category: category,
+            resolutionStatus: .unresolved,
+            ourFollowStatus: .notFollowing
+        )
+    }
 }
 
 extension UserProfileStatistics: DummyData {

--- a/xcode/Subconscious/Shared/Library/Func.swift
+++ b/xcode/Subconscious/Shared/Library/Func.swift
@@ -77,8 +77,8 @@ struct Func {
                     powf(2.0, Float(attempts))
                 )
             )
-            sleep(seconds)
-            
+            try await Task.sleep(for: .seconds(seconds))
+
             return try await self.retryWithBackoff(
                 maxAttempts: maxAttempts,
                 maxWaitSeconds: maxWaitSeconds,

--- a/xcode/Subconscious/Shared/Models/Slashlink.swift
+++ b/xcode/Subconscious/Shared/Models/Slashlink.swift
@@ -224,6 +224,15 @@ extension Slashlink {
             return self
         }
     }
+    
+    func relativizeIfNeeded(petname base: Petname?) -> Slashlink {
+        switch self.peer {
+        case .petname(let name) where name == base:
+            return Slashlink(slug: self.slug)
+        default:
+            return self
+        }
+    }
 
     /// Get petname from slashlink (if any)
     func toPetname() -> Petname? {

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -505,7 +505,9 @@ final class DatabaseService {
             guard
                 let address = row.col(0)?
                     .toString()?
-                    .toSlashlink(),
+                    .toLink()?
+                    .toSlashlink()?
+                    .relativizeIfNeeded(did: owner),
                 let modified = row.col(1)?.toDate(),
                 let excerpt = row.col(2)?.toString()
             else {

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -444,8 +444,8 @@ final class DatabaseService {
             .flatMap { s in
                 // TODO: this is almost certainly the wrong way to do this
                 [
-                    SQLite3Database.Value.text(s.toPublicMemoAddress().description),
-                    SQLite3Database.Value.text(s.toLocalMemoAddress().description)
+                    SQLite3Database.Value.text(s.description),
+                    SQLite3Database.Value.text(s.description)
                 ]
             }
 
@@ -464,7 +464,7 @@ final class DatabaseService {
 
         return results.compactMap({ row in
             guard
-                let address = row.col(0)?.toString()?.toMemoAddress(),
+                let address = row.col(0)?.toString()?.toSlashlink(),
                 let modified = row.col(1)?.toDate(),
                 let excerpt = row.col(2)?.toString()
             else {

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -462,8 +462,7 @@ final class DatabaseService {
             guard
                 let address = row.col(0)?
                     .toString()?
-                    .toSlashlink()?
-                    .relativizeIfNeeded(petname: owner),
+                    .toSlashlink(),
                 let modified = row.col(1)?.toDate(),
                 let excerpt = row.col(2)?.toString()
             else {

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -434,20 +434,20 @@ final class DatabaseService {
         return results.col(0)?.toInt()
     }
     
-    func listEntries(for slashlinks: [Slashlink], owner: Did?) throws -> [EntryStub] {
+    func listEntries(for slashlinks: [Slashlink], owner: Petname?) throws -> [EntryStub] {
         return try slashlinks.compactMap({ slashlink in
             return try readEntry(for: slashlink, owner: owner)
         })
     }
     
-    func readEntry(for slashlink: Slashlink, owner: Did?) throws -> EntryStub? {
+    func readEntry(for slashlink: Slashlink, owner: Petname?) throws -> EntryStub? {
         guard self.state == .ready else {
             throw DatabaseServiceError.notReady
         }
 
         let results = try database.execute(
             sql: """
-        SELECT id, modified, excerpt
+        SELECT slashlink, modified, excerpt
         FROM memo
         WHERE slashlink = ?
         ORDER BY modified DESC
@@ -462,9 +462,8 @@ final class DatabaseService {
             guard
                 let address = row.col(0)?
                     .toString()?
-                    .toLink()?
                     .toSlashlink()?
-                    .relativizeIfNeeded(did: owner),
+                    .relativizeIfNeeded(petname: owner),
                 let modified = row.col(1)?.toDate(),
                 let excerpt = row.col(2)?.toString()
             else {
@@ -507,9 +506,7 @@ final class DatabaseService {
             guard
                 let address = row.col(0)?
                     .toString()?
-                    .toLink()?
-                    .toSlashlink()?
-                    .relativizeIfNeeded(did: owner),
+                    .toSlashlink(),
                 let modified = row.col(1)?.toDate(),
                 let excerpt = row.col(2)?.toString()
             else {

--- a/xcode/Subconscious/Shared/Services/TranscludeService.swift
+++ b/xcode/Subconscious/Shared/Services/TranscludeService.swift
@@ -23,7 +23,7 @@ actor TranscludeService {
         return
             Dictionary(
                 entries.map { entry in
-                    (entry.address.toSlashlink(), entry)
+                    (entry.address, entry)
                 },
                 uniquingKeysWith: { a, b in a}
             )

--- a/xcode/Subconscious/Shared/Services/TranscludeService.swift
+++ b/xcode/Subconscious/Shared/Services/TranscludeService.swift
@@ -1,0 +1,37 @@
+//
+//  TranscludeService.swift
+//  Subconscious
+//
+//  Created by Ben Follington on 5/5/2023.
+//
+
+import Foundation
+import Combine
+
+actor TranscludeService {
+    private var database: DatabaseService
+    
+    init(database: DatabaseService) {
+        self.database = database
+    }
+    
+    func fetchTranscludes(slashlinks: [Slashlink]) async throws -> Dictionary<Slashlink, EntryStub> {
+        let entries = try database.listEntriesForSlashlinks(slashlinks: slashlinks)
+        
+        var dict = Dictionary<Slashlink, EntryStub>()
+        for entry in entries {
+            dict[entry.address.toSlashlink()] = entry
+        }
+        
+        return dict
+    }
+    
+    nonisolated func fetchTranscludesPublisher(
+        slashlinks: [Slashlink]
+    ) -> AnyPublisher<Dictionary<Slashlink, EntryStub>, Error> {
+        Future.detached(priority: .utility) {
+            try await self.fetchTranscludes(slashlinks: slashlinks)
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/xcode/Subconscious/Shared/Services/TranscludeService.swift
+++ b/xcode/Subconscious/Shared/Services/TranscludeService.swift
@@ -25,7 +25,7 @@ actor TranscludeService {
         
         let slashlinks = slashlinks.map { address in
             guard case .petname(_) = address.peer else {
-                // Rebase relative slashlinks to the owner's handle
+                // Rebase relative slashlinks to the owner's handle (if they have one)
                 return Slashlink(peer: owner.address.peer, slug: address.slug)
             }
             

--- a/xcode/Subconscious/Shared/Services/TranscludeService.swift
+++ b/xcode/Subconscious/Shared/Services/TranscludeService.swift
@@ -18,7 +18,7 @@ actor TranscludeService {
     func fetchTranscludes(
         slashlinks: [Slashlink]
     ) async throws -> [Slashlink: EntryStub] {
-        let entries = try database.listEntriesForSlashlinks(slashlinks: slashlinks)
+        let entries = try database.listEntries(for: slashlinks)
         
         return
             Dictionary(

--- a/xcode/Subconscious/Shared/Services/TranscludeService.swift
+++ b/xcode/Subconscious/Shared/Services/TranscludeService.swift
@@ -15,20 +15,24 @@ actor TranscludeService {
         self.database = database
     }
     
-    func fetchTranscludes(slashlinks: [Slashlink]) async throws -> Dictionary<Slashlink, EntryStub> {
+    func fetchTranscludes(
+        slashlinks: [Slashlink]
+    ) async throws -> [Slashlink: EntryStub] {
         let entries = try database.listEntriesForSlashlinks(slashlinks: slashlinks)
         
-        var dict = Dictionary<Slashlink, EntryStub>()
-        for entry in entries {
-            dict[entry.address.toSlashlink()] = entry
-        }
-        
-        return dict
+        return
+            Dictionary(
+                entries.map { entry in
+                    (entry.address.toSlashlink(), entry)
+                },
+                uniquingKeysWith: { a, b in a}
+            )
     }
+
     
     nonisolated func fetchTranscludesPublisher(
         slashlinks: [Slashlink]
-    ) -> AnyPublisher<Dictionary<Slashlink, EntryStub>, Error> {
+    ) -> AnyPublisher<[Slashlink: EntryStub], Error> {
         Future.detached(priority: .utility) {
             try await self.fetchTranscludes(slashlinks: slashlinks)
         }

--- a/xcode/Subconscious/Shared/Services/TranscludeService.swift
+++ b/xcode/Subconscious/Shared/Services/TranscludeService.swift
@@ -40,7 +40,13 @@ actor TranscludeService {
                         return (Slashlink(slug: entry.address.slug), entry)
                     }
                     
-                    return (entry.address.relativizeIfNeeded(petname: petname), entry)
+                    guard let petname = petname else {
+                        return (entry.address.relativizeIfNeeded(petname: petname), entry)
+                    }
+                    
+                    let x = EntryStub(address: entry.address.rebaseIfNeeded(petname: petname), excerpt: entry.excerpt, modified: entry.modified)
+                    
+                    return (entry.address.relativizeIfNeeded(petname: petname), x)
                 },
                 uniquingKeysWith: { a, b in a}
             )

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -188,7 +188,7 @@ actor UserProfileService {
             address: address,
             pfp: .none(did),
             bio: UserProfileBio(userProfileData?.bio ?? ""),
-            category: isOurs ? UserCategory.you : UserCategory.human,
+            category: isOurs ? UserCategory.ourself : UserCategory.human,
             resolutionStatus: resolutionStatus,
             ourFollowStatus: followingStatus
         )

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -2522,8 +2522,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/twostraws/CodeScanner";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
+				kind = exactVersion;
+				version = 2.3.2;
 			};
 		};
 		B822F18927C9615600943C6B /* XCRemoteSwiftPackageReference "ObservableStore" */ = {

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		B508956E29E7862A0048106B /* Tests_AddressBookService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B508956D29E7862A0048106B /* Tests_AddressBookService.swift */; };
 		B508957029E79BE70048106B /* UserProfileService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B508956F29E79BE70048106B /* UserProfileService.swift */; };
 		B508957129E79BE70048106B /* UserProfileService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B508956F29E79BE70048106B /* UserProfileService.swift */; };
+		B50B045B2A04B61000AA584B /* TranscludeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50B045A2A04B61000AA584B /* TranscludeService.swift */; };
+		B50B045C2A04B61000AA584B /* TranscludeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50B045A2A04B61000AA584B /* TranscludeService.swift */; };
 		B51EEAA129F0C37B0055887B /* AppIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51EEAA029F0C37B0055887B /* AppIcon.swift */; };
 		B5293B892A426645001C4DA7 /* Sentry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5293B882A426645001C4DA7 /* Sentry.swift */; };
 		B5293B8A2A426645001C4DA7 /* Sentry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5293B882A426645001C4DA7 /* Sentry.swift */; };
@@ -451,6 +453,7 @@
 /* Begin PBXFileReference section */
 		B508956D29E7862A0048106B /* Tests_AddressBookService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_AddressBookService.swift; sourceTree = "<group>"; };
 		B508956F29E79BE70048106B /* UserProfileService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileService.swift; sourceTree = "<group>"; };
+		B50B045A2A04B61000AA584B /* TranscludeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscludeService.swift; sourceTree = "<group>"; };
 		B51EEAA029F0C37B0055887B /* AppIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIcon.swift; sourceTree = "<group>"; };
 		B5293B882A426645001C4DA7 /* Sentry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sentry.swift; sourceTree = "<group>"; };
 		B532F8C229B1752E00CE9256 /* TranscludeBlockLayoutFragment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscludeBlockLayoutFragment.swift; sourceTree = "<group>"; };
@@ -1009,6 +1012,7 @@
 				B8CBAFA8299580E50079107E /* StoreProtocol.swift */,
 				B508956F29E79BE70048106B /* UserProfileService.swift */,
 				B5CA129F29FF732A00860E9E /* GatewayProvisioningService.swift */,
+				B50B045A2A04B61000AA584B /* TranscludeService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1758,6 +1762,7 @@
 				B8CBAFA42994491B0079107E /* MenuButtonView.swift in Sources */,
 				B57C0AF729D29A8F00D352E3 /* TabbedThreeColumnView.swift in Sources */,
 				B57C0AEE29D280BB00D352E3 /* ThreeColumnView.swift in Sources */,
+				B50B045B2A04B61000AA584B /* TranscludeService.swift in Sources */,
 				B8133AEB29B8FD1300B38760 /* SubtextAttributedStringRenderer.swift in Sources */,
 				B85EC460296F099700558761 /* ProfilePic.swift in Sources */,
 				B57C0AF529D2865600D352E3 /* UserProfileDetailView.swift in Sources */,
@@ -1987,6 +1992,7 @@
 				B8EC568A26F4204F00AC64E5 /* SQLite3Database.swift in Sources */,
 				B8B4251928FDE8AA0081B8D5 /* MemoData.swift in Sources */,
 				B8A59D6A28B692900010DB2F /* StoryPrompt.swift in Sources */,
+				B50B045C2A04B61000AA584B /* TranscludeService.swift in Sources */,
 				B5CFC7FF29E5403900178631 /* FollowUserSheet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		B5690C3D29FB4DEF00067580 /* DidQrCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B569971529B6A0DF003204FC /* DidQrCodeView.swift */; };
 		B569971629B6A0DF003204FC /* FollowUserViaQRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B569971429B6A0DF003204FC /* FollowUserViaQRCodeView.swift */; };
 		B569971729B6A0DF003204FC /* DidQrCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B569971529B6A0DF003204FC /* DidQrCodeView.swift */; };
+		B56C2D4E2A4962D00062DAC0 /* Tests_TranscludeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56C2D4D2A4962D00062DAC0 /* Tests_TranscludeService.swift */; };
 		B56C3D3E2A01E5020071EF70 /* InviteCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56C3D3D2A01E5020071EF70 /* InviteCode.swift */; };
 		B575834528ED8D9100F6EE88 /* combo.json in Resources */ = {isa = PBXBuildFile; fileRef = B575834428ED8D9100F6EE88 /* combo.json */; };
 		B579FA922A1AE4D1008A4D2F /* ResolutionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B579FA912A1AE4D1008A4D2F /* ResolutionStatus.swift */; };
@@ -465,6 +466,7 @@
 		B54B922728E669D6003ACA1F /* MementoGeist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MementoGeist.swift; sourceTree = "<group>"; };
 		B569971429B6A0DF003204FC /* FollowUserViaQRCodeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FollowUserViaQRCodeView.swift; sourceTree = "<group>"; };
 		B569971529B6A0DF003204FC /* DidQrCodeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DidQrCodeView.swift; sourceTree = "<group>"; };
+		B56C2D4D2A4962D00062DAC0 /* Tests_TranscludeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_TranscludeService.swift; sourceTree = "<group>"; };
 		B56C3D3D2A01E5020071EF70 /* InviteCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteCode.swift; sourceTree = "<group>"; };
 		B575834428ED8D9100F6EE88 /* combo.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = combo.json; sourceTree = "<group>"; };
 		B579FA912A1AE4D1008A4D2F /* ResolutionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolutionStatus.swift; sourceTree = "<group>"; };
@@ -902,6 +904,7 @@
 				B80890A92A0693C40087E091 /* Tests_HeaderSubtext.swift */,
 				B840CCC62A0C1F840000C025 /* Tests_Audience.swift */,
 				B8099F012A3B6FA50014FC2E /* Tests_MemoRecord.swift */,
+				B56C2D4D2A4962D00062DAC0 /* Tests_TranscludeService.swift */,
 			);
 			path = SubconsciousTests;
 			sourceTree = "<group>";
@@ -1618,6 +1621,7 @@
 				B80C9E432A2A7CE400E152FB /* Tests_HeaderSubtext.swift in Sources */,
 				B8F27EE42970CD8F00A33E78 /* Tests_Sphere.swift in Sources */,
 				B80C9E452A2A7CF100E152FB /* Tests_Audience.swift in Sources */,
+				B56C2D4E2A4962D00062DAC0 /* Tests_TranscludeService.swift in Sources */,
 				B82BB7FE28243F32000C9FCC /* Tests_Parser.swift in Sources */,
 				B8099F022A3B6FA50014FC2E /* Tests_MemoRecord.swift in Sources */,
 				B84AD8E82811C827006B3153 /* Tests_URLComponentsUtilities.swift in Sources */,

--- a/xcode/Subconscious/SubconsciousTests/TestUtilities.swift
+++ b/xcode/Subconscious/SubconsciousTests/TestUtilities.swift
@@ -31,6 +31,7 @@ struct TestUtilities {
         var local: HeaderSubtextMemoStore
         var addressBook: AddressBookService
         var userProfile: UserProfileService
+        var transclude: TranscludeService
     }
     
     /// Set up and return a data service instance
@@ -86,13 +87,19 @@ struct TestUtilities {
             database: database,
             addressBook: addressBook
         )
+        
+        let transclude = TranscludeService(
+            database: database,
+            noosphere: noosphere
+        )
 
         return DataServiceEnvironment(
             data: data,
             noosphere: noosphere,
             local: local,
             addressBook: addressBook,
-            userProfile: userProfile
+            userProfile: userProfile,
+            transclude: transclude
         )
     }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_TranscludeService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_TranscludeService.swift
@@ -1,8 +1,72 @@
 //
-//  Tests_TranscludeSerivce.swift
+//  Tests_TranscludeService.swift
 //  SubconsciousTests
 //
 //  Created by Ben Follington on 26/6/2023.
 //
 
-import Foundation
+import XCTest
+import Combine
+import ObservableStore
+@testable import Subconscious
+
+final class Tests_TranscludeService: XCTestCase {
+    /// A place to put cancellables from publishers
+    var cancellables: Set<AnyCancellable> = Set()
+    
+    var data: DataService?
+    
+    func testFetchLocalTranscludes() async throws {
+        let tmp = try TestUtilities.createTmpDir()
+        let environment = try await TestUtilities.createDataServiceEnvironment(
+            tmp: tmp
+        )
+        
+        let address = Slashlink("/test")!
+        let memo = Memo(
+            contentType: ContentType.subtext.rawValue,
+            created: Date.now,
+            modified: Date.now,
+            fileExtension: ContentType.subtext.fileExtension,
+            additionalHeaders: [],
+            body: "Test content"
+        )
+        
+        try await environment.data.writeMemo(
+            address: address,
+            memo: memo
+        )
+        
+        let address2 = Slashlink("/test-again")!
+        let memo2 = Memo(
+            contentType: ContentType.subtext.rawValue,
+            created: Date.now,
+            modified: Date.now,
+            fileExtension: ContentType.subtext.fileExtension,
+            additionalHeaders: [],
+            body: "With different content"
+        )
+        
+        try await environment.data.writeMemo(
+            address: address2,
+            memo: memo2
+        )
+        
+        _ = try await environment.data.indexOurSphere()
+        
+        let profile = UserProfile.dummyData(category: .ourself)
+        
+        let transcludes = try await environment
+            .transclude
+            .fetchTranscludePreviews(
+                slashlinks: [address, address2],
+                owner: profile
+            )
+        
+        XCTAssertEqual(transcludes.count, 2)
+        XCTAssertTrue(transcludes[address] != nil)
+        XCTAssertEqual(transcludes[address]!.excerpt, "Test content")
+        XCTAssertTrue(transcludes[address2] != nil)
+        XCTAssertEqual(transcludes[address2]!.excerpt, "With different content")
+    }
+}

--- a/xcode/Subconscious/SubconsciousTests/Tests_TranscludeService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_TranscludeService.swift
@@ -1,0 +1,8 @@
+//
+//  Tests_TranscludeSerivce.swift
+//  SubconsciousTests
+//
+//  Created by Ben Follington on 26/6/2023.
+//
+
+import Foundation


### PR DESCRIPTION
Related to #328 
Resolves #324 
Fixes https://github.com/subconsciousnetwork/subconscious/issues/710

This approach is based on my experiments with rendering in the editor: #428 

# Changes
- Detect slashlinks in subtext blocks
- Fetch transclude previews from the sphere index (SQLite)
- Display inline between blocks
- Translate addresses to match the context
- Tests for fetching local transcludes
    - Difficult to construct a test for 3P content with transcludes

## Own content, own slashlink

<img width="372" alt="image" src="https://github.com/subconsciousnetwork/subconscious/assets/5009316/5d7fae72-f25f-4ed7-b9b2-78635d34d59a">

## 3P Content, their own slashlink

<img width="373" alt="image" src="https://github.com/subconsciousnetwork/subconscious/assets/5009316/78dd7d21-a739-4074-8c18-337f8049f259">


# TODO

- [x] Tests for TranscludeService
    - Insert some notes
    - Force indexing them
    - Call `.fetchTranscludes` with expected links
    - Try different owner values?
- [x] Use `.findAndPushDetail`

