### PR TITLE
Clear invite code after provisioning

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -1514,7 +1514,8 @@ struct AppModel: ModelProtocol {
             state: model,
             actions: [
                 .submitGatewayURL(url.absoluteString),
-                .syncSphereWithGateway
+                .syncSphereWithGateway,
+                .inviteCodeFormField(.reset)
             ],
             environment: environment
         )
@@ -1528,7 +1529,12 @@ struct AppModel: ModelProtocol {
         logger.error("Failed to provision gateway: \(error)")
         var model = state
         model.gatewayProvisioningStatus = .failed(error)
-        return Update(state: model)
+        
+        return update(
+            state: model,
+            action: .inviteCodeFormField(.reset),
+            environment: environment
+        )
     }
 }
 

--- a/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
@@ -121,6 +121,7 @@ struct GatewayURLSettingsView: View {
                     .onDisappear {
                         app.send(.setInviteCode(app.state.inviteCodeFormField.value))
                     }
+                    .disabled(app.state.gatewayProvisioningStatus == .pending)
                     
                     Button(
                         action: {


### PR DESCRIPTION
- Reset invite code field after gateway provisioning
- Prevent editing the invite code while provisioning

We clear the code in the case of failure or success because it is consumed upfront. We should persist the gateway ID separately to help with the unhappy path: https://github.com/subconsciousnetwork/subconscious/issues/643

Fixes https://github.com/subconsciousnetwork/subconscious/issues/607