### PR TITLE
Process user profile bio before reading or writing JSON

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -89,7 +89,7 @@ struct EditProfileSheetModel: ModelProtocol {
     var bioField: FormField<String, String> = FormField(
         value: "",
         validate: { value in
-            value.count >= 280 ? nil : value
+            value.count > 280 ? nil : value
         }
     )
     var pfpUrlField: FormField<String, URL> = FormField(
@@ -174,7 +174,7 @@ struct EditProfileSheet: View {
             nickname: nickname,
             address: user.address,
             pfp: pfp,
-            bio: state.bioField.validated ?? "",
+            bio: UserProfileBio(state.bioField.validated ?? ""),
             category: .you
         )
     }

--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -250,7 +250,6 @@ struct EditProfileSheet: View {
                             axis: .vertical
                         )
                         .formField()
-                        .lineLimit(3)
                         .textInputAutocapitalization(.never)
                         .disableAutocorrection(true)
                     }

--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -89,7 +89,7 @@ struct EditProfileSheetModel: ModelProtocol {
     var bioField: FormField<String, String> = FormField(
         value: "",
         validate: { value in
-            value.count > 280 ? nil : value
+            value.fitsInUserBio ? value : nil
         }
     )
     var pfpUrlField: FormField<String, URL> = FormField(
@@ -120,7 +120,7 @@ struct EditProfileSheetModel: ModelProtocol {
                     .pfpUrlField(.reset),
                     .nicknameField(.setValue(input: user?.nickname ?? "")),
                     .bioField(.setValue(input: user?.bio ?? "")),
-                    .pfpUrlField(.setValue(input: user?.profilePictureUrl ?? "")),
+                    .pfpUrlField(.setValue(input: user?.profilePictureUrl ?? ""))
                 ],
                 environment: environment
             )

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
@@ -84,7 +84,7 @@ struct UserProfileHeaderView: View {
             }
             
             if user.bio.hasVisibleContent {
-                Text(verbatim: user.bio.bio)
+                Text(verbatim: user.bio.verbatim)
             }
         }
     }

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
@@ -83,8 +83,8 @@ struct UserProfileHeaderView: View {
                 )
             }
             
-            if user.bio.count > 0 {
-                Text(verbatim: user.bio)
+            if user.bio.hasVisibleContent {
+                Text(verbatim: user.bio.bio)
             }
         }
     }
@@ -99,7 +99,7 @@ struct BylineLgView_Previews: PreviewProvider {
                     nickname: Petname("ben")!,
                     address: Slashlink(petname: Petname("ben")!),
                     pfp: .image("pfp-dog"),
-                    bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber in a traddlewaddle.",
+                    bio: UserProfileBio("Ploofy snooflewhumps burbled, outflonking the zibber-zabber in a traddlewaddle."),
                     category: .human
                 ),
                 isFollowingUser: false
@@ -110,7 +110,7 @@ struct BylineLgView_Previews: PreviewProvider {
                     nickname: Petname("ben")!,
                     address: Slashlink(petname: Petname("ben")!),
                     pfp: .image("pfp-dog"),
-                    bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber in a traddlewaddle.",
+                    bio: UserProfileBio("Ploofy snooflewhumps burbled, outflonking the zibber-zabber in a traddlewaddle."),
                     category: .geist
                 ),
                 statistics: UserProfileStatistics(noteCount: 123, backlinkCount: 64, followingCount: 19),
@@ -122,7 +122,7 @@ struct BylineLgView_Previews: PreviewProvider {
                     nickname: Petname("ben")!,
                     address: Slashlink.ourProfile,
                     pfp: .image("pfp-dog"),
-                    bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber in a traddlewaddle.",
+                    bio: UserProfileBio("Ploofy snooflewhumps burbled, outflonking the zibber-zabber in a traddlewaddle."),
                     category: .you
                 ),
                 isFollowingUser: false

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
@@ -84,7 +84,7 @@ struct UserProfileHeaderView: View {
             }
             
             if user.bio.hasVisibleContent {
-                Text(verbatim: user.bio.verbatim)
+                Text(verbatim: user.bio.text)
             }
         }
     }

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
@@ -110,7 +110,7 @@ struct StoryUserView: View {
             
             if story.user.bio.hasVisibleContent {
                 Divider()
-                Text(verbatim: story.user.bio.bio)
+                Text(verbatim: story.user.bio.verbatim)
                     .padding(AppTheme.tightPadding)
             }
         }
@@ -118,7 +118,7 @@ struct StoryUserView: View {
         .onTapGesture {
             action(
                 story.user.address,
-                story.user.bio.bio
+                story.user.bio.verbatim
             )
         }
         .background(.background)

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
@@ -108,9 +108,9 @@ struct StoryUserView: View {
             .padding(AppTheme.tightPadding)
             .frame(height: AppTheme.unit * 13)
             
-            if story.user.bio.count > 0 {
+            if story.user.bio.hasVisibleContent {
                 Divider()
-                Text(verbatim: story.user.bio)
+                Text(verbatim: story.user.bio.bio)
                     .padding(AppTheme.tightPadding)
             }
         }
@@ -118,7 +118,7 @@ struct StoryUserView: View {
         .onTapGesture {
             action(
                 story.user.address,
-                story.user.bio
+                story.user.bio.bio
             )
         }
         .background(.background)
@@ -136,7 +136,7 @@ struct StoryUserView_Previews: PreviewProvider {
                         nickname: Petname("ben")!,
                         address: Slashlink(petname: Petname("ben.gordon.chris.bob")!),
                         pfp: .image("pfp-dog"),
-                        bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber.",
+                        bio: UserProfileBio("Ploofy snooflewhumps burbled, outflonking the zibber-zabber."),
                         category: .human
                     ),
                     isFollowingUser: false
@@ -150,7 +150,7 @@ struct StoryUserView_Previews: PreviewProvider {
                         nickname: Petname("ben.gordon.chris.bob")!,
                         address: Slashlink(petname: Petname("ben.gordon.chris.bob")!),
                         pfp: .image("pfp-dog"),
-                        bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber.",
+                        bio: UserProfileBio("Ploofy snooflewhumps burbled, outflonking the zibber-zabber."),
                         category: .human
                     ),
                     isFollowingUser: true
@@ -164,7 +164,7 @@ struct StoryUserView_Previews: PreviewProvider {
                         nickname: Petname("ben.gordon.chris.bob")!,
                         address: Slashlink(petname: Petname("ben.gordon.chris.bob")!),
                         pfp: .image("pfp-dog"),
-                        bio: "Ploofy snooflewhumps burbled, outflonking the zibber-zabber.",
+                        bio: UserProfileBio("Ploofy snooflewhumps burbled, outflonking the zibber-zabber."),
                         category: .you
                     ),
                     isFollowingUser: false
@@ -178,7 +178,7 @@ struct StoryUserView_Previews: PreviewProvider {
                         nickname: Petname("ben.gordon.chris.bob")!,
                         address: Slashlink(petname: Petname("ben.gordon.chris.bob")!),
                         pfp: .image("pfp-dog"),
-                        bio: "",
+                        bio: UserProfileBio.empty,
                         category: .you
                     ),
                     isFollowingUser: false

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
@@ -110,7 +110,7 @@ struct StoryUserView: View {
             
             if story.user.bio.hasVisibleContent {
                 Divider()
-                Text(verbatim: story.user.bio.verbatim)
+                Text(verbatim: story.user.bio.text)
                     .padding(AppTheme.tightPadding)
             }
         }
@@ -118,7 +118,7 @@ struct StoryUserView: View {
         .onTapGesture {
             action(
                 story.user.address,
-                story.user.bio.verbatim
+                story.user.bio.text
             )
         }
         .background(.background)

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -476,7 +476,7 @@ struct UserProfileDetailModel: ModelProtocol {
             
             let profile = UserProfileEntry(
                 nickname: state.user?.nickname.verbatim,
-                bio: state.user?.bio.verbatim,
+                bio: state.user?.bio.text,
                 profilePictureUrl: pfp?.absoluteString
             )
             return update(

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -476,7 +476,7 @@ struct UserProfileDetailModel: ModelProtocol {
             
             let profile = UserProfileEntry(
                 nickname: state.user?.nickname.verbatim,
-                bio: state.user?.bio.bio,
+                bio: state.user?.bio.verbatim,
                 profilePictureUrl: pfp?.absoluteString
             )
             return update(

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -139,7 +139,7 @@ struct UserProfile: Equatable, Codable, Hashable {
     let nickname: Petname
     let address: Slashlink
     let pfp: ProfilePicVariant
-    let bio: String
+    let bio: UserProfileBio
     let category: UserCategory
 }
 
@@ -476,7 +476,7 @@ struct UserProfileDetailModel: ModelProtocol {
             
             let profile = UserProfileEntry(
                 nickname: state.user?.nickname.verbatim,
-                bio: state.user?.bio,
+                bio: state.user?.bio.bio,
                 profilePictureUrl: pfp?.absoluteString
             )
             return update(

--- a/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
@@ -25,6 +25,12 @@ extension Did: DummyData {
     }
 }
 
+extension UserProfileBio: DummyData {
+    static func dummyData() -> UserProfileBio {
+        UserProfileBio(String.dummyDataMedium())
+    }
+}
+
 extension Petname: DummyData {
     static func dummyData() -> Petname {
         let options = [
@@ -75,7 +81,7 @@ extension StoryUser: DummyData {
                 nickname: petname,
                 address: Slashlink(petname: petname),
                 pfp: .image(String.dummyProfilePicture()),
-                bio: String.dummyDataMedium(),
+                bio: UserProfileBio.dummyData(),
                 category: [UserCategory.human, UserCategory.geist].randomElement()!
             ),
             isFollowingUser: Bool.dummyData()
@@ -89,7 +95,7 @@ extension StoryUser: DummyData {
                 nickname: petname,
                 address: Slashlink(petname: petname),
                 pfp: .image(String.dummyProfilePicture()),
-                bio: String.dummyDataMedium(),
+                bio: UserProfileBio.dummyData(),
                 category: [UserCategory.human, UserCategory.geist].randomElement()!
             ),
             isFollowingUser: Bool.dummyData()
@@ -154,7 +160,7 @@ extension UserProfile: DummyData {
             nickname: petname,
             address: Slashlink(petname: petname),
             pfp: .image(String.dummyProfilePicture()),
-            bio: String.dummyDataMedium(),
+            bio: UserProfileBio.dummyData(),
             category: .human
         )
     }

--- a/xcode/Subconscious/Shared/Library/Prose.swift
+++ b/xcode/Subconscious/Shared/Library/Prose.swift
@@ -23,6 +23,8 @@ extension Character {
 }
 
 extension String {
+    private static let visibleContentRegex = /[^\s]/
+    
     /// Truncate string to max length, appending ellipsis if truncated.
     func truncate(
         maxLength: Int = 256,
@@ -48,6 +50,14 @@ extension String {
         self.prefix(while: { character in
             !character.isSentenceEndingPunctuation
         })
+    }
+    
+    var hasVisibleContent: Bool {
+        self.contains(Self.visibleContentRegex)
+    }
+    
+    var fitsInUserBio: Bool {
+        self.count <= UserProfileBio.maxLength
     }
 
     /// Derive title from string.

--- a/xcode/Subconscious/Shared/Models/FormField.swift
+++ b/xcode/Subconscious/Shared/Models/FormField.swift
@@ -62,21 +62,15 @@ struct FormField<Input: Equatable, Output>: ModelProtocol {
     
     /// Attempt to validate the input and produce the backing type
     var validated: Output? {
-        get {
-            validate(value)
-        }
+        validate(value)
     }
     /// Is the current value valid?
     var isValid: Bool {
-        get {
-            validated != nil
-        }
+        validated != nil
     }
     /// Should this field visually display an error?
     var hasError: Bool {
-        get {
-            !isValid && touched
-        }
+        !isValid && touched
     }
     
     static func update(

--- a/xcode/Subconscious/Shared/Models/UserProfileBio.swift
+++ b/xcode/Subconscious/Shared/Models/UserProfileBio.swift
@@ -11,21 +11,19 @@ import Foundation
 public struct UserProfileBio:
     Hashable,
     Equatable,
-    Identifiable,
     Codable {
     
     public static let empty = UserProfileBio("")
     private static let visibleContentRegex = /[^\s]/
     
-    public let verbatim: String
-    public var id: String { verbatim }
+    public let text: String
     
     public var hasVisibleContent: Bool {
-        verbatim.contains(Self.visibleContentRegex)
+        text.contains(Self.visibleContentRegex)
     }
 
     public init(_ description: String) {
-        self.verbatim = description
+        self.text = description
             // Turn all whitespace into spaces
             .replacingOccurrences(
                 of: "\\s+",

--- a/xcode/Subconscious/Shared/Models/UserProfileBio.swift
+++ b/xcode/Subconscious/Shared/Models/UserProfileBio.swift
@@ -14,12 +14,12 @@ public struct UserProfileBio:
     Codable {
     
     public static let empty = UserProfileBio("")
-    private static let visibleContentRegex = /[^\s]/
+    public static let maxLength = 280
     
     public let text: String
     
     public var hasVisibleContent: Bool {
-        text.contains(Self.visibleContentRegex)
+        text.hasVisibleContent
     }
 
     public init(_ description: String) {
@@ -32,7 +32,7 @@ public struct UserProfileBio:
             )
             // Catch leading spaces
             .trimmingCharacters(in: .whitespacesAndNewlines)
-            .prefix(280)
+            .prefix(Self.maxLength)
             .toString()
     }
 }

--- a/xcode/Subconscious/Shared/Models/UserProfileBio.swift
+++ b/xcode/Subconscious/Shared/Models/UserProfileBio.swift
@@ -25,14 +25,16 @@ public struct UserProfileBio:
     }
 
     public init(_ description: String) {
-        let bio = description.prefix(280)
-        // Turn all whitespace into spaces
-        let cleanedBio = bio.replacingOccurrences(
-            of: "\\s",
-            with: " ",
-            options: .regularExpression
-        )
-
-        self.verbatim = cleanedBio
+        self.verbatim = description
+            // Turn all whitespace into spaces
+            .replacingOccurrences(
+                of: "\\s+",
+                with: " ",
+                options: .regularExpression
+            )
+            // Catch leading spaces
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .prefix(280)
+            .toString()
     }
 }

--- a/xcode/Subconscious/Shared/Models/UserProfileBio.swift
+++ b/xcode/Subconscious/Shared/Models/UserProfileBio.swift
@@ -17,11 +17,11 @@ public struct UserProfileBio:
     public static let empty = UserProfileBio("")
     private static let visibleContentRegex = /[^\s]/
     
-    public let bio: String
-    public var id: String { bio }
+    public let verbatim: String
+    public var id: String { verbatim }
     
     public var hasVisibleContent: Bool {
-        bio.contains(Self.visibleContentRegex)
+        verbatim.contains(Self.visibleContentRegex)
     }
 
     public init(_ description: String) {
@@ -33,6 +33,6 @@ public struct UserProfileBio:
             options: .regularExpression
         )
 
-        self.bio = cleanedBio
+        self.verbatim = cleanedBio
     }
 }

--- a/xcode/Subconscious/Shared/Models/UserProfileBio.swift
+++ b/xcode/Subconscious/Shared/Models/UserProfileBio.swift
@@ -1,0 +1,38 @@
+//
+//  UserProfileBio.swift
+//  Subconscious (iOS)
+//
+//  Created by Ben Follington on 17/5/2023.
+//
+
+import Foundation
+
+/// A type representing a user profile bio, with restricted characters and length.
+public struct UserProfileBio:
+    Hashable,
+    Equatable,
+    Identifiable,
+    Codable {
+    
+    public static let empty = UserProfileBio("")
+    private static let visibleContentRegex = /[^\s]/
+    
+    public let bio: String
+    public var id: String { bio }
+    
+    public var hasVisibleContent: Bool {
+        bio.contains(Self.visibleContentRegex)
+    }
+
+    public init(_ description: String) {
+        let bio = description.prefix(280)
+        // Turn all whitespace into spaces
+        let cleanedBio = bio.replacingOccurrences(
+            of: "\\s",
+            with: " ",
+            options: .regularExpression
+        )
+
+        self.bio = cleanedBio
+    }
+}

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -168,7 +168,7 @@ actor UserProfileService {
             nickname: Petname(userProfileData?.nickname ?? "") ?? fallbackPetname,
             address: address,
             pfp: pfp,
-            bio: userProfileData?.bio ?? "",
+            bio: UserProfileBio(userProfileData?.bio ?? ""),
             category: address.isOurProfile ? .you : .human
         )
         

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -277,7 +277,7 @@ actor UserProfileService {
             body: data
         )
         
-        let _ = try await self.noosphere.save()
+        _ = try await self.noosphere.save()
         
         do {
             _ = try await self.noosphere.sync()

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -71,7 +71,7 @@ struct UserProfileEntry: Codable, Equatable {
     init(nickname: String?, bio: String?, profilePictureUrl: String?) {
         self.version = Self.currentVersion
         self.nickname = nickname
-        self.bio = bio
+        self.bio = UserProfileBio(bio ?? "").bio
         self.profilePictureUrl = profilePictureUrl
     }
     

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -71,7 +71,7 @@ struct UserProfileEntry: Codable, Equatable {
     init(nickname: String?, bio: String?, profilePictureUrl: String?) {
         self.version = Self.currentVersion
         self.nickname = nickname
-        self.bio = UserProfileBio(bio ?? "").verbatim
+        self.bio = UserProfileBio(bio ?? "").text
         self.profilePictureUrl = profilePictureUrl
     }
     

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -71,7 +71,7 @@ struct UserProfileEntry: Codable, Equatable {
     init(nickname: String?, bio: String?, profilePictureUrl: String?) {
         self.version = Self.currentVersion
         self.nickname = nickname
-        self.bio = UserProfileBio(bio ?? "").bio
+        self.bio = UserProfileBio(bio ?? "").verbatim
         self.profilePictureUrl = profilePictureUrl
     }
     

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		B5CFC7FF29E5403900178631 /* FollowUserSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CFC7FD29E5403900178631 /* FollowUserSheet.swift */; };
 		B5D769CB29F770440015385A /* GenerativeProfilePic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D769CA29F770440015385A /* GenerativeProfilePic.swift */; };
 		B5D769CC29F770440015385A /* GenerativeProfilePic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D769CA29F770440015385A /* GenerativeProfilePic.swift */; };
+		B5E60C8B2A145F04007065A1 /* UserProfileBio.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E60C8A2A145F04007065A1 /* UserProfileBio.swift */; };
 		B5F68F602A09F7E200CE4DD7 /* StackedGlowingImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F68F5F2A09F7E200CE4DD7 /* StackedGlowingImage.swift */; };
 		B5F68F612A09F7E200CE4DD7 /* StackedGlowingImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F68F5F2A09F7E200CE4DD7 /* StackedGlowingImage.swift */; };
 		B5F68F632A0B1E6900CE4DD7 /* OnboardingTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F68F622A0B1E6900CE4DD7 /* OnboardingTheme.swift */; };
@@ -466,6 +467,7 @@
 		B5CFC7FD29E5403900178631 /* FollowUserSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowUserSheet.swift; sourceTree = "<group>"; };
 		B5D769CA29F770440015385A /* GenerativeProfilePic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerativeProfilePic.swift; sourceTree = "<group>"; };
 		B5D8D30029AF1F9B0011D820 /* Did.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Did.swift; sourceTree = "<group>"; };
+		B5E60C8A2A145F04007065A1 /* UserProfileBio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileBio.swift; sourceTree = "<group>"; };
 		B5F68F5F2A09F7E200CE4DD7 /* StackedGlowingImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackedGlowingImage.swift; sourceTree = "<group>"; };
 		B5F68F622A0B1E6900CE4DD7 /* OnboardingTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTheme.swift; sourceTree = "<group>"; };
 		B5F6ADC829C02F4A00690DE4 /* AddressBookService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookService.swift; sourceTree = "<group>"; };
@@ -1036,6 +1038,8 @@
 				B59D556229BBFF56007915E2 /* FormField.swift */,
 				B8EA3EE72915C23200B92C2E /* HeaderSubtext.swift */,
 				B86BC75329B143CD005B5833 /* Identified.swift */,
+				B56C3D3D2A01E5020071EF70 /* InviteCode.swift */,
+				B5E60C8A2A145F04007065A1 /* UserProfileBio.swift */,
 				B8CAA6CA2A02FA7000F4A0F6 /* Link.swift */,
 				B86DFF3427C07438002E57ED /* LinkSuggestion.swift */,
 				B8C7E8BD2809F19500E439DC /* Markup.swift */,
@@ -1057,7 +1061,6 @@
 				B58A46B429D3CE9700491E43 /* StoryUser.swift */,
 				B8B54F3C271F7C6B00B9B507 /* Suggestion.swift */,
 				B81A1A6C29DF267200B4CD1C /* LoadingState.swift */,
-				B56C3D3D2A01E5020071EF70 /* InviteCode.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1731,6 +1734,7 @@
 				B8EA3EE529159C5500B92C2E /* HeaderSubtextMemoStore.swift in Sources */,
 				B86DFF3127C06EBC002E57ED /* RenameSuggestion.swift in Sources */,
 				B81D063B29F1821E00593BBA /* SphereFile.swift in Sources */,
+				B5E60C8B2A145F04007065A1 /* UserProfileBio.swift in Sources */,
 				B88B1CE1298EAE730062CB7F /* PillButtonStyle.swift in Sources */,
 				B8AE34A7276A885300777FF0 /* TextViewRepresentable.swift in Sources */,
 				B8C0A1B4297C938000D59532 /* Error.swift in Sources */,

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		B5D769CB29F770440015385A /* GenerativeProfilePic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D769CA29F770440015385A /* GenerativeProfilePic.swift */; };
 		B5D769CC29F770440015385A /* GenerativeProfilePic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D769CA29F770440015385A /* GenerativeProfilePic.swift */; };
 		B5E60C8B2A145F04007065A1 /* UserProfileBio.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E60C8A2A145F04007065A1 /* UserProfileBio.swift */; };
+		B5E60C8D2A146838007065A1 /* Tests_UserProfileBio.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E60C8C2A146838007065A1 /* Tests_UserProfileBio.swift */; };
 		B5F68F602A09F7E200CE4DD7 /* StackedGlowingImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F68F5F2A09F7E200CE4DD7 /* StackedGlowingImage.swift */; };
 		B5F68F612A09F7E200CE4DD7 /* StackedGlowingImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F68F5F2A09F7E200CE4DD7 /* StackedGlowingImage.swift */; };
 		B5F68F632A0B1E6900CE4DD7 /* OnboardingTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F68F622A0B1E6900CE4DD7 /* OnboardingTheme.swift */; };
@@ -468,6 +469,7 @@
 		B5D769CA29F770440015385A /* GenerativeProfilePic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerativeProfilePic.swift; sourceTree = "<group>"; };
 		B5D8D30029AF1F9B0011D820 /* Did.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Did.swift; sourceTree = "<group>"; };
 		B5E60C8A2A145F04007065A1 /* UserProfileBio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileBio.swift; sourceTree = "<group>"; };
+		B5E60C8C2A146838007065A1 /* Tests_UserProfileBio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_UserProfileBio.swift; sourceTree = "<group>"; };
 		B5F68F5F2A09F7E200CE4DD7 /* StackedGlowingImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackedGlowingImage.swift; sourceTree = "<group>"; };
 		B5F68F622A0B1E6900CE4DD7 /* OnboardingTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTheme.swift; sourceTree = "<group>"; };
 		B5F6ADC829C02F4A00690DE4 /* AddressBookService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookService.swift; sourceTree = "<group>"; };
@@ -858,6 +860,7 @@
 				B5908BEA29DAB05B00225B1A /* TestUtilities.swift */,
 				B80890A92A0693C40087E091 /* Tests_HeaderSubtext.swift */,
 				B840CCC62A0C1F840000C025 /* Tests_Audience.swift */,
+				B5E60C8C2A146838007065A1 /* Tests_UserProfileBio.swift */,
 			);
 			path = SubconsciousTests;
 			sourceTree = "<group>";
@@ -1540,6 +1543,7 @@
 				B5432B8329F8BAED003BBB23 /* Tests_UserProfileService.swift in Sources */,
 				B87288E0299B05B500EF7E07 /* Tests_DataService.swift in Sources */,
 				B80890AA2A0693C40087E091 /* Tests_HeaderSubtext.swift in Sources */,
+				B5E60C8D2A146838007065A1 /* Tests_UserProfileBio.swift in Sources */,
 				B8AAAADB28CBDED800DBC8A9 /* Tests_Search.swift in Sources */,
 				B809AFF428D8E7BC00D0589A /* Tests_MarkupText.swift in Sources */,
 				B88A76D729E0AA44005F3422 /* Tests_MemoViewerDetailMetaSheet.swift in Sources */,

--- a/xcode/Subconscious/SubconsciousTests/Tests_UserProfileBio.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_UserProfileBio.swift
@@ -29,6 +29,21 @@ class Tests_UserProfileBio: XCTestCase {
         XCTAssertEqual("This is a nice bio.", UserProfileBio(bio).text)
     }
     
+    func testAppliedInProfileEditor() {
+        let state = EditProfileSheetModel()
+        let valid = "hello world"
+        let tooLong = """
+                      I arose at precisely 7:32 AM and embarked on my morning ritual. \
+                      In my quaint kitchen, I prepared a breakfast of champions. \
+                      I began with two perfectly toasted slices of golden brown sourdough \
+                      bread, each grain visible. Upon them, I delicately spread a \
+                      layer of creamy, organic butter.
+                      """
+        
+        XCTAssertNotNil(state.bioField.validate(valid))
+        XCTAssertNil(state.bioField.validate(tooLong))
+    }
+    
     func testTruncation() throws {
         let bio = """
                   I arose at precisely 7:32 AM and embarked on my morning ritual. \

--- a/xcode/Subconscious/SubconsciousTests/Tests_UserProfileBio.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_UserProfileBio.swift
@@ -14,14 +14,8 @@ class Tests_UserProfileBio: XCTestCase {
         XCTAssertEqual(bio, UserProfileBio(bio).text)
     }
     
-    func testExtendedUnicode() throws {
-        let bio = "豈 更 車ぁ あ ぃ✁ ✂ ✃☀ ☁ ☂ก ข ฃ"
-        
-        XCTAssertEqual(bio, UserProfileBio(bio).text)
-    }
-    
-    func testEmoji() throws {
-        let bio = "🧠🤝🤖"
+    func testUnicode() throws {
+        let bio = "🧠🤝🤖豈 更 車ぁ あ ぃ✁ ✂ ✃☀ ☁ ☂ก ข ฃ"
         
         XCTAssertEqual(bio, UserProfileBio(bio).text)
     }

--- a/xcode/Subconscious/SubconsciousTests/Tests_UserProfileBio.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_UserProfileBio.swift
@@ -1,0 +1,57 @@
+//
+//  Tests_UserProfileBio.swift
+//  SubconsciousTests
+//
+//  Created by Ben Follington on 17/5/2023.
+//
+
+import XCTest
+@testable import Subconscious
+
+class Tests_UserProfileBio: XCTestCase {
+    func testUnchanged() throws {
+        let bio = "This is a nice bio."
+        XCTAssertEqual(bio, UserProfileBio(bio).verbatim)
+    }
+    
+    func testExtendedUnicode() throws {
+        let bio = "豈 更 車ぁ あ ぃ✁ ✂ ✃☀ ☁ ☂ก ข ฃ"
+        
+        XCTAssertEqual(bio, UserProfileBio(bio).verbatim)
+    }
+    
+    func testEmoji() throws {
+        let bio = "🧠🤝🤖"
+        
+        XCTAssertEqual(bio, UserProfileBio(bio).verbatim)
+    }
+    
+    func testWhitespace() throws {
+        let bio = """
+                  This            is a
+        nice bio.
+        """
+        
+        XCTAssertEqual("This is a nice bio.", UserProfileBio(bio).verbatim)
+    }
+    
+    func testTruncation() throws {
+        let bio = """
+                  I arose at precisely 7:32 AM and embarked on my morning ritual. \
+                  In my quaint kitchen, I prepared a breakfast of champions. \
+                  I began with two perfectly toasted slices of golden brown sourdough \
+                  bread, each grain visible. Upon them, I delicately spread a \
+                  layer of creamy, organic butter.
+                  """
+        
+        let expected = """
+                  I arose at precisely 7:32 AM and embarked on my morning ritual. \
+                  In my quaint kitchen, I prepared a breakfast of champions. \
+                  I began with two perfectly toasted slices of golden brown sourdough \
+                  bread, each grain visible. Upon them, I delicately spread a \
+                  layer of creamy, organic butt
+                  """
+        
+        XCTAssertEqual(expected, UserProfileBio(bio).verbatim)
+    }
+}

--- a/xcode/Subconscious/SubconsciousTests/Tests_UserProfileBio.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_UserProfileBio.swift
@@ -11,19 +11,19 @@ import XCTest
 class Tests_UserProfileBio: XCTestCase {
     func testUnchanged() throws {
         let bio = "This is a nice bio."
-        XCTAssertEqual(bio, UserProfileBio(bio).verbatim)
+        XCTAssertEqual(bio, UserProfileBio(bio).text)
     }
     
     func testExtendedUnicode() throws {
         let bio = "豈 更 車ぁ あ ぃ✁ ✂ ✃☀ ☁ ☂ก ข ฃ"
         
-        XCTAssertEqual(bio, UserProfileBio(bio).verbatim)
+        XCTAssertEqual(bio, UserProfileBio(bio).text)
     }
     
     func testEmoji() throws {
         let bio = "🧠🤝🤖"
         
-        XCTAssertEqual(bio, UserProfileBio(bio).verbatim)
+        XCTAssertEqual(bio, UserProfileBio(bio).text)
     }
     
     func testWhitespace() throws {
@@ -32,7 +32,7 @@ class Tests_UserProfileBio: XCTestCase {
         nice bio.
         """
         
-        XCTAssertEqual("This is a nice bio.", UserProfileBio(bio).verbatim)
+        XCTAssertEqual("This is a nice bio.", UserProfileBio(bio).text)
     }
     
     func testTruncation() throws {
@@ -52,6 +52,6 @@ class Tests_UserProfileBio: XCTestCase {
                   layer of creamy, organic butt
                   """
         
-        XCTAssertEqual(expected, UserProfileBio(bio).verbatim)
+        XCTAssertEqual(expected, UserProfileBio(bio).text)
     }
 }


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/587

# Changes

- Bio is processed before reading or writing to change all whitespace to spaces & truncate at the max length
  - Even with #647 users could still modify their profile to inject massive bio strings etc. 
- Remove line limit on bio editor, it makes life harder than it has to be