### PR TITLE
Implement keyboard submit navigation in First Run

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -508,6 +508,14 @@ struct AppModel: ModelProtocol {
             var model = state
             model.firstRunPath = path
             
+            if path.last == .nickname  {
+                return update(
+                    state: model,
+                    action: .createSphere,
+                    environment: environment
+                )
+            }
+            
             return Update(state: model)
         case let .pushFirstRunStep(step):
             var model = state

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -202,6 +202,9 @@ enum AppAction: CustomLogStringConvertible {
     case beginProvisionGateway(String)
     case completeProvisionGateway(URL)
     case failProvisionGateway(String)
+    
+    case setFirstRunPath([FirstRunStep])
+    case pushFirstRunStep(FirstRunStep)
 
     /// Set settings sheet presented?
     case presentSettingsSheet(_ isPresented: Bool)
@@ -329,6 +332,13 @@ enum AppDatabaseState {
     case ready
 }
 
+enum FirstRunStep {
+    case nickname
+    case sphere
+    case recovery
+    case connect
+}
+
 // MARK: Model
 struct AppModel: ModelProtocol {
     /// Is Noosphere enabled?
@@ -351,6 +361,7 @@ struct AppModel: ModelProtocol {
     /// update both the model property (triggering a view re-render)
     /// and persist the new value to UserDefaults.
     var isFirstRunComplete = false
+    var firstRunPath: [FirstRunStep] = []
 
     /// Should first run show?
     var shouldPresentFirstRun: Bool {
@@ -493,6 +504,16 @@ struct AppModel: ModelProtocol {
                 state: state,
                 environment: environment
             )
+        case let .setFirstRunPath(path):
+            var model = state
+            model.firstRunPath = path
+            
+            return Update(state: model)
+        case let .pushFirstRunStep(step):
+            var model = state
+            model.firstRunPath.append(step)
+            
+            return Update(state: model)
         case let .setAppUpgraded(isUpgraded):
             return setAppUpgraded(
                 state: state,
@@ -1145,6 +1166,7 @@ struct AppModel: ModelProtocol {
         AppDefaults.standard.firstRunComplete = isComplete
         var model = state
         model.isFirstRunComplete = isComplete
+        model.firstRunPath = []
         
         return Update(state: model).animation(.default)
     }

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -507,15 +507,6 @@ struct AppModel: ModelProtocol {
         case let .setFirstRunPath(path):
             var model = state
             model.firstRunPath = path
-            
-            if path.last == .nickname  {
-                return update(
-                    state: model,
-                    action: .createSphere,
-                    environment: environment
-                )
-            }
-            
             return Update(state: model)
         case let .pushFirstRunStep(step):
             var model = state

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -1174,7 +1174,11 @@ struct AppModel: ModelProtocol {
         AppDefaults.standard.firstRunComplete = isComplete
         var model = state
         model.isFirstRunComplete = isComplete
-        model.firstRunPath = []
+        
+        // Reset navigation
+        if !isComplete {
+            model.firstRunPath = []
+        }
         
         return Update(state: model).animation(.default)
     }

--- a/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
@@ -20,6 +20,9 @@ struct ValidatedTextField: View {
     var autoFocus: Bool = false
     @FocusState var focused: Bool
     
+    var submitLabel: SubmitLabel = .return
+    var onSubmit: () -> Void = { }
+    
     var backgroundColor = Color.background
     
     /// When appearing in a form the background colour of a should change
@@ -52,6 +55,10 @@ struct ValidatedTextField: View {
                 }
                 .onChange(of: focused) { focused in
                     onFocusChanged(focused)
+                }
+                .submitLabel(submitLabel)
+                .onSubmit {
+                    onSubmit()
                 }
                 .task {
                     if autoFocus {

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunDoneView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunDoneView.swift
@@ -58,51 +58,51 @@ struct FirstRunDoneView: View {
     }
 
     var body: some View {
-        NavigationStack {
-            VStack(spacing: AppTheme.padding * 4) {
-                Spacer()
-                Text(statusLabel)
+        VStack(spacing: AppTheme.padding * 4) {
+            Spacer()
+            Text(statusLabel)
                 .foregroundColor(.secondary)
-                StackedGlowingImage() {
-                    HStack(
-                        alignment: .center,
-                        spacing: AppTheme.unit2
-                    ) {
-                        if let did = did {
-                            GenerativeProfilePic(
-                                did: did,
-                                size: 64
-                            )
-                        }
-                        dottedLine
-                        ResourceSyncBadge(status: status)
-                        dottedLine
-                        Image("ns_logo")
-                            .resizable()
-                            .frame(width: 80, height: 80)
-                            .offset(x: -5) // account for padding in image
-                    }
-                    .frame(height: 64)
-                }
-                Text(guidanceLabel)
-                    .foregroundColor(.secondary)
-                Spacer()
-                Button(
-                    action: {
-                        app.send(.persistFirstRunComplete(true))
-                    }
+            StackedGlowingImage() {
+                HStack(
+                    alignment: .center,
+                    spacing: AppTheme.unit2
                 ) {
-                    Text("Begin")
+                    if let did = did {
+                        GenerativeProfilePic(
+                            did: did,
+                            size: 64
+                        )
+                    }
+                    dottedLine
+                    ResourceSyncBadge(status: status)
+                    dottedLine
+                    Image("ns_logo")
+                        .resizable()
+                        .frame(width: 80, height: 80)
+                        .offset(x: -5) // account for padding in image
                 }
-                .buttonStyle(PillButtonStyle())
-                .disabled(app.state.sphereIdentity == nil)
+                .frame(height: 64)
             }
-            .padding()
-            .background(
-                AppTheme.onboarding
-                    .appBackgroundGradient(colorScheme)
-            )
+            Text(guidanceLabel)
+                .foregroundColor(.secondary)
+            Spacer()
+            Button(
+                action: {
+                    app.send(.persistFirstRunComplete(true))
+                }
+            ) {
+                Text("Begin")
+            }
+            .buttonStyle(PillButtonStyle())
+            .disabled(app.state.sphereIdentity == nil)
         }
+        .padding()
+        .navigationTitle("Done")
+        .navigationBarTitleDisplayMode(.inline)
+        .background(
+            AppTheme.onboarding
+                .appBackgroundGradient(colorScheme)
+        )
     }
 }
 

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
@@ -34,7 +34,9 @@ struct FirstRunProfileView: View {
                     autoFocus: true,
                     submitLabel: .continue,
                     onSubmit: {
-                        app.send(.pushFirstRunStep(.sphere))
+                        if app.state.nicknameFormField.isValid {
+                            app.send(.pushFirstRunStep(.sphere))
+                        }
                     }
                 )
                 .textFieldStyle(.roundedBorder)

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
@@ -13,60 +13,60 @@ struct FirstRunProfileView: View {
     @Environment(\.colorScheme) var colorScheme
     
     var body: some View {
-        NavigationStack {
-            VStack(spacing: AppTheme.padding) {
-                Spacer()
-                Text("What should we call you?")
-                    .foregroundColor(.secondary)
-                VStack(alignment: .leading, spacing: AppTheme.unit4) {
-                    ValidatedTextField(
-                        alignment: .center,
-                        placeholder: "nickname",
-                        text: Binding(
-                            get: { app.state.nicknameFormFieldValue },
-                            send: app.send,
-                            tag: AppAction.setNickname
-                        ),
-                        onFocusChanged: { focused in
-                            app.send(.nicknameFormField(.focusChange(focused: focused)))
-                        },
-                        caption: "Lowercase letters, numbers and dashes only.",
-                        hasError: !app.state.isNicknameFormFieldValid,
-                        autoFocus: true
-                    )
-                    .textFieldStyle(.roundedBorder)
-                    .textInputAutocapitalization(.never)
-                    .disableAutocorrection(true)
-                    .shadow(
-                        color: AppTheme.onboarding
-                            .shadow(colorScheme).opacity(1),
-                        radius: AppTheme.onboarding.shadowSize
-                    )
-                }
-                
-                Spacer()
-                
-                if !app.state.nicknameFormField.hasFocus {
-                    NavigationLink(
-                        destination: {
-                            FirstRunSphereView(app: app)
-                        },
-                        label: {
-                            Text("Continue")
-                        }
-                    )
-                    .buttonStyle(PillButtonStyle())
-                    .disabled(!app.state.isNicknameFormFieldValid)
-                }
+        VStack(spacing: AppTheme.padding) {
+            Spacer()
+            Text("What should we call you?")
+                .foregroundColor(.secondary)
+            VStack(alignment: .leading, spacing: AppTheme.unit4) {
+                ValidatedTextField(
+                    alignment: .center,
+                    placeholder: "nickname",
+                    text: Binding(
+                        get: { app.state.nicknameFormFieldValue },
+                        send: app.send,
+                        tag: AppAction.setNickname
+                    ),
+                    onFocusChanged: { focused in
+                        app.send(.nicknameFormField(.focusChange(focused: focused)))
+                    },
+                    caption: "Lowercase letters, numbers and dashes only.",
+                    hasError: !app.state.isNicknameFormFieldValid,
+                    autoFocus: true,
+                    submitLabel: .continue,
+                    onSubmit: {
+                        app.send(.pushFirstRunStep(.sphere))
+                    }
+                )
+                .textFieldStyle(.roundedBorder)
+                .textInputAutocapitalization(.never)
+                .disableAutocorrection(true)
+                .shadow(
+                    color: AppTheme.onboarding
+                        .shadow(colorScheme).opacity(1),
+                    radius: AppTheme.onboarding.shadowSize
+                )
             }
-            .padding()
-            .navigationTitle("Your Profile")
-            .navigationBarTitleDisplayMode(.inline)
-            .background(
-                AppTheme.onboarding
-                    .appBackgroundGradient(colorScheme)
-            )
+            
+            Spacer()
+            
+            if !app.state.nicknameFormField.hasFocus {
+                NavigationLink(
+                    value: FirstRunStep.sphere,
+                    label: {
+                        Text("Continue")
+                    }
+                )
+                .buttonStyle(PillButtonStyle())
+                .disabled(!app.state.isNicknameFormFieldValid)
+            }
         }
+        .padding()
+        .navigationTitle("Your Profile")
+        .navigationBarTitleDisplayMode(.inline)
+        .background(
+            AppTheme.onboarding
+                .appBackgroundGradient(colorScheme)
+        )
     }
 }
 

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunRecoveryView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunRecoveryView.swift
@@ -17,47 +17,43 @@ struct FirstRunRecoveryView: View {
     }
     
     var body: some View {
-        NavigationStack {
-            VStack(spacing: AppTheme.padding) {
-                Spacer()
+        VStack(spacing: AppTheme.padding) {
+            Spacer()
+        
+            Text("This is your secret recovery phrase. You can use it to recover your data if you lose access.")
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
             
-                Text("This is your secret recovery phrase. You can use it to recover your data if you lose access.")
-                    .foregroundColor(.secondary)
-                    .multilineTextAlignment(.center)
-                
-                RecoveryPhraseView(
-                    state: app.state.recoveryPhrase,
-                    send: Address.forward(
-                        send: app.send,
-                        tag: AppRecoveryPhraseCursor.tag
-                    )
+            RecoveryPhraseView(
+                state: app.state.recoveryPhrase,
+                send: Address.forward(
+                    send: app.send,
+                    tag: AppRecoveryPhraseCursor.tag
                 )
-                .shadow(
-                    color: AppTheme.onboarding
-                        .shadow(colorScheme).opacity(0.5),
-                    radius: AppTheme.onboarding.shadowSize
-                )
-                
-                Text("It's for your eyes only. We don't store it.\n Write it down or add it to your password manager. Keep it secret, keep it safe.")
-                    .foregroundColor(.secondary)
-                    .multilineTextAlignment(.center)
-                Spacer()
-                NavigationLink(
-                    destination: {
-                        FirstRunDoneView(app: app)
-                    },
-                    label: {
-                        Text("Ok, I wrote it down")
-                    }
-                )
-                .buttonStyle(PillButtonStyle())
-            }
-            .padding()
-            .background(
-                AppTheme.onboarding
-                    .appBackgroundGradient(colorScheme)
             )
+            .shadow(
+                color: AppTheme.onboarding
+                    .shadow(colorScheme).opacity(0.5),
+                radius: AppTheme.onboarding.shadowSize
+            )
+            
+            Text("It's for your eyes only. We don't store it.\n Write it down or add it to your password manager. Keep it secret, keep it safe.")
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+            Spacer()
+            NavigationLink(
+                value: FirstRunStep.connect,
+                label: {
+                    Text("Ok, I wrote it down")
+                }
+            )
+            .buttonStyle(PillButtonStyle())
         }
+        .padding()
+        .background(
+            AppTheme.onboarding
+                .appBackgroundGradient(colorScheme)
+        )
         .navigationTitle("Recovery Phrase")
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunSphereView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunSphereView.swift
@@ -16,56 +16,52 @@ struct FirstRunSphereView: View {
     }
     
     var body: some View {
-        NavigationStack {
-            VStack {
-                Spacer()
-                VStack(spacing: AppTheme.padding) {
-                    if let name = app.state.nicknameFormField.validated  {
-                        HStack(spacing: 0) {
-                            Text("Hi, ")
-                                .foregroundColor(.secondary)
-                            PetnameView(nickname: name)
-                            Text(".")
-                                .foregroundColor(.secondary)
-                        }
+        VStack {
+            Spacer()
+            VStack(spacing: AppTheme.padding) {
+                if let name = app.state.nicknameFormField.validated  {
+                    HStack(spacing: 0) {
+                        Text("Hi, ")
+                            .foregroundColor(.secondary)
+                        PetnameView(nickname: name)
+                        Text(".")
+                            .foregroundColor(.secondary)
                     }
-                    
-                    if let did = did {
-                        StackedGlowingImage() {
-                            GenerativeProfilePic(
-                                did: did,
-                                size: 80
-                            )
-                        }
-                        .padding(AppTheme.padding)
-                    }
-                    
-                    Text("This is your sphere. It stores your data.")
-                        .foregroundColor(.secondary)
-                    
-                    Text("Your sphere connects to Noosphere allowing you to explore and follow other spheres.")
-                        .foregroundColor(.secondary)
                 }
-                .multilineTextAlignment(.center)
                 
-                Spacer()
-                
-                NavigationLink(
-                    destination: {
-                        FirstRunRecoveryView(app: app)
-                    },
-                    label: {
-                        Text("Got it")
+                if let did = did {
+                    StackedGlowingImage() {
+                        GenerativeProfilePic(
+                            did: did,
+                            size: 80
+                        )
                     }
-                )
-                .buttonStyle(PillButtonStyle())
+                    .padding(AppTheme.padding)
+                }
+                
+                Text("This is your sphere. It stores your data.")
+                    .foregroundColor(.secondary)
+                
+                Text("Your sphere connects to Noosphere allowing you to explore and follow other spheres.")
+                    .foregroundColor(.secondary)
             }
-            .padding()
-            .background(
-                AppTheme.onboarding
-                    .appBackgroundGradient(colorScheme)
+            .multilineTextAlignment(.center)
+            
+            Spacer()
+            
+            NavigationLink(
+                value: FirstRunStep.recovery,
+                label: {
+                    Text("Got it")
+                }
             )
+            .buttonStyle(PillButtonStyle())
         }
+        .padding()
+        .background(
+            AppTheme.onboarding
+                .appBackgroundGradient(colorScheme)
+        )
         .navigationTitle("Your Sphere")
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
@@ -82,11 +82,6 @@ struct FirstRunView: View {
                     )
                     .buttonStyle(PillButtonStyle())
                     .disabled(!app.state.inviteCodeFormField.isValid)
-                    // TODO: do this in the model
-                    .simultaneousGesture(TapGesture().onEnded {
-                        app.send(.createSphere)
-                    })
-                        
                 }
                 
                 // MARK: Use Offline
@@ -102,10 +97,6 @@ struct FirstRunView: View {
                                 .font(.caption)
                         }
                     )
-                    // TODO: do this in the model
-                    .simultaneousGesture(TapGesture().onEnded {
-                        app.send(.createSphere)
-                    })
                 }
                 .padding(
                     .init(

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
@@ -61,7 +61,9 @@ struct FirstRunView: View {
                     hasError: app.state.inviteCodeFormField.hasError,
                     submitLabel: .continue,
                     onSubmit: {
-                        app.send(.pushFirstRunStep(.nickname))
+                        if app.state.inviteCodeFormField.isValid {
+                            app.send(.pushFirstRunStep(.nickname))
+                        }
                     }
                 )
                 .textFieldStyle(.roundedBorder)

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
@@ -128,6 +128,9 @@ struct FirstRunView: View {
                     FirstRunDoneView(app: app)
                 }
             }
+            .onAppear {
+                app.send(.createSphere)
+            }
         }
     }
 }


### PR DESCRIPTION
Moved the FirstRun navigation path into the store and used that to implement keyboard navigation. The diff is very noisy but most views are unchanged, just removed the wrapping NavigationStack from every step past the welcome view.

# Changes
- Introduce `submitLabel` and `onSubmit` fields to `ValidatedTextField`
- Implement navigation using `onSubmit`
- Move `.createSphere` logic into the model

Fixes #620 