### PR TITLE
Index 3P spheres in DB

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -1309,7 +1309,7 @@ struct AppModel: ModelProtocol {
         state: AppModel,
         environment: AppEnvironment
     ) -> Update<AppModel> {
-        let fx: Fx<AppAction> = environment.data.syncSphereWithDatabasePublisher().map({
+        let fx: Fx<AppAction> = environment.data.indexOurSpherePublisher().map({
             version in
             AppAction.succeedSyncSphereWithDatabase(version: version)
         }).catch({ error in

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -174,9 +174,9 @@ enum AppAction: CustomLogStringConvertible {
 
     /// Sync current sphere state with database state
     /// Sphere always wins.
-    case syncSphereWithDatabase
-    case succeedSyncSphereWithDatabase(version: String)
-    case failSyncSphereWithDatabase(String)
+    case indexOurSphere
+    case succeedIndexOurSphere(version: String)
+    case failIndexOurSphere(String)
     
     /// Sync database with file system.
     /// File system always wins.
@@ -648,19 +648,19 @@ struct AppModel: ModelProtocol {
                 environment: environment,
                 error: error
             )
-        case .syncSphereWithDatabase:
-            return syncSphereWithDatabase(
+        case .indexOurSphere:
+            return indexOurSphere(
                 state: state,
                 environment: environment
             )
-        case let .succeedSyncSphereWithDatabase(version):
-            return succeedSyncSphereWithDatabase(
+        case let .succeedIndexOurSphere(version):
+            return succeedIndexOurSphere(
                 state: state,
                 environment: environment,
                 version: version
             )
-        case let .failSyncSphereWithDatabase(error):
-            return failSyncSphereWithDatabase(
+        case let .failIndexOurSphere(error):
+            return failIndexOurSphere(
                 state: state,
                 environment: environment,
                 error: error
@@ -1283,7 +1283,7 @@ struct AppModel: ModelProtocol {
         
         return update(
             state: model,
-            action: .syncSphereWithDatabase,
+            action: .indexOurSphere,
             environment: environment
         )
     }
@@ -1300,21 +1300,21 @@ struct AppModel: ModelProtocol {
         
         return update(
             state: model,
-            action: .syncSphereWithDatabase,
+            action: .indexOurSphere,
             environment: environment
         )
     }
     
-    static func syncSphereWithDatabase(
+    static func indexOurSphere(
         state: AppModel,
         environment: AppEnvironment
     ) -> Update<AppModel> {
         let fx: Fx<AppAction> = environment.data.indexOurSpherePublisher().map({
             version in
-            AppAction.succeedSyncSphereWithDatabase(version: version)
+            AppAction.succeedIndexOurSphere(version: version)
         }).catch({ error in
             Just(
-                AppAction.failSyncSphereWithDatabase(error.localizedDescription)
+                AppAction.failIndexOurSphere(error.localizedDescription)
             )
         }).eraseToAnyPublisher()
         
@@ -1323,13 +1323,13 @@ struct AppModel: ModelProtocol {
         return Update(state: model, fx: fx)
     }
     
-    static func succeedSyncSphereWithDatabase(
+    static func succeedIndexOurSphere(
         state: AppModel,
         environment: AppEnvironment,
         version: String
     ) -> Update<AppModel> {
         let identity = state.sphereIdentity ?? "unknown"
-        logger.log("Database synced to sphere \(identity) @ \(version)")
+        logger.log("Database indexed sphere \(identity) @ \(version)")
         
         var model = state
         model.sphereSyncStatus = .succeeded
@@ -1341,7 +1341,7 @@ struct AppModel: ModelProtocol {
         )
     }
     
-    static func failSyncSphereWithDatabase(
+    static func failIndexOurSphere(
         state: AppModel,
         environment: AppEnvironment,
         error: String

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -168,6 +168,35 @@ actor DataService {
         return try await indexSphere(sphere)
     }
 
+    /// Index the contents of a sphere, referenced by petname
+    nonisolated func indexSpherePublisher(
+        petname: Petname
+    ) -> AnyPublisher<String, Error> {
+        Future.detached(priority: .utility) {
+            try await self.indexSphere(petname: petname)
+        }
+        .eraseToAnyPublisher()
+    }
+    
+    /// Purge sphere from database with the given petname.
+    ///
+    /// Gets did for petname, then purges everything belonging to did
+    /// from Database.
+    func purgeSphere(petname: Petname) async throws {
+        let did = try await noosphere.getPetname(petname: petname)
+        try database.purgeSphere(did: did)
+    }
+    
+    /// Purge sphere from database with the given petname.
+    nonisolated func purgeSpherePublisher(
+        petname: Petname
+    ) -> AnyPublisher<Void, Error> {
+        Future.detached(priority: .utility) {
+            try await self.purgeSphere(petname: petname)
+        }
+        .eraseToAnyPublisher()
+    }
+    
     /// Sync file system with database.
     /// Note file system is source-of-truth (leader).
     /// Syncing will never delete files on the file system.

--- a/xcode/Subconscious/SubconsciousTests/Tests_DatabaseService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DatabaseService.swift
@@ -601,7 +601,7 @@ class Tests_DatabaseService: XCTestCase {
     func testReadBacklinksWithoutOwner() throws {
         let service = try createDatabaseService()
         _ = try service.migrate()
-
+        
         // Add some entries to DB
         let now = Date.now
         
@@ -645,11 +645,11 @@ class Tests_DatabaseService: XCTestCase {
                 slug: Slug("foo")!
             )
         )
-
+        
         let slashlinks = Set(
             stubs.map({ stub in stub.address })
         )
-
+        
         XCTAssertEqual(slashlinks.count, 1)
         XCTAssertTrue(
             slashlinks.contains(
@@ -659,6 +659,105 @@ class Tests_DatabaseService: XCTestCase {
                 )
             ),
             "Has link, appears in results"
+        )
+    }
+    
+    func testPurgeSphere() throws {
+        let service = try createDatabaseService()
+        _ = try service.migrate()
+        
+        // Add some entries to DB
+        let now = Date.now
+        
+        let did = Did("did:key:abc123")!
+        
+        let foo = Memo(
+            contentType: "text/subtext",
+            created: now,
+            modified: now,
+            fileExtension: "subtext",
+            additionalHeaders: [],
+            body: "Foo"
+        )
+        try service.writeMemo(
+            link: Link(
+                did: did,
+                slug: Slug("foo")!
+            ),
+            memo: foo
+        )
+        
+        // Contains link, should show up in results
+        let bar = Memo(
+            contentType: "text/subtext",
+            created: now,
+            modified: now,
+            fileExtension: "subtext",
+            additionalHeaders: [],
+            body: "Bar /foo should appear in results"
+        )
+        try service.writeMemo(
+            link: Link(
+                did: Did.local,
+                slug: Slug("bar")!
+            ),
+            memo: bar,
+            size: bar.toHeaderSubtext().size()!
+        )
+        
+        // Contains link, should show up in results
+        let baz = Memo(
+            contentType: "text/subtext",
+            created: now,
+            modified: now,
+            fileExtension: "subtext",
+            additionalHeaders: [],
+            body: "Baz /foo should appear in results"
+        )
+        try service.writeMemo(
+            link: Link(
+                did: did,
+                slug: Slug("baz")!
+            ),
+            memo: baz
+        )
+        
+        // Does not contain link, should not show up in results
+        let bing = Memo(
+            contentType: "text/subtext",
+            created: now,
+            modified: now,
+            fileExtension: "subtext",
+            additionalHeaders: [],
+            body: "Bing"
+        )
+        try service.writeMemo(
+            link: Link(
+                did: did,
+                slug: Slug("bing")!
+            ),
+            memo: bing
+        )
+        
+        // Write fake sphere sync info so we can purge it
+        try service.writeSphereSyncInfo(
+            sphereIdentity: did,
+            version: "bafyxyz123"
+        )
+        
+        try service.purgeSphere(did: did)
+        
+        let syncInfo = try service.readSphereSyncInfo(sphereIdentity: did)
+        XCTAssertNil(syncInfo)
+        
+        let recent = try service.listRecentMemos(owner: did)
+        XCTAssertEqual(recent.count, 1)
+        XCTAssertEqual(
+            recent.first?.address,
+            Slashlink(
+                peer: Peer.did(Did.local),
+                slug: Slug("bar")!
+            )
         )
     }
 }


### PR DESCRIPTION
This PR adds functions to:

- Index any followed sphere in database
- Purge any sphere by did from database
- Purge any sphere you follow by petname from database

This should give us the methods we need to implement indexing/purging on follow/unfollow. Note this PR only creates the methods, it does not yet implement indexing/purging in the app.

Precursor to #323 #363 #551 

TODO:

- [x] Implement `Dataservice.indexSphere(_ sphere: Sphere)`
  - [x] Use this to implement sphere indexing (sphere->database sync).
  - [x] Change method names
  - [x] Change action names
- [x] Implement `Database.purgeSphere(_ did: Did)`
- [x] Implement `DataService.purgeSphere(petname: Petname)`
- [x] Tests