### PR TITLE
Fix memory santization error

### DIFF
--- a/xcode/Subconscious/Shared/Services/Noosphere/Noosphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Noosphere.swift
@@ -244,6 +244,9 @@ public actor Noosphere {
         _ perform: (UnsafeMutablePointer<OpaquePointer?>) -> Z
     ) throws -> Z {
         let error = UnsafeMutablePointer<OpaquePointer?>.allocate(capacity: 1)
+        // Explicitly clear this memory before use
+        error.pointee = nil
+        
         defer {
             error.deallocate()
         }

--- a/xcode/Subconscious/Subconscious.xcodeproj/xcshareddata/xcschemes/Subconscious (iOS).xcscheme
+++ b/xcode/Subconscious/Subconscious.xcodeproj/xcshareddata/xcschemes/Subconscious (iOS).xcscheme
@@ -26,7 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       enableASanStackUseAfterReturn = "YES">
       <EnvironmentVariables>
          <EnvironmentVariable
@@ -62,6 +62,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableAddressSanitizer = "YES"
+      enableASanStackUseAfterReturn = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -78,6 +80,13 @@
             ReferencedContainer = "container:Subconscious.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <AdditionalOptions>
+         <AdditionalOption
+            key = "MallocScribble"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
Fixes #759 

Discovered using the `Address Sanitizer` diagnostic in Xcode, which I've left enabled in Debug.

We must explicitly zero-out the `pointee` field after this unsafe allocation, otherwise it could literally be pointing _anywhere_.