### PR TITLE
Update Noosphere to d8488b68...

### DIFF
--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -2432,7 +2432,7 @@
 			repositoryURL = "https://github.com/subconsciousnetwork/noosphere";
 			requirement = {
 				kind = revision;
-				revision = 6d87f8d4413a51f0b18106e5e39c46d55eaeaa31;
+				revision = d8488b68bdd68a1ffc0f2d7f00fa29d6f6cb8e56;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/subconsciousnetwork/noosphere",
       "state" : {
-        "revision" : "6d87f8d4413a51f0b18106e5e39c46d55eaeaa31"
+        "revision" : "d8488b68bdd68a1ffc0f2d7f00fa29d6f6cb8e56"
       }
     },
     {


### PR DESCRIPTION
New revision:
d8488b68bdd68a1ffc0f2d7f00fa29d6f6cb8e56

Contains fix for sphere traversal.

Note from @cdata:

> After I cleaned up your test, it turned out the original
bug we found after play testing had been fixed, but your test uncovered a second bug where traversing to a
second-order sphere was done with the wrong "origin" sphere, which lead the HTTP client to try to handshake as the wrong sphere (hence unable to look up gateway identity gateway is rejecting you)