### PR TITLE
Use `go` label for keyboard submit button

### DIFF
--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
@@ -32,7 +32,7 @@ struct FirstRunProfileView: View {
                     caption: "Lowercase letters, numbers and dashes only.",
                     hasError: !app.state.isNicknameFormFieldValid,
                     autoFocus: true,
-                    submitLabel: .continue,
+                    submitLabel: .go,
                     onSubmit: {
                         if app.state.nicknameFormField.isValid {
                             app.send(.pushFirstRunStep(.sphere))

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
@@ -59,7 +59,7 @@ struct FirstRunView: View {
                     },
                     caption: "Look for this in your welcome email.",
                     hasError: app.state.inviteCodeFormField.hasError,
-                    submitLabel: .continue,
+                    submitLabel: .go,
                     onSubmit: {
                         if app.state.inviteCodeFormField.isValid {
                             app.send(.pushFirstRunStep(.nickname))


### PR DESCRIPTION
This ensures it appears in blue:

![image](https://github.com/subconsciousnetwork/subconscious/assets/5009316/8ce76978-5841-4f92-8d74-8d1ee4b74e30)

Of the available options:
- done
- go
- send
- join
- route
- search
- return
- next
- continue

Only three are blue (that I've found anyway):
- done
- go
- search