### PR TITLE
Make notes empty state pull-to-refreshable

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListEmptyView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListEmptyView.swift
@@ -1,0 +1,59 @@
+//
+//  EntryListEmptyView.swift
+//  Subconscious (iOS)
+//
+//  Created by Gordon Brander on 6/28/23.
+//
+
+import SwiftUI
+
+struct EntryListEmptyView: View {
+    var onRefresh: () -> Void
+
+    var body: some View {
+        GeometryReader { geom in
+            ScrollView {
+                VStack {
+                    Spacer()
+                    HStack {
+                        Spacer()
+                        VStack(spacing: AppTheme.unit * 6) {
+                            Image(systemName: "sparkles")
+                                .font(.system(size: 64))
+                            Text("Your Subconscious is empty")
+                            VStack(spacing: AppTheme.unit) {
+                                Text(
+                                    "If your mind is empty, it is always ready for anything, it is open to everything. In the beginner's mind there are many possibilities, but in the expert's mind there are few."
+                                )
+                                .italic()
+                                Text(
+                                    "Shunryū Suzuki"
+                                )
+                            }
+                            .frame(width: 240)
+                            .font(.caption)
+                        }
+                        Spacer()
+                    }
+                    Spacer()
+                }
+                .multilineTextAlignment(.center)
+                .padding()
+                .frame(minHeight: geom.size.height)
+            }
+            .foregroundColor(Color.secondary)
+            .background(Color.background)
+            .refreshable {
+                onRefresh()
+            }
+        }
+    }
+}
+
+struct EntryListEmptyView_Previews: PreviewProvider {
+    static var previews: some View {
+        EntryListEmptyView(
+            onRefresh: {}
+        )
+    }
+}

--- a/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListView.swift
@@ -61,34 +61,7 @@ struct EntryListView: View {
                 }
                 .listStyle(.plain)
             } else {
-                VStack(spacing: AppTheme.unit * 6) {
-                    Spacer()
-                    Image(systemName: "sparkles")
-                        .font(.system(size: 64))
-                    Text("Your Subconscious is empty")
-                    VStack(spacing: AppTheme.unit) {
-                        Text(
-                            "If your mind is empty, it is always ready for anything, it is open to everything. In the beginner's mind there are many possibilities, but in the expert's mind there are few."
-                        )
-                        .italic()
-                        Text(
-                            "Shunryū Suzuki"
-                        )
-                    }
-                    .frame(maxWidth: 240)
-                    // Some extra padding to visually center the group.
-                    // The icon is large and rather heavy. This offset
-                    // helps prevent the illusion of being off-center.
-                    .padding(.bottom, AppTheme.unit * 24)
-                    .font(.caption)
-                    Spacer()
-                }
-                .multilineTextAlignment(.center)
-                .padding()
-                .frame(maxWidth: .infinity)
-                .foregroundColor(Color.secondary)
-                .background(Color.background)
-                .transition(.opacity)
+                EntryListEmptyView(onRefresh: onRefresh)
             }
         } else {
             ProgressScrimView()

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -220,6 +220,7 @@
 		B88A76D429E09B51005F3422 /* PasteboardService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88A76D329E09B51005F3422 /* PasteboardService.swift */; };
 		B88A76D529E09B51005F3422 /* PasteboardService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88A76D329E09B51005F3422 /* PasteboardService.swift */; };
 		B88A76D729E0AA44005F3422 /* Tests_MemoViewerDetailMetaSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88A76D629E0AA44005F3422 /* Tests_MemoViewerDetailMetaSheet.swift */; };
+		B88A91A12A4C9C0100422ABF /* EntryListEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88A91A02A4C9C0100422ABF /* EntryListEmptyView.swift */; };
 		B88B1CDE298DE66E0062CB7F /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88B1CDD298DE66E0062CB7F /* SettingsView.swift */; };
 		B88B1CE1298EAE730062CB7F /* PillButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88B1CE0298EAE730062CB7F /* PillButtonStyle.swift */; };
 		B88B1CE3298EB0100062CB7F /* BarButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88B1CE2298EB0100062CB7F /* BarButtonStyle.swift */; };
@@ -602,6 +603,7 @@
 		B8879EAB26F944DA00A0B4FF /* MemoEditorDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoEditorDetail.swift; sourceTree = "<group>"; };
 		B88A76D329E09B51005F3422 /* PasteboardService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardService.swift; sourceTree = "<group>"; };
 		B88A76D629E0AA44005F3422 /* Tests_MemoViewerDetailMetaSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_MemoViewerDetailMetaSheet.swift; sourceTree = "<group>"; };
+		B88A91A02A4C9C0100422ABF /* EntryListEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryListEmptyView.swift; sourceTree = "<group>"; };
 		B88B1CDD298DE66E0062CB7F /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		B88B1CE0298EAE730062CB7F /* PillButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillButtonStyle.swift; sourceTree = "<group>"; };
 		B88B1CE2298EB0100062CB7F /* BarButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarButtonStyle.swift; sourceTree = "<group>"; };
@@ -1020,6 +1022,15 @@
 			path = Services;
 			sourceTree = "<group>";
 		};
+		B88A919F2A4C9BED00422ABF /* EntryList */ = {
+			isa = PBXGroup;
+			children = (
+				B86DFF2C27C0280B002E57ED /* EntryListView.swift */,
+				B88A91A02A4C9C0100422ABF /* EntryListEmptyView.swift */,
+			);
+			path = EntryList;
+			sourceTree = "<group>";
+		};
 		B88B1CDC298DE65E0062CB7F /* Settings */ = {
 			isa = PBXGroup;
 			children = (
@@ -1301,7 +1312,6 @@
 		B8EC568426F41A2C00AC64E5 /* Common */ = {
 			isa = PBXGroup;
 			children = (
-				B540F8B82A0C748100876256 /* Shapes */,
 				B8CBAFA5299449810079107E /* Audience */,
 				B8AC648E278F7E7B0099E96B /* BackLabelStyle.swift */,
 				B8545F0C2970577600BC4EA1 /* BacklinkReacts.swift */,
@@ -1310,7 +1320,8 @@
 				B822F18C27C9C0AB00943C6B /* CountChip.swift */,
 				B57D63BA29B1CA8B008BBB62 /* DidView.swift */,
 				B8B4D7ED27EA8AA000633B5F /* DragHandleView.swift */,
-				B86DFF2C27C0280B002E57ED /* EntryListView.swift */,
+				B5A7AD312A0D0B0E007C3535 /* EmptyStateView.swift */,
+				B88A919F2A4C9BED00422ABF /* EntryList */,
 				B82FD4552730A62C002CB641 /* EntryRow.swift */,
 				B8A1621729B39337008322EB /* ExpandAlignedLeadingViewModifier.swift */,
 				B83E91D627692EC600045C6A /* FAB.swift */,
@@ -1320,6 +1331,7 @@
 				B8AE34CA276C195E00777FF0 /* LinkSuggestionLabelView.swift */,
 				B856521F2975BA9000B7FCA0 /* MetaTableView.swift */,
 				B8DEBF182798B6A8007CB528 /* NavigationToolbar.swift */,
+				B5D71D182A32B2AF000E058A /* NotFoundView.swift */,
 				B8249D9F27E2668500BCDFBA /* PinTrailingBottom.swift */,
 				B58A46B829D4001500491E43 /* Profile */,
 				B8AC648B278F757B0099E96B /* ProgressScrimView.swift */,
@@ -1329,6 +1341,7 @@
 				B8AE34BE276BD61400777FF0 /* RowButtonStyle.swift */,
 				B85BF46E27BB0FA800F55730 /* RowViewModifier.swift */,
 				B8CC433C27A07CE10079D2F9 /* ScrimView.swift */,
+				B540F8B82A0C748100876256 /* Shapes */,
 				B8A41D502811F87C0096D2E7 /* SlashlinkBarView.swift */,
 				B80890A62A056A130087E091 /* SlashlinkDisplayView.swift */,
 				B85652182975B29800B7FCA0 /* Story */,
@@ -1341,8 +1354,6 @@
 				B85BF47427BB3D6E00F55730 /* ToolbarTitleGroupView.swift */,
 				B532F8C129B1750F00CE9256 /* Transclude */,
 				B8A41D4D2811E81E0096D2E7 /* WikilinkBarView.swift */,
-				B5A7AD312A0D0B0E007C3535 /* EmptyStateView.swift */,
-				B5D71D182A32B2AF000E058A /* NotFoundView.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1755,6 +1766,7 @@
 				B5CA448929D6A1C7002FD83C /* DummyDataUtilities.swift in Sources */,
 				B8879EAC26F944DA00A0B4FF /* MemoEditorDetail.swift in Sources */,
 				B8E1A94B2A14198400B757A5 /* OurSphereRecord.swift in Sources */,
+				B88A91A12A4C9C0100422ABF /* EntryListEmptyView.swift in Sources */,
 				B5F6ADC929C02F4A00690DE4 /* AddressBookService.swift in Sources */,
 				B8925B2F29C23017001F9503 /* MemoViewerDetailView.swift in Sources */,
 				B56C3D3E2A01E5020071EF70 /* InviteCode.swift in Sources */,
@@ -2221,6 +2233,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iOS/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Subconscious;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Optionally adding friends via scanning a QR Code";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -2261,6 +2274,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iOS/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Subconscious;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Optionally adding friends via scanning a QR Code";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;


### PR DESCRIPTION
Fixes #599

- Create group for EntryList views
- Break empty state out into separate view
- Wrap empty state in scrollview, implement refreshable

Creates an escape hatch, at least, if users run into https://github.com/subconsciousnetwork/subconscious/issues/723