### PR TITLE
Profile refresh & resolution

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -101,7 +101,14 @@ struct FollowTabView: View {
                 StoryUserView(
                     story: follow,
                     action: { _ in onNavigateToUser(follow.user) },
-                    profileAction: onProfileAction
+                    profileAction: onProfileAction,
+                    onRefreshUser: {
+                        guard let petname = follow.user.address.toPetname() else {
+                            return
+                        }
+                        
+                        send(.requestWaitForFollowedUserResolution(petname))
+                    }
                 )
             }
             

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
@@ -43,6 +43,7 @@ struct StoryUserView: View {
     var action: (Slashlink) -> Void
     
     var profileAction: (UserProfile, UserProfileAction) -> Void = { _, _ in }
+    var onRefreshUser: () -> Void = {}
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -105,7 +106,23 @@ struct StoryUserView: View {
                                 }
                             )
                         }
-                       
+                        
+                        switch story.user.resolutionStatus {
+                        case .unresolved:
+                            Button(
+                                action: {
+                                    onRefreshUser()
+                                },
+                                label: {
+                                    Label(
+                                        title: { Text("Refresh") },
+                                        icon: { Image(systemName: "arrow.clockwise") }
+                                    )
+                                }
+                            )
+                        case _:
+                            EmptyView()
+                        }
                     },
                     label: {
                         Image(systemName: "ellipsis")

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
@@ -59,7 +59,7 @@ struct StoryUserView: View {
                     
                     switch story.user.resolutionStatus {
                     case .unresolved:
-                        Image(systemName: "exclamationmark.triangle.fill")
+                        Image(systemName: "person.fill.questionmark")
                             .foregroundColor(.secondary)
                     case .pending:
                         PendingSyncBadge()

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
@@ -106,23 +106,6 @@ struct StoryUserView: View {
                                 }
                             )
                         }
-                        
-                        switch story.user.resolutionStatus {
-                        case .unresolved:
-                            Button(
-                                action: {
-                                    onRefreshUser()
-                                },
-                                label: {
-                                    Label(
-                                        title: { Text("Refresh") },
-                                        icon: { Image(systemName: "arrow.clockwise") }
-                                    )
-                                }
-                            )
-                        case _:
-                            EmptyView()
-                        }
                     },
                     label: {
                         Image(systemName: "ellipsis")
@@ -142,8 +125,10 @@ struct StoryUserView: View {
         }
         .contentShape(.interaction, RectangleCroppedTopRightCorner())
         .onTapGesture {
-            switch story.user.ourFollowStatus {
-            case .following(let name):
+            switch (story.user.ourFollowStatus, story.user.resolutionStatus) {
+            case (.following(_), .unresolved):
+                onRefreshUser()
+            case (.following(let name), _):
                 action(Slashlink(petname: name.toPetname()))
             case _:
                 action(story.user.address)

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -508,7 +508,11 @@ struct UserProfileDetailModel: ModelProtocol {
                 }
                 .eraseToAnyPublisher()
             
-            return Update(state: state, fx: fx)
+            return update(
+                state: state,
+                action: .refresh,
+                environment: environment
+            ).mergeFx(fx)
         case .succeedResolveFollowedUser:
             return update(state: state, action: .refresh, environment: environment)
         case .failResolveFollowedUser(let message):

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -245,7 +245,7 @@ extension Store<UserProfileDetailModel> {
         }
         
         do {
-            let res = try await Self.Model.refresh(
+            let res = try await Self.Model.forceRefresh(
                 address: address,
                 environment: self.environment
             )
@@ -270,6 +270,21 @@ extension UserProfileDetailModel {
             }
         }
     }
+    
+    static func forceRefresh(
+       address: Slashlink,
+       environment: UserProfileDetailModel.Environment
+   ) async throws -> UserProfileContentResponse {
+       return try await Func.run {
+           _ = try await environment.noosphere.sync()
+           
+           if let petname = address.toPetname() {
+               return try await environment.userProfile.requestUserProfile(petname: petname)
+           } else {
+               return try await environment.userProfile.requestOurProfile()
+           }
+       }
+   }
 }
 
 // MARK: Model

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -53,7 +53,10 @@ struct UserProfileDetailView: View {
             onNavigateToNote: self.onNavigateToNote,
             onNavigateToUser: self.onNavigateToUser,
             onProfileAction: self.onProfileAction,
-            onRefresh: store.refresh
+            onRefresh: {
+                app.send(.syncAll)
+                await store.refresh()
+            }
         )
         .onAppear {
             // When an editor is presented, refresh if stale.
@@ -245,7 +248,7 @@ extension Store<UserProfileDetailModel> {
         }
         
         do {
-            let res = try await Self.Model.forceRefresh(
+            let res = try await Self.Model.refresh(
                 address: address,
                 environment: self.environment
             )
@@ -270,21 +273,6 @@ extension UserProfileDetailModel {
             }
         }
     }
-    
-    static func forceRefresh(
-       address: Slashlink,
-       environment: UserProfileDetailModel.Environment
-   ) async throws -> UserProfileContentResponse {
-       return try await Func.run {
-           _ = try await environment.noosphere.sync()
-           
-           if let petname = address.toPetname() {
-               return try await environment.userProfile.requestUserProfile(petname: petname)
-           } else {
-               return try await environment.userProfile.requestOurProfile()
-           }
-       }
-   }
 }
 
 // MARK: Model

--- a/xcode/Subconscious/Shared/Services/AddressBookService.swift
+++ b/xcode/Subconscious/Shared/Services/AddressBookService.swift
@@ -355,7 +355,7 @@ actor AddressBookService {
     func waitForPetnameResolution(
         petname: Petname
     ) async throws -> Cid? {
-        let maxAttempts = 10 // 1+2+4+8+16+32+32+32+32+32 = 191 seconds
+        let maxAttempts = 13 // 1+2+4+8+16+32+32+32+32+32+32+32+32 = 287 seconds
         
         self.pendingFollows.append(petname)
         


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/684
Fixes https://github.com/subconsciousnetwork/subconscious/issues/699

# Changes

- Changed "unresolved" icon to be less prominent (screenshot below)
- Introduced "Refresh" option in context menu
- Sync with gateway when doing pull-to-refresh on profile
- Slightly increase wait duration for resolution

<img width="379" alt="image" src="https://github.com/subconsciousnetwork/subconscious/assets/5009316/c4771224-7b62-4051-8b91-76224e40968e">
