### PR TITLE
Fix seeded RNG implementation

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/Profile/GenerativeProfilePic.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/GenerativeProfilePic.swift
@@ -20,6 +20,8 @@ struct RandomNumberGeneratorWithSeed: RandomNumberGenerator {
     }
 
     mutating func next() -> UInt64 {
+        // nextInt() generates a random number between 0 and Int32.max inclusive.
+        // Carefully combine these into 64 bits of randomness.
         let highBits = UInt64(randomSource.nextInt(upperBound: Int(UInt32.max)))
         let lowBits = UInt64(randomSource.nextInt(upperBound: Int(UInt32.max)))
         return highBits << 32 | lowBits

--- a/xcode/Subconscious/Shared/Components/Common/Profile/GenerativeProfilePic.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/GenerativeProfilePic.swift
@@ -20,8 +20,8 @@ struct RandomNumberGeneratorWithSeed: RandomNumberGenerator {
     }
 
     mutating func next() -> UInt64 {
-        let highBits = UInt64(bitPattern: Int64(randomSource.nextInt()))
-        let lowBits = UInt64(bitPattern: Int64(randomSource.nextInt()))
+        let highBits = UInt64(randomSource.nextInt(upperBound: Int(UInt32.max)))
+        let lowBits = UInt64(randomSource.nextInt(upperBound: Int(UInt32.max)))
         return highBits << 32 | lowBits
     }
 }


### PR DESCRIPTION
Fixes a bug in my RNG implementation that resulted in an incomplete random distribution.

Before:
<img src="https://github.com/subconsciousnetwork/subconscious/assets/5009316/97cd7eb7-7cd7-4c1a-8c1c-7593398016b7" width=320 />

After:
<img src="https://github.com/subconsciousnetwork/subconscious/assets/5009316/138e1514-d160-4fc9-aebb-79f0d8624026" width=320 />


