### PR TITLE
Persist Gateway ID during provisioning

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -198,6 +198,7 @@ enum AppAction: CustomLogStringConvertible {
     case succeedFollowDefaultGeist
     case failFollowDefaultGeist(String)
     
+    case submitProvisionGatewayForm
     case requestProvisionGateway(_ inviteCode: InviteCode)
     case receiveGatewayId(_ gatewayId: String)
     case requestGatewayProvisioningStatus
@@ -767,6 +768,21 @@ struct AppModel: ModelProtocol {
             logger.error("Failed to follow default geist: \(error)")
             return Update(state: state)
             
+        case .submitProvisionGatewayForm:
+            switch (state.inviteCodeFormField.validated, state.gatewayId) {
+            case (.some(let inviteCode), .none):
+                return update(
+                    state: state,
+                    action: .requestProvisionGateway(inviteCode),
+                    environment: environment
+                )
+            case _:
+                return update(
+                    state: state,
+                    action: .requestGatewayProvisioningStatus,
+                    environment: environment
+                )
+            }
         case .requestProvisionGateway(let inviteCode):
             return requestProvisionGateway(
                 state: state,

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -201,7 +201,7 @@ enum AppAction: CustomLogStringConvertible {
     case requestProvisionGateway(_ inviteCode: InviteCode)
     case receiveGatewayId(_ gatewayId: String)
     case requestGatewayProvisioningStatus
-    case completeProvisionGateway(_ gatewayURL: URL)
+    case succeedProvisionGateway(_ gatewayURL: URL)
     case failProvisionGateway(_ error: String)
     
     case setFirstRunPath([FirstRunStep])
@@ -788,7 +788,7 @@ struct AppModel: ModelProtocol {
                 state: state,
                 environment: environment
             )
-        case .completeProvisionGateway(let url):
+        case .succeedProvisionGateway(let url):
             return succeedProvisionGateway(
                 state: state,
                 environment: environment,

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -1607,7 +1607,7 @@ struct AppModel: ModelProtocol {
         state: AppModel,
         environment: AppEnvironment
     ) -> Update<AppModel> {
-        guard let gatewayId = AppDefaults.standard.gatewayId else {
+        guard let gatewayId = state.gatewayId else {
             return Update(state: state)
         }
         

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -1639,7 +1639,7 @@ struct AppModel: ModelProtocol {
                     return AppAction.failProvisionGateway("Timed out waiting for URL")
                 }
                 
-                return AppAction.completeProvisionGateway(url)
+                return AppAction.succeedProvisionGateway(url)
             }
             .recover { err in
                 AppAction.failProvisionGateway(err.localizedDescription)

--- a/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
@@ -131,16 +131,9 @@ struct GatewayURLSettingsView: View {
                     }
                     .disabled(app.state.gatewayProvisioningStatus == .pending)
                     
-                   Button(
+                    Button(
                         action: {
-                            // TODO: lift logic into model
-                            if let inviteCode = app.state.inviteCodeFormField.validated,
-                               app.state.gatewayId == nil {
-                                app.send(.requestProvisionGateway(inviteCode))
-                            } else {
-                                app.send(.requestGatewayProvisioningStatus)
-                            }
-                            
+                            app.send(.submitProvisionGatewayForm)
                         },
                         label: {
                             GatewayProvisionLabel(

--- a/xcode/Subconscious/Shared/Services/AppDefaults.swift
+++ b/xcode/Subconscious/Shared/Services/AppDefaults.swift
@@ -23,4 +23,10 @@ struct AppDefaults {
     
     @UserDefaultsProperty(forKey: "gatewayURL")
     var gatewayURL = "http://127.0.0.1:4433"
+    
+    @UserDefaultsProperty(forKey: "gatewayId")
+    var gatewayId: String? = nil
+    
+    @UserDefaultsProperty(forKey: "inviteCode")
+    var inviteCode: String? = nil
 }


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/643

# Changes

Explicitly record both the invite code and the gateway ID during provisioning. If the provisioning times out, the app crashes or the user loses connection etc. we can now pick up where we left off and check on our gateway.

I've confirmed that you can quit the app at any point during the lifecycle and resume it in a valid state.