### PR TITLE
Decorate Sentry errors with log stream

### DIFF
--- a/xcode/Subconscious/Shared/Library/LogFmt.swift
+++ b/xcode/Subconscious/Shared/Library/LogFmt.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 import os
+import OSLog
+import Sentry
 
 struct LogFmt {
     private static func escapeValuePart(_ value: String) -> String {
@@ -38,6 +40,40 @@ struct LogFmt {
             parameters.append(parameter)
         }
         return parameters.joined(separator: " ")
+    }
+}
+
+extension OSLogType {
+    func toSentry() -> Sentry.SentryLevel {
+        switch (self) {
+        case .debug:
+            return .debug
+        case .info:
+            return .info
+        case .error:
+            return .error
+        case .fault:
+            return .fatal
+        default:
+            return .debug
+        }
+    }
+}
+
+extension OSLogEntryLog.Level {
+    func toSentry() -> Sentry.SentryLevel {
+        switch (self) {
+        case .debug:
+            return .debug
+        case .info:
+            return .info
+        case .error:
+            return .error
+        case .fault:
+            return .fatal
+        default:
+            return .debug
+        }
     }
 }
 

--- a/xcode/Subconscious/Shared/Library/LogFmt.swift
+++ b/xcode/Subconscious/Shared/Library/LogFmt.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import os
 
 struct LogFmt {
     private static func escapeValuePart(_ value: String) -> String {

--- a/xcode/Subconscious/Shared/Library/LogFmt.swift
+++ b/xcode/Subconscious/Shared/Library/LogFmt.swift
@@ -6,9 +6,6 @@
 //
 
 import Foundation
-import os
-import OSLog
-import Sentry
 
 struct LogFmt {
     private static func escapeValuePart(_ value: String) -> String {
@@ -43,39 +40,6 @@ struct LogFmt {
     }
 }
 
-extension OSLogType {
-    func toSentry() -> Sentry.SentryLevel {
-        switch (self) {
-        case .debug:
-            return .debug
-        case .info:
-            return .info
-        case .error:
-            return .error
-        case .fault:
-            return .fatal
-        default:
-            return .debug
-        }
-    }
-}
-
-extension OSLogEntryLog.Level {
-    func toSentry() -> Sentry.SentryLevel {
-        switch (self) {
-        case .debug:
-            return .debug
-        case .info:
-            return .info
-        case .error:
-            return .error
-        case .fault:
-            return .fatal
-        default:
-            return .debug
-        }
-    }
-}
 
 /// Extend logger to provide a LogFmt variant that allows you to log
 /// `KeyValuePairs` as a LogFmt string.

--- a/xcode/Subconscious/Shared/Library/LogFmt.swift
+++ b/xcode/Subconscious/Shared/Library/LogFmt.swift
@@ -41,7 +41,6 @@ struct LogFmt {
     }
 }
 
-
 /// Extend logger to provide a LogFmt variant that allows you to log
 /// `KeyValuePairs` as a LogFmt string.
 extension Logger {

--- a/xcode/Subconscious/Shared/Library/Sentry.swift
+++ b/xcode/Subconscious/Shared/Library/Sentry.swift
@@ -18,8 +18,12 @@ extension SentryIntegration {
             // per https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization this is fine to be public, unless it's abused (e.g. someone sending us /extra/ errors.
             options.dsn = "https://72ea1a54aeb04f60880d75fcffe705ed@o4505393671569408.ingest.sentry.io/4505393756438528"
             options.beforeSend = { event in
-                var ev = event
-                ev.breadcrumbs = getCrumbs()
+                let ev = event
+                if ev.breadcrumbs == nil {
+                    ev.breadcrumbs = []
+                }
+                
+                ev.breadcrumbs?.append(contentsOf: getCrumbs())
                 return ev
             }
         }

--- a/xcode/Subconscious/Shared/Library/Sentry.swift
+++ b/xcode/Subconscious/Shared/Library/Sentry.swift
@@ -1,0 +1,91 @@
+//
+//  Sentry.swift
+//  Subconscious
+//
+//  Created by Ben Follington on 21/6/2023.
+//
+
+import Foundation
+import os
+import OSLog
+import Sentry
+
+struct SentryIntegration {}
+
+extension SentryIntegration {
+    public static func start() {
+        SentrySDK.start { options in
+            // per https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization this is fine to be public, unless it's abused (e.g. someone sending us /extra/ errors.
+            options.dsn = "https://72ea1a54aeb04f60880d75fcffe705ed@o4505393671569408.ingest.sentry.io/4505393756438528"
+            options.beforeSend = { event in
+                var ev = event
+                ev.breadcrumbs = getCrumbs()
+                return ev
+            }
+        }
+    }
+    
+    private static func getCrumbs() -> [Breadcrumb] {
+        var crumbs: [Breadcrumb] = []
+        do {
+            let logStore = try OSLogStore(scope: .currentProcessIdentifier)
+            let logs = try logStore.getEntries()
+            
+            for l in logs {
+                guard let item = l as? OSLogEntryLog else {
+                    continue
+                }
+                
+                // There are many other system log categories to filter out
+                guard item.category == "app" else {
+                    continue
+                }
+                
+                let crumb = Breadcrumb(
+                    level: item.level.toSentry(),
+                    category: item.category
+                )
+                crumb.message = item.composedMessage
+                crumbs.append(crumb)
+            }
+        } catch {
+            return crumbs
+        }
+        
+        return crumbs
+    }
+}
+
+extension OSLogType {
+    func toSentry() -> Sentry.SentryLevel {
+        switch (self) {
+        case .debug:
+            return .debug
+        case .info:
+            return .info
+        case .error:
+            return .error
+        case .fault:
+            return .fatal
+        default:
+            return .debug
+        }
+    }
+}
+
+extension OSLogEntryLog.Level {
+    func toSentry() -> Sentry.SentryLevel {
+        switch (self) {
+        case .debug:
+            return .debug
+        case .info:
+            return .info
+        case .error:
+            return .error
+        case .fault:
+            return .fatal
+        default:
+            return .debug
+        }
+    }
+}

--- a/xcode/Subconscious/Shared/Library/Sentry.swift
+++ b/xcode/Subconscious/Shared/Library/Sentry.swift
@@ -23,7 +23,8 @@ extension SentryIntegration {
                     ev.breadcrumbs = []
                 }
                 
-                ev.breadcrumbs?.append(contentsOf: getCrumbs())
+                let crumbs = getCrumbs()
+                ev.breadcrumbs?.append(contentsOf: crumbs)
                 return ev
             }
         }
@@ -50,6 +51,8 @@ extension SentryIntegration {
                     category: item.category
                 )
                 crumb.message = item.composedMessage
+                crumb.timestamp = item.date
+                crumb.type = "log"
                 crumbs.append(crumb)
             }
         } catch {

--- a/xcode/Subconscious/Shared/SubconsciousApp.swift
+++ b/xcode/Subconscious/Shared/SubconsciousApp.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import Sentry
+import OSLog
 
 @main
 struct SubconsciousApp: App {
@@ -14,6 +15,33 @@ struct SubconsciousApp: App {
         SentrySDK.start { options in
             // per https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization this is fine to be public, unless it's abused (e.g. someone sending us /extra/ errors.
             options.dsn = "https://72ea1a54aeb04f60880d75fcffe705ed@o4505393671569408.ingest.sentry.io/4505393756438528"
+            options.beforeSend = { event in
+                var ev = event
+                var crumbs: [Breadcrumb] = []
+                do {
+                    let logStore = try OSLogStore(scope: .currentProcessIdentifier)
+                    let logs = try logStore.getEntries()
+                    
+                    for l in logs {
+                        guard let item = l as? OSLogEntryLog else {
+                            continue
+                        }
+                        
+                        guard item.category == "app" else {
+                            continue
+                        }
+                        
+                        let crumb = Breadcrumb(level: item.level.toSentry(), category: item.category)
+                        crumb.message = item.composedMessage
+                        crumbs.append(crumb)
+                    }
+                } catch {
+                    
+                }
+                ev.breadcrumbs = crumbs
+                
+                return ev
+            }
         }
     }
 

--- a/xcode/Subconscious/Shared/SubconsciousApp.swift
+++ b/xcode/Subconscious/Shared/SubconsciousApp.swift
@@ -12,37 +12,7 @@ import OSLog
 @main
 struct SubconsciousApp: App {
     init() {
-        SentrySDK.start { options in
-            // per https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization this is fine to be public, unless it's abused (e.g. someone sending us /extra/ errors.
-            options.dsn = "https://72ea1a54aeb04f60880d75fcffe705ed@o4505393671569408.ingest.sentry.io/4505393756438528"
-            options.beforeSend = { event in
-                var ev = event
-                var crumbs: [Breadcrumb] = []
-                do {
-                    let logStore = try OSLogStore(scope: .currentProcessIdentifier)
-                    let logs = try logStore.getEntries()
-                    
-                    for l in logs {
-                        guard let item = l as? OSLogEntryLog else {
-                            continue
-                        }
-                        
-                        guard item.category == "app" else {
-                            continue
-                        }
-                        
-                        let crumb = Breadcrumb(level: item.level.toSentry(), category: item.category)
-                        crumb.message = item.composedMessage
-                        crumbs.append(crumb)
-                    }
-                } catch {
-                    
-                }
-                ev.breadcrumbs = crumbs
-                
-                return ev
-            }
-        }
+        SentryIntegration.start()
     }
 
     var body: some Scene {

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		B508957029E79BE70048106B /* UserProfileService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B508956F29E79BE70048106B /* UserProfileService.swift */; };
 		B508957129E79BE70048106B /* UserProfileService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B508956F29E79BE70048106B /* UserProfileService.swift */; };
 		B51EEAA129F0C37B0055887B /* AppIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51EEAA029F0C37B0055887B /* AppIcon.swift */; };
+		B5293B892A426645001C4DA7 /* Sentry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5293B882A426645001C4DA7 /* Sentry.swift */; };
+		B5293B8A2A426645001C4DA7 /* Sentry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5293B882A426645001C4DA7 /* Sentry.swift */; };
 		B532F8C329B1752E00CE9256 /* TranscludeBlockLayoutFragment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532F8C229B1752E00CE9256 /* TranscludeBlockLayoutFragment.swift */; };
 		B540F8BA2A0C748C00876256 /* Line.swift in Sources */ = {isa = PBXBuildFile; fileRef = B540F8B92A0C748C00876256 /* Line.swift */; };
 		B54187B829EF5CA00056E4A9 /* FollowUserFormSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54187B729EF5CA00056E4A9 /* FollowUserFormSheet.swift */; };
@@ -450,6 +452,7 @@
 		B508956D29E7862A0048106B /* Tests_AddressBookService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_AddressBookService.swift; sourceTree = "<group>"; };
 		B508956F29E79BE70048106B /* UserProfileService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileService.swift; sourceTree = "<group>"; };
 		B51EEAA029F0C37B0055887B /* AppIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIcon.swift; sourceTree = "<group>"; };
+		B5293B882A426645001C4DA7 /* Sentry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sentry.swift; sourceTree = "<group>"; };
 		B532F8C229B1752E00CE9256 /* TranscludeBlockLayoutFragment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscludeBlockLayoutFragment.swift; sourceTree = "<group>"; };
 		B540F8B92A0C748C00876256 /* Line.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Line.swift; sourceTree = "<group>"; };
 		B54187B729EF5CA00056E4A9 /* FollowUserFormSheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FollowUserFormSheet.swift; sourceTree = "<group>"; };
@@ -1283,6 +1286,7 @@
 				B8249DA227E2753800BCDFBA /* ViewUtilities.swift */,
 				B5CA448829D6A1C7002FD83C /* DummyDataUtilities.swift */,
 				B8E1A9452A12F69E00B757A5 /* LogFmt.swift */,
+				B5293B882A426645001C4DA7 /* Sentry.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -1732,6 +1736,7 @@
 				B58862C829F612CE006C2EE4 /* EditProfileSheet.swift in Sources */,
 				B8D7F04227A4AE590042C7CF /* SuggestionViewModifier.swift in Sources */,
 				B58A46AF29D3C62B00491E43 /* StoryEntryView.swift in Sources */,
+				B5293B892A426645001C4DA7 /* Sentry.swift in Sources */,
 				B8E00A2D299294A0003B40C1 /* UserDefaultsProperty.swift in Sources */,
 				B57C0AF129D280E900D352E3 /* TabButtonView.swift in Sources */,
 				B8B604E629146DF6006FCB77 /* MemoryStore.swift in Sources */,
@@ -1967,6 +1972,7 @@
 				B8DA32B629CB999500EA166E /* AppUpgradeView.swift in Sources */,
 				B58C73A829DBB3B500B00EA1 /* UserProfileView.swift in Sources */,
 				B8B4250D28FB43C90081B8D5 /* ContentType.swift in Sources */,
+				B5293B8A2A426645001C4DA7 /* Sentry.swift in Sources */,
 				B8A41D4F2811E81E0096D2E7 /* WikilinkBarView.swift in Sources */,
 				B86DFF2927BF02F0002E57ED /* CollectionUtilities.swift in Sources */,
 				B8879EA126F90C5100A0B4FF /* NotebookNavigationView.swift in Sources */,


### PR DESCRIPTION
Extends #740 

Use `OSLogEnumerator` to pin the app logs to the reported error. This probably isn't super efficient but given the nature of reporting a crash, that's probably ok.