### PR TITLE
Fix stale navigation titles

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -183,7 +183,7 @@ struct UserProfileView: View {
                 Text("Not found")
             }
         }
-        .navigationTitle(state.user?.displayName ?? "")
+        .navigationTitle(state.user?.address.peer?.markup ?? "Profile")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar(content: {
             if let user = state.user {

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -30,6 +30,14 @@ struct MemoEditorDetailView: View {
     var description: MemoEditorDetailDescription
     /// An address to forward notifications (informational actions)
     var notify: (MemoEditorDetailNotification) -> Void
+    var navigationTitle: String {
+        switch store.state.audience {
+        case .local:
+            return store.state.address?.slug.markup ?? store.state.title
+        case .public:
+            return store.state.address?.markup ?? store.state.title
+        }
+    }
 
     private func onLink(
         url: URL
@@ -129,7 +137,7 @@ struct MemoEditorDetailView: View {
                 }
             }
         }
-        .navigationTitle(store.state.title)
+        .navigationTitle(navigationTitle)
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.visible)
         .toolbarBackground(Color.background, for: .navigationBar)

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -20,6 +20,9 @@ struct MemoViewerDetailView: View {
 
     var description: MemoViewerDetailDescription
     var notify: (MemoViewerDetailNotification) -> Void
+    var navigationTitle: String {
+        store.state.address?.markup ?? store.state.title
+    }
 
     var body: some View {
         VStack {
@@ -44,7 +47,7 @@ struct MemoViewerDetailView: View {
                 )
             }
         }
-        .navigationTitle(store.state.title)
+        .navigationTitle(navigationTitle)
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.visible)
         .toolbarBackground(Color.background, for: .navigationBar)


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/585

Use the address for navigation titles, this is more scannable anyway and avoids the problem of loading content in the background just to update the title.

<img width="384" alt="image" src="https://github.com/subconsciousnetwork/subconscious/assets/5009316/957f1c98-e8e8-4a00-a0ee-ff699390b86d">