### PR TITLE
Correctly resolve second-order(+) petnames

### DIFF
--- a/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
@@ -74,7 +74,8 @@ extension SphereProtocol {
             return slashlink
         case .petname(let petname):
             // Get did for petname
-            let did = try await self.getPetname(petname: petname)
+            let sphere = try await self.traverse(petname: petname)
+            let did = try await sphere.identity()
             // Return new slashlink with did root
             return Slashlink(
                 peer: .did(did),

--- a/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
@@ -74,8 +74,15 @@ extension SphereProtocol {
             return slashlink
         case .petname(let petname):
             // Get did for petname
-            let sphere = try await self.traverse(petname: petname)
-            let did = try await sphere.identity()
+            let did = try await Func.run {
+                do {
+                    return try await self.getPetname(petname: petname)
+                } catch {
+                    let sphere = try await self.traverse(petname: petname)
+                    return try await sphere.identity()
+                }
+            }
+            
             // Return new slashlink with did root
             return Slashlink(
                 peer: .did(did),


### PR DESCRIPTION
`getPetname` is a footgun, it only looks in the sphere's address book.

Fixes https://github.com/subconsciousnetwork/subconscious/issues/626