### PR TITLE
Wait to provision gateway until after we have the invite code

### DIFF
--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
@@ -69,6 +69,9 @@ struct FirstRunProfileView: View {
             AppTheme.onboarding
                 .appBackgroundGradient(colorScheme)
         )
+        .onAppear {
+            app.send(.createSphere)
+        }
     }
 }
 

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
@@ -128,9 +128,6 @@ struct FirstRunView: View {
                     FirstRunDoneView(app: app)
                 }
             }
-            .onAppear {
-                app.send(.createSphere)
-            }
         }
     }
 }


### PR DESCRIPTION
Gateway provisioning was broken because we tried to start it before we have the invite code. We should probably decouple the sphere creation and gateway provisioning further, but this fixes the immediate issue.