### PR TITLE
Fix loading bar animation

### DIFF
--- a/xcode/Subconscious/Shared/Components/OmniboxView.swift
+++ b/xcode/Subconscious/Shared/Components/OmniboxView.swift
@@ -83,7 +83,6 @@ struct OmniboxView: View {
                     value: phase
                 )
                 // Keep the view mounted but invisible
-                // This prevents a race condition where SwiftUI animates the position
                 .opacity(status == .loading ? 0.5 : 0)
         )
         .frame(minWidth: 100, idealWidth: 240, maxWidth: 240)

--- a/xcode/Subconscious/Shared/Components/OmniboxView.swift
+++ b/xcode/Subconscious/Shared/Components/OmniboxView.swift
@@ -63,7 +63,6 @@ struct OmniboxView: View {
         .padding(.leading, 8)
         .padding(.trailing, 12)
         .frame(height: 34)
-        .frame(minWidth: 100, idealWidth: 240, maxWidth: 240)
         .overlay(
             RoundedRectangle(cornerRadius: AppTheme.cornerRadius)
                 .stroke(Color.separator, lineWidth: 0.5)
@@ -87,6 +86,7 @@ struct OmniboxView: View {
                 // This prevents a race condition where SwiftUI animates the position
                 .opacity(status == .loading ? 0.5 : 0)
         )
+        .frame(minWidth: 100, idealWidth: 240, maxWidth: 240)
         .task {
             phase += Double.pi * 2
         }

--- a/xcode/Subconscious/Shared/Components/OmniboxView.swift
+++ b/xcode/Subconscious/Shared/Components/OmniboxView.swift
@@ -63,6 +63,7 @@ struct OmniboxView: View {
         .padding(.leading, 8)
         .padding(.trailing, 12)
         .frame(height: 34)
+        .frame(minWidth: 100, idealWidth: 240, maxWidth: 240)
         .overlay(
             RoundedRectangle(cornerRadius: AppTheme.cornerRadius)
                 .stroke(Color.separator, lineWidth: 0.5)
@@ -86,8 +87,7 @@ struct OmniboxView: View {
                 // This prevents a race condition where SwiftUI animates the position
                 .opacity(status == .loading ? 0.5 : 0)
         )
-        .frame(minWidth: 100, idealWidth: 240, maxWidth: 240)
-        .onAppear {
+        .task {
             phase += Double.pi * 2
         }
     }


### PR DESCRIPTION
Fixes #709 

It really seems like switching from `.onAppear` to `.task` is enough. I could speculate as to why, but the short answer must be a race condition between layout and animation that is resolved by the time a `.task` runs.

I can trigger the issue occasionally by spamming navigation with `.onAppear` but not with `.task`.