### PR TITLE
Ensure draft editor loads latest version of its content

### DIFF
--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -979,7 +979,7 @@ struct MemoEditorDetailModel: ModelProtocol {
         info: MemoEditorDetailDescription
     ) -> Update<MemoEditorDetailModel> {
         // No address? This is a draft.
-        guard let address = info.address else {
+        guard let address = state.address ?? info.address else {
             return update(
                 state: state,
                 action: .setDraftDetail(


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/683

When initially presented, the draft editor has no address associated with it (because the note lacks a title). Once the note has been saved (e.g. when leaving the view by tapping a slashlink) it now _has_ an address. When the draft editor's `.appear` action fired it incorrectly assumed it had no address and attempts to recreate the from scratch. We need to check if the `state.address` exists and use _that_ instead of the stale `description.address`.

h/t @gordonbrander for telling me to check the description logic 🙏 

Simple fix, subtle issue.