### PR TITLE
Change user-facing instances of "local" to "draft"

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/Audience/AudienceMenuButtonView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Audience/AudienceMenuButtonView.swift
@@ -23,7 +23,9 @@ struct AudienceMenuButtonView: View {
                         }
                     ) {
                         Label(
-                            title: { Text(Audience.local.description) },
+                            title: {
+                                Text(verbatim: Audience.local.userDescription)
+                            },
                             icon: { Image(audience: .local) }
                         )
                     }
@@ -33,7 +35,9 @@ struct AudienceMenuButtonView: View {
                         }
                     ) {
                         Label(
-                            title: { Text(Audience.public.description) },
+                            title: {
+                                Text(verbatim: Audience.public.userDescription)
+                            },
                             icon: { Image(audience: .public) }
                         )
                     }
@@ -42,7 +46,7 @@ struct AudienceMenuButtonView: View {
             label: {
                 MenuButtonView(
                     icon: Image(audience: audience),
-                    label: audience.description
+                    label: audience.userDescription
                 )
                 .frame(width: width)
             }

--- a/xcode/Subconscious/Shared/Components/Common/Suggestion/SuggestionLabelView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Suggestion/SuggestionLabelView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct SuggestionCreateHeading: View {
+    var label: String
     var fallback: String
 
     private var preview: String {
@@ -17,13 +18,13 @@ struct SuggestionCreateHeading: View {
     var body: some View {
         if !preview.isEmpty {
             HStack {
-                Text("New note")
+                Text(label)
                 Text(verbatim: #""\#(preview)""#)
                     .foregroundColor(.secondary)
             }
         } else {
             HStack {
-                Text("New note")
+                Text(label)
             }
         }
     }
@@ -31,7 +32,6 @@ struct SuggestionCreateHeading: View {
 
 struct SuggestionLabelView: View, Equatable {
     var suggestion: Suggestion
-    var empty = String(localized: "Empty note")
 
     var body: some View {
         switch suggestion {
@@ -40,7 +40,9 @@ struct SuggestionLabelView: View, Equatable {
                 title: {
                     TitleGroupView(
                         title: Text(
-                            verbatim: !title.isEmpty ? title : empty
+                            verbatim: !title.isEmpty ?
+                                title :
+                                String(localized: "Empty note")
                         ),
                         subtitle: SlashlinkDisplayView(slashlink: address)
                             .theme(base: .secondary, slug: .secondary)
@@ -54,8 +56,11 @@ struct SuggestionLabelView: View, Equatable {
             Label(
                 title: {
                     TitleGroupView(
-                        title: SuggestionCreateHeading(fallback: fallback),
-                        subtitle: Text("Local note")
+                        title: SuggestionCreateHeading(
+                            label: String(localized: "New draft"),
+                            fallback: fallback
+                        ),
+                        subtitle: Text("Private draft")
                     )
                 },
                 icon: {
@@ -66,7 +71,10 @@ struct SuggestionLabelView: View, Equatable {
             Label(
                 title: {
                     TitleGroupView(
-                        title: SuggestionCreateHeading(fallback: fallback),
+                        title: SuggestionCreateHeading(
+                            label: String(localized: "New note"),
+                            fallback: fallback
+                        ),
                         subtitle: Text("Public note")
                     )
                 },

--- a/xcode/Subconscious/Shared/Models/Audience.swift
+++ b/xcode/Subconscious/Shared/Models/Audience.swift
@@ -9,21 +9,35 @@ import Foundation
 
 /// Model enumerating the possible audience/scopes for a piece of content.
 /// Right now we only have two: local-only draft or fully public
-enum Audience: String, Codable {
+enum Audience: String, Codable, CustomStringConvertible {
     /// A local-only draft
     case local = "local"
     /// Public sphere content
     case `public` = "public"
-}
-
-extension Audience: CustomStringConvertible {
-    var description: String {
+    
+    /// The user-facing description of this value.
+    /// For users, we index on the value proposition, not the implementation
+    /// detail of where the note is stored.
+    ///
+    /// - `.local` is draft
+    /// - `.public` is public
+    var userDescription: String {
         switch self {
         case .local:
-            return "Local"
+            return String(localized: "Draft")
         case .public:
-            return "Everyone"
+            return String(localized: "Public")
         }
+    }
+}
+
+extension Audience: LosslessStringConvertible {
+    var description: String {
+        self.rawValue
+    }
+    
+    init?(_ description: String) {
+        self.init(rawValue: description)
     }
 }
 

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		B83B19A92A0183AA007657D9 /* Tests_Did+SubconsciousLocal.swift in Sources */ = {isa = PBXBuildFile; fileRef = B83B19A82A0183AA007657D9 /* Tests_Did+SubconsciousLocal.swift */; };
 		B83E91D727692EC600045C6A /* FAB.swift in Sources */ = {isa = PBXBuildFile; fileRef = B83E91D627692EC600045C6A /* FAB.swift */; };
 		B83E91D827692EC600045C6A /* FAB.swift in Sources */ = {isa = PBXBuildFile; fileRef = B83E91D627692EC600045C6A /* FAB.swift */; };
+		B840CCC72A0C1F840000C025 /* Tests_Audience.swift in Sources */ = {isa = PBXBuildFile; fileRef = B840CCC62A0C1F840000C025 /* Tests_Audience.swift */; };
 		B848FDAA2991837900245115 /* DeveloperSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B848FDA82991836900245115 /* DeveloperSettingsView.swift */; };
 		B84AD8DF280F3659006B3153 /* Tests_EntryLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84AD8DE280F3659006B3153 /* Tests_EntryLink.swift */; };
 		B84AD8E1280F7A19006B3153 /* Tests_StringUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84AD8E0280F7A19006B3153 /* Tests_StringUtilities.swift */; };
@@ -508,6 +509,7 @@
 		B83B19A42A015D93007657D9 /* Tests_Did.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tests_Did.swift; sourceTree = "<group>"; };
 		B83B19A82A0183AA007657D9 /* Tests_Did+SubconsciousLocal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tests_Did+SubconsciousLocal.swift"; sourceTree = "<group>"; };
 		B83E91D627692EC600045C6A /* FAB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FAB.swift; sourceTree = "<group>"; };
+		B840CCC62A0C1F840000C025 /* Tests_Audience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_Audience.swift; sourceTree = "<group>"; };
 		B848FDA82991836900245115 /* DeveloperSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperSettingsView.swift; sourceTree = "<group>"; };
 		B84AD8DE280F3659006B3153 /* Tests_EntryLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_EntryLink.swift; sourceTree = "<group>"; };
 		B84AD8E0280F7A19006B3153 /* Tests_StringUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_StringUtilities.swift; sourceTree = "<group>"; };
@@ -842,6 +844,7 @@
 				B5432B8229F8BAED003BBB23 /* Tests_UserProfileService.swift */,
 				B5908BEA29DAB05B00225B1A /* TestUtilities.swift */,
 				B80890A92A0693C40087E091 /* Tests_HeaderSubtext.swift */,
+				B840CCC62A0C1F840000C025 /* Tests_Audience.swift */,
 			);
 			path = SubconsciousTests;
 			sourceTree = "<group>";
@@ -1551,6 +1554,7 @@
 				B88CC956284FCF8C00994928 /* Tests_DatabaseService.swift in Sources */,
 				B8D328BA29A69D2D00850A37 /* Tests_URLUtilities.swift in Sources */,
 				B831BDB72824DA9700C4CE92 /* Tests_Tape.swift in Sources */,
+				B840CCC72A0C1F840000C025 /* Tests_Audience.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/xcode/Subconscious/SubconsciousTests/Tests_Audience.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Audience.swift
@@ -1,0 +1,27 @@
+//
+//  Tests_Audience.swift
+//  SubconsciousTests
+//
+//  Created by Gordon Brander on 5/10/23.
+//
+
+import XCTest
+@testable import Subconscious
+
+final class Tests_Audience: XCTestCase {
+    func testAudienceUserDescription() throws {
+        let local = Audience.local
+        XCTAssertEqual(local.userDescription, "Draft")
+        
+        let `public` = Audience.public
+        XCTAssertEqual(`public`.userDescription, "Public")
+    }
+    
+    func testAudienceLosslessStringConvertible() throws {
+        let local = Audience("local")
+        XCTAssertEqual(local, Audience.local)
+        
+        let `public` = Audience("public")
+        XCTAssertEqual(`public`, Audience.public)
+    }
+}


### PR DESCRIPTION
Fixes #605

While the domain model still thinks in "sphere" and "local" scopes, we use "public" and "draft" to refer to these concepts when speaking to the user. "Local" is an implementation detail. "Draft" more closely matches user intent (see #519).

<img src="https://github.com/subconsciousnetwork/subconscious/assets/58421/a7ab9038-4c4b-4d4b-8717-bc5f825af6b5" width="320">

<img src="https://github.com/subconsciousnetwork/subconscious/assets/58421/b6186f79-c21b-486f-b488-0e2f7d6c4770" width="320">
