### PR TITLE
Prevent overwriting petnames via Follow User form

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserFormSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserFormSheet.swift
@@ -264,7 +264,7 @@ struct FollowUserFormView: View {
                         send: send,
                         tag: FollowUserFormAction.petnameField
                     ),
-                    caption: "Lowercase letters, numbers and dashes only."
+                    caption: state.failFollowMessage ?? "Lowercase letters, numbers and dashes only."
                 )
                 .lineLimit(1)
                 .textInputAutocapitalization(.never)
@@ -279,6 +279,7 @@ struct FollowUserFormView: View {
 enum FollowUserFormAction: Equatable {
     case didField(FormFieldAction<String>)
     case petnameField(FormFieldAction<String>)
+    case failFollow(_ error: String)
     case reset
 }
 
@@ -297,6 +298,8 @@ struct FollowUserFormModel: ModelProtocol {
         value: "",
         validate: Self.validatePetname
     )
+    
+    var failFollowMessage: String? = nil
     
     static func validateDid(key: String) -> Did? {
         Did(key)
@@ -324,6 +327,10 @@ struct FollowUserFormModel: ModelProtocol {
                 action: action,
                 environment: FormFieldEnvironment()
             )
+        case .failFollow(let error):
+            var model = state
+            model.failFollowMessage = error
+            return Update(state: model)
         case .reset:
             return update(
                 state: state,

--- a/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserFormSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserFormSheet.swift
@@ -136,7 +136,7 @@ enum FollowNewUserFormSheetAction {
     case qrCodeScanned(scannedContent: String)
     case qrCodeScanError(error: String)
     
-    case failFollow(error: String, petname: Petname.Name)
+    case failFollowDueToPetnameCollision(error: String, petname: Petname.Name)
     case attemptToFindUniquePetname(petname: Petname.Name)
     case succeedFindUniquePetname(petname: Petname.Name)
     case failToFindUniquePetname(_ error: String)
@@ -195,12 +195,12 @@ struct FollowNewUserFormSheetModel: ModelProtocol {
             model.failQRCodeScanErrorMessage = error
             return Update(state: model)
             
-        case .failFollow(let error, let petname):
+        case .failFollowDueToPetnameCollision(let error, let petname):
             return update(
                 state: state,
                 actions: [
                     .attemptToFindUniquePetname(petname: petname),
-                    .form(.failFollow(error))
+                    .form(.failFollowDueToPetnameCollision(error))
                 ],
                 environment: environment
             )
@@ -326,7 +326,7 @@ struct FollowUserFormView: View {
 enum FollowUserFormAction: Equatable {
     case didField(FormFieldAction<String>)
     case petnameField(FormFieldAction<String>)
-    case failFollow(_ error: String)
+    case failFollowDueToPetnameCollision(_ error: String)
     case reset
 }
 
@@ -374,7 +374,7 @@ struct FollowUserFormModel: ModelProtocol {
                 action: action,
                 environment: FormFieldEnvironment()
             )
-        case .failFollow(let error):
+        case .failFollowDueToPetnameCollision(let error):
             var model = state
             model.failFollowMessage = error
             return update(

--- a/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserFormSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserFormSheet.swift
@@ -385,8 +385,10 @@ struct FollowUserFormModel: ModelProtocol {
                 environment: environment
             )
         case .reset:
+            var model = state
+            model.failFollowMessage = nil
             return update(
-                state: state,
+                state: model,
                 actions: [
                     .didField(.reset),
                     .petnameField(.reset)

--- a/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserFormSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserFormSheet.swift
@@ -227,8 +227,12 @@ struct FollowNewUserFormSheetModel: ModelProtocol {
                 environment: environment
             )
         case .failToFindUniquePetname(let error):
-            // Not a huge deal, the user will have to enter a name themselves
             logger.warning("Failed to find a unique petname: \(error)")
+            // We do not need to surface an error to the UI here.
+            // If we tried to find a unique name in the first place then
+            // the input field will already be marked as invalid and have
+            // the caption changed to the message "Petname already in use" or whatever
+            // the localizedDescription for the relevant AddressBookServiceError.
             return Update(state: state)
         }
     }

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -717,7 +717,24 @@ struct UserProfileDetailModel: ModelProtocol {
     ) -> Update<Self> {
         var model = state
         model.failFollowErrorMessage = error
-        return Update(state: model)
+        return update(
+            state: model,
+            actions: [
+                .followNewUserFormSheet(
+                    .form(
+                        .failFollow(error)
+                    )
+                ),
+                .followNewUserFormSheet(
+                    .form(
+                        .petnameField(
+                            .setValidationStatus(valid: false)
+                        )
+                    )
+                )
+            ],
+            environment: environment
+        )
     }
     
     static func dismissFailFollowError(

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -130,7 +130,8 @@ enum UserProfileDetailAction: CustomLogStringConvertible {
     
     case requestFollow(UserProfile)
     case attemptFollow(Did, Petname)
-    case failFollow(error: String, petname: Petname)
+    case failFollow(error: String)
+    case failFollowDueToPetnameCollision(petname: Petname)
     case dismissFailFollowError
     case succeedFollow(_ petname: Petname)
     
@@ -426,12 +427,17 @@ struct UserProfileDetailModel: ModelProtocol {
                 environment: environment,
                 petname: petname
             )
-        case .failFollow(let error, let petname):
+        case .failFollow(let error):
             return failFollow(
                 state: state,
                 environment: environment,
-                petname: petname,
                 error: error
+            )
+        case .failFollowDueToPetnameCollision(let petname):
+            return failFollowDueToPetnameCollision(
+                state: state,
+                environment: environment,
+                petname: petname
             )
         case .dismissFailFollowError:
             return dismissFailFollowError(
@@ -672,13 +678,17 @@ struct UserProfileDetailModel: ModelProtocol {
             .map({ _ in
                 UserProfileDetailAction.succeedFollow(petname)
             })
-            .catch { error in
-                Just(
-                    UserProfileDetailAction.failFollow(
-                        error: error.localizedDescription,
+            .recover { error in
+                switch error {
+                case AddressBookError.invalidAttemptToOverwitePetname:
+                    return .failFollowDueToPetnameCollision(
                         petname: petname
                     )
-                )
+                case _:
+                    return .failFollow(
+                        error: error.localizedDescription
+                    )
+                }
             }
             .eraseToAnyPublisher()
         
@@ -715,16 +725,29 @@ struct UserProfileDetailModel: ModelProtocol {
     static func failFollow(
         state: Self,
         environment: Environment,
-        petname: Petname,
         error: String
     ) -> Update<Self> {
         var model = state
         model.failFollowErrorMessage = error
+        
+        return Update(state: model)
+    }
+    
+    static func failFollowDueToPetnameCollision(
+        state: Self,
+        environment: Environment,
+        petname: Petname
+    ) -> Update<Self> {
         return update(
-            state: model,
+            state: state,
             actions: [
                 .followNewUserFormSheet(
-                    .failFollow(error: error, petname: petname.root)
+                    .failFollow(
+                        error: AddressBookError
+                            .invalidAttemptToOverwitePetname
+                            .localizedDescription,
+                        petname: petname.root
+                    )
                 )
             ],
             environment: environment

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -130,7 +130,7 @@ enum UserProfileDetailAction: CustomLogStringConvertible {
     
     case requestFollow(UserProfile)
     case attemptFollow(Did, Petname)
-    case failFollow(error: String)
+    case failFollow(error: String, petname: Petname)
     case dismissFailFollowError
     case succeedFollow(_ petname: Petname)
     
@@ -347,7 +347,7 @@ struct UserProfileDetailModel: ModelProtocol {
             return FollowNewUserFormSheetCursor.update(
                 state: state,
                 action: action,
-                environment: ()
+                environment: environment
             )
         case .editProfileSheet(let action):
             return EditProfileSheetCursor.update(
@@ -426,10 +426,11 @@ struct UserProfileDetailModel: ModelProtocol {
                 environment: environment,
                 petname: petname
             )
-        case .failFollow(error: let error):
+        case .failFollow(let error, let petname):
             return failFollow(
                 state: state,
                 environment: environment,
+                petname: petname,
                 error: error
             )
         case .dismissFailFollowError:
@@ -674,7 +675,8 @@ struct UserProfileDetailModel: ModelProtocol {
             .catch { error in
                 Just(
                     UserProfileDetailAction.failFollow(
-                        error: error.localizedDescription
+                        error: error.localizedDescription,
+                        petname: petname
                     )
                 )
             }
@@ -713,6 +715,7 @@ struct UserProfileDetailModel: ModelProtocol {
     static func failFollow(
         state: Self,
         environment: Environment,
+        petname: Petname,
         error: String
     ) -> Update<Self> {
         var model = state
@@ -721,16 +724,7 @@ struct UserProfileDetailModel: ModelProtocol {
             state: model,
             actions: [
                 .followNewUserFormSheet(
-                    .form(
-                        .failFollow(error)
-                    )
-                ),
-                .followNewUserFormSheet(
-                    .form(
-                        .petnameField(
-                            .setValidationStatus(valid: false)
-                        )
-                    )
+                    .failFollow(error: error, petname: petname.root)
                 )
             ],
             environment: environment

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -742,7 +742,7 @@ struct UserProfileDetailModel: ModelProtocol {
             state: state,
             actions: [
                 .followNewUserFormSheet(
-                    .failFollow(
+                    .failFollowDueToPetnameCollision(
                         error: AddressBookError
                             .invalidAttemptToOverwitePetname
                             .localizedDescription,

--- a/xcode/Subconscious/Shared/Services/AddressBookService.swift
+++ b/xcode/Subconscious/Shared/Services/AddressBookService.swift
@@ -53,7 +53,7 @@ extension AddressBookError: LocalizedError {
             )
         case .invalidAttemptToOverwitePetname:
             return String(
-                localized: "This petname is already in use.",
+                localized: "Petname already in use.",
                 comment: "Address Book error description"
             )
         case .other(let msg):

--- a/xcode/Subconscious/Shared/Services/AddressBookService.swift
+++ b/xcode/Subconscious/Shared/Services/AddressBookService.swift
@@ -400,7 +400,11 @@ actor AddressBookService {
         preventOverwrite: Bool = false
     ) -> AnyPublisher<Void, Error> {
         Future.detached {
-            try await self.followUser(did: did, petname: petname)
+            try await self.followUser(
+                did: did,
+                petname: petname,
+                preventOverwrite: preventOverwrite
+            )
         }
         .eraseToAnyPublisher()
     }


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/769

# Demo

https://github.com/subconsciousnetwork/subconscious/assets/5009316/74cbe177-07a9-4763-acf0-63d7d770e383

# Questions

- Is it better to:
    1. mark collision as a validation error and force the user to pick a new name
    2. replace the name with an available suffixed version _in the form_
    3. dismiss the form and find a unique name in the background, adding a suffix if needed

I tried (1) first and liked it but currently we have (2). (3) seems like a hard sell without #333.

# Changes
- Prevent overwriting petnames
- Surface overwrite petname error to UI
- Suggest a unique name if there is a collision
