### PR TITLE
Ensure `requestCreateInitialProfile` is idempotent

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -931,7 +931,7 @@ struct AppModel: ModelProtocol {
         nickname: String
     ) -> Update<AppModel> {
         let fx: Fx<AppAction> = Future.detached {
-            try await environment.userProfile.setOurInitialNickname(nickname: nickname)
+            try await environment.userProfile.requestSetOurInitialNickname(nickname: nickname)
             return AppAction.succeedCreateInitialProfile
         }
         .recover { error in

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -931,14 +931,7 @@ struct AppModel: ModelProtocol {
         nickname: String
     ) -> Update<AppModel> {
         let fx: Fx<AppAction> = Future.detached {
-            let profile =
-                UserProfileEntry(
-                    nickname: nickname,
-                    bio: nil,
-                    profilePictureUrl: nil
-                )
-            
-            try await environment.userProfile.writeOurProfile(profile: profile)
+            try await environment.userProfile.setOurInitialNickname(nickname: nickname)
             return AppAction.succeedCreateInitialProfile
         }
         .recover { error in

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -51,7 +51,7 @@ extension UserProfileServiceError: LocalizedError {
             }
         case .profileAlreadyExists:
             return String(
-                localized: "Attempted to create initial profile but user already has a profile memo",
+                localized: "Request to create initial profile but user already has a profile memo",
                 comment: "UserProfileService error description"
             )
         case .other(let msg):
@@ -116,7 +116,6 @@ actor UserProfileService {
         self.jsonEncoder.outputFormatting = .sortedKeys
     }
     
-    
     /// Attempt to read & deserialize a user `_profile_.json` at the given address.
     /// Because profile data is optional and we expect it will not always be present
     /// any errors are logged & handled and nil will be returned if reading fails.
@@ -143,7 +142,7 @@ actor UserProfileService {
                 guard let string = String(data: data.body, encoding: .utf8) else {
                     throw UserProfileServiceError.failedToDeserializeProfile(error, nil)
                 }
-                
+
                 throw UserProfileServiceError.failedToDeserializeProfile(error, string)
             }
         } catch {
@@ -254,7 +253,6 @@ actor UserProfileService {
                 ? Slashlink.ourProfile
                 : slashlink
             
-            
             let weAreFollowingListedUser = await self.addressBook.isFollowingUser(did: entry.did)
             let isPendingFollow = await self.addressBook.isPendingResolution(petname: entry.petname)
             let status = weAreFollowingListedUser && isPendingFollow ? .pending : entry.status
@@ -277,7 +275,8 @@ actor UserProfileService {
         return following
     }
     
-    /// Sets our nickname if (and only if) there is no existing profile data. This is intended to be idempotent for use in the onboarding flow.
+    /// Sets our nickname if (and only if) there is no existing profile data.
+    /// This is intended to be idempotent for use in the onboarding flow.
     func setOurInitialNickname(nickname: String) async throws {
         guard await readProfileMemo(address: Slashlink.ourProfile) != nil else {
             let profile = UserProfileEntry(
@@ -288,7 +287,7 @@ actor UserProfileService {
             
             return try await writeOurProfile(profile: profile)
         }
-        
+
         throw UserProfileServiceError.profileAlreadyExists
     }
     

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -277,7 +277,7 @@ actor UserProfileService {
     
     /// Sets our nickname if (and only if) there is no existing profile data.
     /// This is intended to be idempotent for use in the onboarding flow.
-    func setOurInitialNickname(nickname: String) async throws {
+    func requestSetOurInitialNickname(nickname: String) async throws {
         guard await readProfileMemo(address: Slashlink.ourProfile) != nil else {
             let profile = UserProfileEntry(
                 nickname: nickname,


### PR DESCRIPTION
Builds on https://github.com/subconsciousnetwork/subconscious/pull/661

This was causing the profile to be trashed and recreated **whenever** the nickname changed regardless of whether the user already had a profile, erasing the bio. This explains a decent chunk of the weirdness we saw in playtesting. 