### PR TITLE
Improve handling of long petnames

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/Buttons/PillButtonStyle.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Buttons/PillButtonStyle.swift
@@ -39,10 +39,11 @@ struct PillButtonView: View {
                 case .regular:
                     return AppTheme.unit * 12
                 case .small:
-                    return AppTheme.unit * 6
+                    return AppTheme.unit * 8
                 }
             }
         )
+        
     }
 }
 
@@ -72,20 +73,23 @@ struct PillButtonStyle: ButtonStyle {
         )
         .clipShape(Capsule())
         .animation(.default, value: configuration.isPressed)
+        .frame(minHeight: AppTheme.minTouchSize)
     }
 }
 
 struct PillButtonStyle_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
-            Button(
-                action: {},
-                label: {
-                    Text("Floop")
-                }
-            ).buttonStyle(
-                PillButtonStyle(size: .small)
-            )
+            HStack {
+                Button(
+                    action: {},
+                    label: {
+                        Text("Floop")
+                    }
+                ).buttonStyle(
+                    PillButtonStyle(size: .small)
+                )
+            }
             Button(
                 action: {},
                 label: {

--- a/xcode/Subconscious/Shared/Components/Common/Buttons/PillButtonStyle.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Buttons/PillButtonStyle.swift
@@ -18,7 +18,7 @@ struct PillButtonView: View {
     
     var body: some View {
         HStack {
-            Spacer()
+            Spacer(minLength: 0)
             label
                 .font(
                     Func.run {
@@ -26,11 +26,11 @@ struct PillButtonView: View {
                         case .regular:
                             return .body
                         case .small:
-                            return .callout
+                            return .caption
                         }
                     }
                 )
-            Spacer()
+            Spacer(minLength: 0)
         }
         .bold()
         .frame(
@@ -39,7 +39,7 @@ struct PillButtonView: View {
                 case .regular:
                     return AppTheme.unit * 12
                 case .small:
-                    return AppTheme.unit * 9
+                    return AppTheme.unit * 6
                 }
             }
         )

--- a/xcode/Subconscious/Shared/Components/Common/Byline/PetnameView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Byline/PetnameView.swift
@@ -53,6 +53,8 @@ struct PeerView: View {
                 .foregroundColor(.secondary)
                 .fontWeight(.regular)
                 .font(.caption)
+                .lineLimit(1)
+                .truncationMode(.middle)
         }
     }
 }

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
@@ -60,7 +60,7 @@ struct UserProfileHeaderView: View {
                         }
                     )
                     .buttonStyle(GhostPillButtonStyle(size: .small))
-                    .frame(maxWidth: 160)
+                    .frame(maxWidth: user.category == .you ? 120 : 100)
                 }
             }
             


### PR DESCRIPTION
Fixes #680 
Fixes #713 

<img width="370" alt="image" src="https://github.com/subconsciousnetwork/subconscious/assets/5009316/f51a4b29-dbd8-4138-886e-dbc2782f78f5">

# Changes
- Truncate petname in the middle
- Reduce size of profile action button

# Questions
- Do we want to shrink the buttons? We can probably get away with truncation but I feel like the buttons were a little large