### PR TITLE
Prevent gateway ID wrapping the line

### DIFF
--- a/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
@@ -154,7 +154,7 @@ struct GatewayURLSettingsView: View {
                 footer: {
                     VStack {
                         if let gatewayId = app.state.gatewayId {
-                            VStack {
+                            VStack(alignment: .leading) {
                                 Text("Gateway ID")
                                     .foregroundColor(.secondary)
                                     .bold()

--- a/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
@@ -154,7 +154,7 @@ struct GatewayURLSettingsView: View {
                 footer: {
                     VStack {
                         if let gatewayId = app.state.gatewayId {
-                            HStack {
+                            VStack {
                                 Text("Gateway ID")
                                     .foregroundColor(.secondary)
                                     .bold()


### PR DESCRIPTION
Ignore the somewhat amusing invite code, look at the gateway ID:

<img width="366" alt="Pasted Graphic" src="https://github.com/subconsciousnetwork/subconscious/assets/5009316/33146905-b5ca-44f1-809a-8752b029e1c3">
