### PR TITLE
Make Gateway URL update idempotent

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -1105,6 +1105,7 @@ struct AppModel: ModelProtocol {
         url: URL
     ) -> Update<AppModel> {
         guard state.gatewayURL != url.absoluteString else {
+            logger.log("Gateway URL is identical to current value, doing nothing")
             return Update(state: state)
         }
         
@@ -1135,6 +1136,7 @@ struct AppModel: ModelProtocol {
         environment: AppEnvironment
     ) -> Update<AppModel> {
         guard let url = state.gatewayURLField.validated else {
+            logger.log("Gateway URL field is invalid, doing nothing")
             return Update(state: state)
         }
         

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -121,6 +121,7 @@ enum AppAction: CustomLogStringConvertible {
 
     /// Set gateway URL
     case submitGatewayURL(_ url: URL)
+    case submitGatewayURLForm
     case succeedResetGatewayURL(_ url: URL)
 
     /// Create a new sphere given an owner key name
@@ -658,6 +659,11 @@ struct AppModel: ModelProtocol {
                 environment: environment,
                 url: url
             )
+        case .submitGatewayURLForm:
+            return submitGatewayURLForm(
+                state: state,
+                environment: environment
+            )
         case let .succeedResetGatewayURL(url):
             return succeedResetGatewayURL(
                 state: state,
@@ -1093,6 +1099,10 @@ struct AppModel: ModelProtocol {
         environment: AppEnvironment,
         url: URL
     ) -> Update<AppModel> {
+        guard state.gatewayURL != url.absoluteString else {
+            return Update(state: state)
+        }
+        
         var model = state
         model.gatewayURL = url.absoluteString
 
@@ -1113,6 +1123,21 @@ struct AppModel: ModelProtocol {
             environment: environment
         )
         .mergeFx(fx)
+    }
+    
+    static func submitGatewayURLForm(
+        state: AppModel,
+        environment: AppEnvironment
+    ) -> Update<AppModel> {
+        guard let url = state.gatewayURLField.validated else {
+            return Update(state: state)
+        }
+        
+        return update(
+            state: state,
+            action: .submitGatewayURL(url),
+            environment: environment
+        )
     }
     
     static func succeedResetGatewayURL(

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -490,6 +490,11 @@ struct AppModel: ModelProtocol {
     )
     var lastGatewaySyncStatus = ResourceStatus.initial
     
+    var gatewayOperationInProgress: Bool {
+        lastGatewaySyncStatus == .pending ||
+        gatewayProvisioningStatus == .pending
+    }
+    
     /// Show settings sheet?
     var isSettingsSheetPresented = false
     

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -1142,7 +1142,10 @@ struct AppModel: ModelProtocol {
         
         return update(
             state: state,
-            action: .submitGatewayURL(url),
+            actions: [
+                .submitGatewayURL(url),
+                .syncSphereWithGateway
+            ],
             environment: environment
         )
     }

--- a/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
@@ -109,16 +109,14 @@ struct GatewayURLSettingsView: View {
                     .autocapitalization(.none)
                     .keyboardType(.URL)
                     .onDisappear {
-                        guard let url = app.state.gatewayURLField.validated else {
-                            return
-                        }
-                        
-                        app.send(.submitGatewayURL(url))
+                        app.send(.submitGatewayURLForm)
                     }
                     
                     if app.state.gatewayProvisioningStatus != .pending {
                         Button(
                             action: {
+                                // Ensure URL is updated before trying to sync
+                                app.send(.submitGatewayURLForm)
                                 app.send(.syncSphereWithGateway)
                             },
                             label: {

--- a/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
@@ -111,22 +111,24 @@ struct GatewayURLSettingsView: View {
                     .onDisappear {
                         app.send(.submitGatewayURLForm)
                     }
+                    .disabled(app.state.gatewayOperationInProgress)
                     
-                    if app.state.gatewayProvisioningStatus != .pending {
-                        Button(
-                            action: {
-                                // Ensure URL is updated before trying to sync
-                                app.send(.submitGatewayURLForm)
-                                app.send(.syncSphereWithGateway)
-                            },
-                            label: {
-                                GatewaySyncLabel(
-                                    status: app.state.lastGatewaySyncStatus
-                                )
-                            }
-                        )
-                        .disabled(app.state.gatewayURL.count == 0)
-                    }
+                    Button(
+                        action: {
+                            // Ensure URL is updated before trying to sync
+                            app.send(.submitGatewayURLForm)
+                            app.send(.syncSphereWithGateway)
+                        },
+                        label: {
+                            GatewaySyncLabel(
+                                status: app.state.lastGatewaySyncStatus
+                            )
+                        }
+                    )
+                    .disabled(
+                        app.state.gatewayURL.count == 0 ||
+                        app.state.gatewayOperationInProgress
+                    )
                 }, header: {
                     Text("Gateway")
                 }, footer: {

--- a/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
@@ -115,9 +115,7 @@ struct GatewayURLSettingsView: View {
                     
                     Button(
                         action: {
-                            // Ensure URL is updated before trying to sync
                             app.send(.submitGatewayURLForm)
-                            app.send(.syncSphereWithGateway)
                         },
                         label: {
                             GatewaySyncLabel(

--- a/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
@@ -65,7 +65,7 @@ struct GatewayProvisioningSection: View {
                 .onDisappear {
                     app.send(.setInviteCode(app.state.inviteCodeFormField.value))
                 }
-                .disabled(app.state.gatewayProvisioningStatus == .pending)
+                .disabled(app.state.gatewayOperationInProgress)
                 
                 Button(
                     action: {
@@ -81,7 +81,7 @@ struct GatewayProvisioningSection: View {
                 )
                 .disabled(
                     !app.state.inviteCodeFormField.isValid ||
-                    app.state.gatewayProvisioningStatus == .pending
+                    app.state.gatewayOperationInProgress
                 )
             },
             header: {

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -117,6 +117,11 @@ actor NoosphereService:
     /// Update Gateway.
     /// Resets memoized Noosphere and Sphere instances.
     func resetGateway(url: URL?) {
+        guard self.gatewayURL != url else {
+            logger.debug("Reset gateway to identical URL, ignoring")
+            return
+        }
+       
         logger.debug("Reset gateway: \(url?.absoluteString ?? "none")")
         self.gatewayURL = url
         self._noosphere = nil


### PR DESCRIPTION
Related to https://github.com/subconsciousnetwork/subconscious/issues/693

# Changes
- Clarify gateway URL lifecycle
- Make updates to gateway URL idempotent
- Prevent editing key values during sync

Unsure if this technically "fixes" the issue, since we still reset our noosphere instance as-soon-as there's a reason to update the gateway URL. Perhaps we should be queuing the reset operation (somehow) until after in-flight work is complete? Or perhaps we can find a way to update the gateway URL without tearing down and rebuilding noosphere?