### PR TITLE
Persist nickname in profile memo during onboarding

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -796,9 +796,6 @@ struct AppModel: ModelProtocol {
                     AppDefaults.standard.firstRunComplete
                 ),
                 .fetchNicknameFromProfile
-//                .setNickname(
-//                    AppDefaults.standard.nickname ?? state.nickname
-//                )
             ],
             environment: environment
         ).mergeFx(fx)

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -885,7 +885,7 @@ struct AppModel: ModelProtocol {
             logger.log("Nickname saved: \(validated)")
             
             return update(
-                state: state,
+                state: model,
                 action: .requestCreateInitialProfile(text),
                 environment: environment
             )

--- a/xcode/Subconscious/Shared/Models/Petname.swift
+++ b/xcode/Subconscious/Shared/Models/Petname.swift
@@ -19,6 +19,8 @@ public struct Petname:
     private static let petnameRegex = /([\w\d\-]+)(\.[\w\d\-]+)*/
     private static let numberedSuffixRegex = /^(?<petname>(.*?))(?<separator>-+)?(?<suffix>(\d+))?$/
     
+    public static let unknown = Petname("unknown")!
+    
     public static func < (lhs: Self, rhs: Self) -> Bool {
         lhs.id < rhs.id
     }

--- a/xcode/Subconscious/Shared/Services/AppDefaults.swift
+++ b/xcode/Subconscious/Shared/Services/AppDefaults.swift
@@ -14,10 +14,6 @@ struct AppDefaults {
     /// Are Noosphere features enabled for end-users?
     @UserDefaultsProperty(forKey: "isNoosphereEnabled")
     var isNoosphereEnabled = false
-
-    /// The user/sphere nickname.
-    @UserDefaultsProperty(forKey: "nickname")
-    var nickname: String? = nil
     
     @UserDefaultsProperty(forKey: "sphereIdentity")
     var sphereIdentity: String? = nil

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -305,7 +305,6 @@ actor UserProfileService {
             address: address,
             slugs: notes
         )
-        let topEntries = entries
         let recentEntries = sortEntriesByModified(entries: entries)
         
         let profile = try await self.loadProfileFromMemo(

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -328,13 +328,8 @@ actor UserProfileService {
     
     /// Retrieve all the content for the App User's profile view, fetching their profile, notes and address book.
     func requestOurProfile() async throws -> UserProfileContentResponse {
-        guard let nickname = AppDefaults.standard.nickname,
-              let nickname = Petname(nickname) else {
-                  throw UserProfileServiceError.missingPreferredPetname
-        }
-        
         let address = Slashlink.ourProfile
-        return try await loadProfileData(address: address, fallbackPetname: nickname)
+        return try await loadProfileData(address: address, fallbackPetname: Petname.unknown)
     }
     
     nonisolated func requestOwnProfilePublisher(

--- a/xcode/Subconscious/SubconsciousTests/Tests_UserProfileService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_UserProfileService.swift
@@ -13,8 +13,6 @@ final class Tests_UserProfileService: XCTestCase {
         let tmp = try TestUtilities.createTmpDir()
         let data = try await TestUtilities.createDataServiceEnvironment(tmp: tmp)
         
-        AppDefaults.standard.nickname = "test"
-        
         let memoA = Memo(
             contentType: ContentType.subtext.rawValue,
             created: Date.now,
@@ -65,8 +63,6 @@ final class Tests_UserProfileService: XCTestCase {
     func testFollowingListAddresses() async throws {
         let tmp = try TestUtilities.createTmpDir()
         let data = try await TestUtilities.createDataServiceEnvironment(tmp: tmp)
-        
-        AppDefaults.standard.nickname = "test"
         
         let _ = try await data.addressBook.followUser(
             did: Did("did:key:123")!,


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/631
Fixes https://github.com/subconsciousnetwork/subconscious/issues/559

# Changes

- Write to `_profile_` during onboarding so every user has a populated nickname
- Remove `AppDefaults.nickname`

# Questions

Should we also remove the Nickname field in the settings? It seems superfluous. We _could_ allow access to the same "Edit Profile" form via the settings view (in addition to editing from the "your profile" view) but two ways to edit something sets off my design spidey sense.