### PR TITLE
Introduce strict validation constructor for URL

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -95,7 +95,7 @@ struct EditProfileSheetModel: ModelProtocol {
     var pfpUrlField: FormField<String, URL> = FormField(
         value: "",
         validate: { value in
-            URL(validatedString: value)
+            URL(validating: value)
         }
     )
     

--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -95,7 +95,7 @@ struct EditProfileSheetModel: ModelProtocol {
     var pfpUrlField: FormField<String, URL> = FormField(
         value: "",
         validate: { value in
-            URL(string: value)
+            URL(validatedString: value)
         }
     )
     

--- a/xcode/Subconscious/Shared/Library/URLUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/URLUtilities.swift
@@ -8,6 +8,37 @@
 import Foundation
 
 extension URL {
+    /// Attempt to construct a URL from the passed string and validate its components
+    /// This will only allow http & https URLs with a full hostname
+    init?(validatedString string: String) {
+        guard let url = URL(string: string) else {
+            return nil
+        }
+        
+        var components = URLComponents()
+        components.scheme = url.scheme
+        components.host = url.host
+        components.path = url.path
+        
+        guard let scheme = components.scheme,
+              ["http", "https"].contains(scheme.lowercased()) else {
+            return nil
+        }
+        guard components.host != nil else {
+            return nil
+        }
+        
+        if components.path.isEmpty {
+            components.path = "/"
+        }
+        
+        guard let validatedUrl = components.url else {
+            return nil
+        }
+        
+        self = validatedUrl
+    }
+    
     /// Check if URL is HTTP or HTTPs
     func isHTTP() -> Bool {
         return self.scheme == "http" || self.scheme == "https"

--- a/xcode/Subconscious/Shared/Library/URLUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/URLUtilities.swift
@@ -10,33 +10,20 @@ import Foundation
 extension URL {
     /// Attempt to construct a URL from the passed string and validate its components
     /// This will only allow http & https URLs with a full hostname
-    init?(validatedString string: String) {
+    init?(validating string: String) {
         guard let url = URL(string: string) else {
             return nil
         }
         
-        var components = URLComponents()
-        components.scheme = url.scheme
-        components.host = url.host
-        components.path = url.path
-        
-        guard let scheme = components.scheme,
-              ["http", "https"].contains(scheme.lowercased()) else {
-            return nil
-        }
-        guard components.host != nil else {
+        guard url.isHTTP() else {
             return nil
         }
         
-        if components.path.isEmpty {
-            components.path = "/"
-        }
-        
-        guard let validatedUrl = components.url else {
+        guard (url.host ?? "").count > 0 else {
             return nil
         }
         
-        self = validatedUrl
+        self = url
     }
     
     /// Check if URL is HTTP or HTTPs

--- a/xcode/Subconscious/SubconsciousTests/Tests_URLUtilities.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_URLUtilities.swift
@@ -30,6 +30,14 @@ final class Tests_URLUtilities: XCTestCase {
         XCTAssertEqual(url?.absoluteString, urlString)
     }
     
+    func testSchemeOnly() {
+        let a = URL(validatedString: "http:")
+        XCTAssertNil(a)
+        
+        let b = URL(validatedString: "https:")
+        XCTAssertNil(b)
+    }
+    
     func testInvalidURL() {
         let urlString = "not a url"
         let url = URL(validatedString: urlString)

--- a/xcode/Subconscious/SubconsciousTests/Tests_URLUtilities.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_URLUtilities.swift
@@ -22,4 +22,36 @@ final class Tests_URLUtilities: XCTestCase {
         let urlD = URL(string: "file://example.com")!
         XCTAssertFalse(urlD.isHTTP())
     }
+    
+    func testValidURL() {
+        let urlString = "https://example.com/image.jpg"
+        let url = URL(validatedString: urlString)
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url?.absoluteString, urlString)
+    }
+    
+    func testInvalidURL() {
+        let urlString = "not a url"
+        let url = URL(validatedString: urlString)
+        XCTAssertNil(url)
+    }
+    
+    func testInvalidScheme() {
+        let urlString = "ftp://example.com/image.jpg"
+        let url = URL(validatedString: urlString)
+        XCTAssertNil(url)
+    }
+    
+    func testMissingHost() {
+        let urlString = "https:///image.jpg"
+        let url = URL(validatedString: urlString)
+        XCTAssertNil(url)
+    }
+    
+    func testMissingPath() {
+        let urlString = "https://example.com"
+        let url = URL(validatedString: urlString)
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url?.absoluteString, urlString + "/")
+    }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_URLUtilities.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_URLUtilities.swift
@@ -30,8 +30,8 @@ final class Tests_URLUtilities: XCTestCase {
         XCTAssertEqual(url?.absoluteString, urlString)
     }
     
-    func testPreservesQueryAndFragment() {
-        let urlString = "https://example.com/image.jpg?q=123#hello"
+    func testPreservesUrlComponents() {
+        let urlString = "https://example.com:8080/image.jpg?q=123#hello"
         let url = URL(validating: urlString)
         XCTAssertNotNil(url)
         XCTAssertEqual(url?.absoluteString, urlString)
@@ -65,6 +65,13 @@ final class Tests_URLUtilities: XCTestCase {
     
     func testMissingPath() {
         let urlString = "https://example.com"
+        let url = URL(validating: urlString)
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url?.absoluteString, urlString)
+    }
+    
+    func testPort() {
+        let urlString = "https://example.com:8080"
         let url = URL(validating: urlString)
         XCTAssertNotNil(url)
         XCTAssertEqual(url?.absoluteString, urlString)

--- a/xcode/Subconscious/SubconsciousTests/Tests_URLUtilities.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_URLUtilities.swift
@@ -25,41 +25,55 @@ final class Tests_URLUtilities: XCTestCase {
     
     func testValidURL() {
         let urlString = "https://example.com/image.jpg"
-        let url = URL(validatedString: urlString)
+        let url = URL(validating: urlString)
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url?.absoluteString, urlString)
+    }
+    
+    func testPreservesQueryAndFragment() {
+        let urlString = "https://example.com/image.jpg?q=123#hello"
+        let url = URL(validating: urlString)
         XCTAssertNotNil(url)
         XCTAssertEqual(url?.absoluteString, urlString)
     }
     
     func testSchemeOnly() {
-        let a = URL(validatedString: "http:")
+        let a = URL(validating: "http:")
         XCTAssertNil(a)
         
-        let b = URL(validatedString: "https:")
+        let b = URL(validating: "https:")
         XCTAssertNil(b)
     }
     
     func testInvalidURL() {
         let urlString = "not a url"
-        let url = URL(validatedString: urlString)
+        let url = URL(validating: urlString)
         XCTAssertNil(url)
     }
     
     func testInvalidScheme() {
         let urlString = "ftp://example.com/image.jpg"
-        let url = URL(validatedString: urlString)
+        let url = URL(validating: urlString)
         XCTAssertNil(url)
     }
     
     func testMissingHost() {
         let urlString = "https:///image.jpg"
-        let url = URL(validatedString: urlString)
+        let url = URL(validating: urlString)
         XCTAssertNil(url)
     }
     
     func testMissingPath() {
         let urlString = "https://example.com"
-        let url = URL(validatedString: urlString)
+        let url = URL(validating: urlString)
         XCTAssertNotNil(url)
-        XCTAssertEqual(url?.absoluteString, urlString + "/")
+        XCTAssertEqual(url?.absoluteString, urlString)
+    }
+    
+    func testIpAddress() {
+        let urlString = "https://127.0.0.1"
+        let url = URL(validating: urlString)
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url?.absoluteString, urlString)
     }
 }


### PR DESCRIPTION
Introduce a new URL extension that is stricter than the default `URL(string:)` init. 

Fixes https://github.com/subconsciousnetwork/subconscious/issues/588

(Trivia: I generated this with copilot chat, including the tests! The tests failed at first but after telling it that it produced working code)