### PR TITLE
Fix unresponsive toolbar icons

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -60,6 +60,7 @@ struct AppView: View {
             )
         ) {
             SettingsView(app: store)
+                .presentationDetents([.fraction(0.999)]) // https://stackoverflow.com/a/74631815
         }
         .onAppear {
             store.send(.appear)


### PR DESCRIPTION
Fixes #550 

This appears to be a longstanding bug in SwiftUI:
- https://stackoverflow.com/questions/58512344/swiftui-navigation-bar-button-not-clickable-after-sheet-has-been-presented
- https://stackoverflow.com/questions/60026248/swiftui-tap-target-for-navigation-bar-button-misaligned-after-dismissing-a-shee

The only fix that worked for me is https://stackoverflow.com/a/74631815 which is extremely hacky but works on-device.