### PR TITLE
Simplify `UserProfileService`

### DIFF
--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -417,11 +417,11 @@ actor NoosphereService:
         switch (address.peer) {
         case .none:
             return try self.sphere()
-        case .some(.did(let did)) where did == identity:
+        case .did(let did) where did == identity:
             return try self.sphere()
-        case .some(.petname(let petname)):
+        case .petname(let petname):
             return try await self.traverse(petname: petname)
-        case _:
+        default:
             throw NoosphereServiceError.cannotFindSphereForUnknownIdentity
         }
     }

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -407,8 +407,14 @@ actor NoosphereService:
         try await self.sphere().traverse(petname: petname)
     }
     
-    func sphere(did: Did) async throws -> Sphere {
-        try Sphere(noosphere: self.noosphere(), identity: did.did)
+    /// Intelligently open a sphere by traversing or, if this is our address, returning the default sphere.
+    func sphere(address: Slashlink) async throws -> Sphere {
+        switch (address.petname) {
+        case .none:
+            return try self.sphere()
+        case .some(let petname):
+            return try await self.traverse(petname: petname)
+        }
     }
     
     nonisolated func traversePublisher(

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -210,7 +210,7 @@ actor UserProfileService {
     }
     
     /// Produce a reverse-chronological list of the entries passed in
-    private func recentEntries(entries: [EntryStub]) -> [EntryStub] {
+    private func sortEntriesByModified(entries: [EntryStub]) -> [EntryStub] {
         var recentEntries = entries
         recentEntries.sort(by: { a, b in
             a.modified > b.modified
@@ -306,7 +306,7 @@ actor UserProfileService {
             slugs: notes
         )
         let topEntries = entries
-        let recentEntries = recentEntries(entries: entries)
+        let recentEntries = sortEntriesByModified(entries: entries)
         
         let profile = try await self.loadProfileFromMemo(
             did: did,

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -151,7 +151,7 @@ actor UserProfileService {
     /// Load the underlying `_profile_` for a user and construct a `UserProfile` from it.
     private func loadProfileFromMemo(
         did: Did,
-        petname: Petname,
+        fallbackPetname: Petname,
         address: Slashlink
     ) async throws -> UserProfile {
         let userProfileData = await self.readProfileMemo(address: address)
@@ -165,7 +165,7 @@ actor UserProfileService {
         
         let profile = UserProfile(
             did: did,
-            nickname: Petname(userProfileData?.nickname ?? "") ?? petname,
+            nickname: Petname(userProfileData?.nickname ?? "") ?? fallbackPetname,
             address: address,
             pfp: pfp,
             bio: userProfileData?.bio ?? "",
@@ -248,7 +248,7 @@ actor UserProfileService {
             
             let user = try await self.loadProfileFromMemo(
                 did: entry.did,
-                petname: address.petname ?? entry.petname,
+                fallbackPetname: address.petname ?? entry.petname,
                 address: address
             )
             
@@ -310,7 +310,7 @@ actor UserProfileService {
         
         let profile = try await self.loadProfileFromMemo(
             did: did,
-            petname: fallbackPetname,
+            fallbackPetname: fallbackPetname,
             address: address
         )
         

--- a/xcode/Subconscious/SubconsciousTests/Tests_UserProfileService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_UserProfileService.swift
@@ -73,15 +73,12 @@ final class Tests_UserProfileService: XCTestCase {
             petname: Petname("ronald")!
         )
         
-        let did = try await data.noosphere.identity()
-        
         let following = try await data.userProfile.getFollowingList(
-            identity: did,
-            address: Slashlink(petname: Petname("bob.alice")!)
+            address: Slashlink.ourProfile
         )
         
         if let petname = following.first?.user.address.petname {
-            XCTAssertEqual(petname, Petname("ronald.bob.alice")!)
+            XCTAssertEqual(petname, Petname("ronald")!)
         } else {
             XCTFail("No followed users")
         }


### PR DESCRIPTION
Fixes a bug that blocks us from loading profiles, I collapsed the two paths into one to ensure this particular edge-case cannot reoccur.

The actual issue was introduced by `NoosphereService.sphere(did: Did)`, opening a sphere this way DID seems to succeed but leads to null pointer errors down the line. I replaced it with `NoosphereService.sphere(address: MemoAddress)` which will call traverse when appropriate. 

This will need to be adjusted slightly in the wake of https://github.com/subconsciousnetwork/subconscious/pull/561