### PR TITLE
Implement Authorization FFI

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -243,6 +243,8 @@ enum AppAction: CustomLogStringConvertible {
     /// We cache user profiles for performance during browsing, but we should clear this cache on sync
     case resetUserProfileCache
     case succeedResetUserProfileCache
+    
+    case authorization(_ action: AuthorizationSettingsAction)
 
     /// Set recovery phrase on recovery phrase component
     static func setRecoveryPhrase(_ phrase: String) -> AppAction {
@@ -485,6 +487,8 @@ struct AppModel: ModelProtocol {
     /// one-time long-running migration tasks at startup.
     var appUpgrade = AppUpgradeModel()
     
+    var authorization = AuthorizationSettingsModel()
+    
     /// Preferred Gateway URL.
     ///
     /// This property is updated at `.start` with the corresponding value
@@ -568,6 +572,12 @@ struct AppModel: ModelProtocol {
                 state: state,
                 action: action,
                 environment: FormFieldEnvironment()
+            )
+        case .authorization(let action):
+            return AuthorizationSettingsCursor.update(
+                state: state,
+                action: action,
+                environment: environment
             )
         case .scenePhaseChange(let scenePhase):
             return scenePhaseChange(

--- a/xcode/Subconscious/Shared/Components/Common/EllipsisLabelView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EllipsisLabelView.swift
@@ -1,0 +1,17 @@
+//
+//  EllipsisLabelView.swift
+//  Subconscious (iOS)
+//
+//  Created by Ben Follington on 19/7/2023.
+//
+
+import Foundation
+import SwiftUI
+
+struct EllipsisLabelView: View {
+    var body: some View {
+        Image(systemName: "ellipsis")
+            .frame(width: AppTheme.minTouchSize, height: AppTheme.minTouchSize)
+            .foregroundColor(.secondary)
+    }
+}

--- a/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserFormSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserFormSheet.swift
@@ -405,7 +405,7 @@ struct FollowUserFormModel: ModelProtocol {
 
 // MARK: Cursors
 
-struct PetnameFieldCursor: CursorProtocol {
+private struct PetnameFieldCursor: CursorProtocol {
     typealias Model = FollowUserFormModel
     typealias ViewModel = FormField<String, Petname.Name>
 
@@ -424,7 +424,7 @@ struct PetnameFieldCursor: CursorProtocol {
     }
 }
 
-struct DidFieldCursor: CursorProtocol {
+private struct DidFieldCursor: CursorProtocol {
     typealias Model = FollowUserFormModel
     typealias ViewModel = FormField<String, Did>
 

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
@@ -108,10 +108,7 @@ struct StoryUserView: View {
                         }
                     },
                     label: {
-                        Image(systemName: "ellipsis")
-                            .frame(width: AppTheme.minTouchSize, height: AppTheme.minTouchSize)
-                            .background(.background)
-                            .foregroundColor(.secondary)
+                        EllipsisLabelView()
                     }
                 ).disabled(story.user.category == .ourself)
             }

--- a/xcode/Subconscious/Shared/Components/Settings/AuthorizationSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/AuthorizationSettingsView.swift
@@ -31,10 +31,13 @@ struct AuthorizationView: View {
 
 struct AuthorizationSettingsView: View {
     @ObservedObject var app: Store<AppModel>
+    var state: AuthorizationSettingsModel {
+        app.state.authorization
+    }
 
     var body: some View {
         Form {
-            if let lastAuth = app.state.authorization.lastAuthorization {
+            if let lastAuth = state.lastAuthorization {
                 Section(
                     content: {
                         AuthorizationView(authorization: lastAuth)
@@ -49,7 +52,7 @@ struct AuthorizationSettingsView: View {
                     
                     ValidatedFormField(
                         placeholder: "DID",
-                        field: app.state.authorization.form.did,
+                        field: state.form.did,
                         send: Address.forward(
                             send: app.send,
                             tag: { a in .authorization(.form(.didField(a))) }
@@ -66,7 +69,7 @@ struct AuthorizationSettingsView: View {
                     
                     ValidatedFormField(
                         placeholder: "name",
-                        field: app.state.authorization.form.name,
+                        field: state.form.name,
                         send: Address.forward(
                             send: app.send,
                             tag: { a in .authorization(.form(.nameField(a))) }
@@ -97,7 +100,7 @@ struct AuthorizationSettingsView: View {
                 }, header: {
                     Text("Authorization Settings")
                 }, footer: {
-                    if let message = app.state.authorization.errorMessage {
+                    if let message = state.errorMessage {
                         Text(message)
                             .foregroundStyle(.red)
                     }
@@ -106,7 +109,7 @@ struct AuthorizationSettingsView: View {
             Section(
                 content: {
                     List {
-                        ForEach(app.state.authorization.authorizations, id: \.self) { auth in
+                        ForEach(state.authorizations, id: \.self) { auth in
                             HStack {
                                 Text(auth)
                                     .font(.callout.monospaced())
@@ -121,8 +124,12 @@ struct AuthorizationSettingsView: View {
                                             },
                                             label: {
                                                 Label(
-                                                    title: { Text("Revoke") },
-                                                    icon: { Image(systemName: "exclamationmark.octagon.fill") }
+                                                    title: {
+                                                        Text("Revoke")
+                                                    },
+                                                    icon: {
+                                                        Image(systemName: "exclamationmark.octagon.fill")
+                                                    }
                                                 )
                                             }
                                         )
@@ -142,8 +149,12 @@ struct AuthorizationSettingsView: View {
             "This may revoke other authorizations that depend on this authorization, are you sure?",
             isPresented:
                 Binding(
-                    get: { app.state.authorization.isConfirmRevokePresented },
-                    set: { _ in app.send(.authorization(.presentRevokeConfirmation(false))) }
+                    get: { state.isConfirmRevokePresented },
+                    set: { _ in
+                        app.send(.authorization(
+                            .presentRevokeConfirmation(false)
+                        ))
+                    }
                 )
         ) {
             Button(

--- a/xcode/Subconscious/Shared/Components/Settings/AuthorizationSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/AuthorizationSettingsView.swift
@@ -1,0 +1,282 @@
+//
+//  AuthorizationSettingsView.swift
+//  Subconscious (iOS)
+//
+//  Created by Ben Follington on 19/7/2023.
+//
+
+import SwiftUI
+import ObservableStore
+import os
+
+struct AuthorizationSettingsView: View {
+    @ObservedObject var app: Store<AppModel>
+
+    var body: some View {
+        Form {
+            Section(
+                content: {
+                    ValidatedFormField(
+                        placeholder: "did:key:mmm",
+                        field: app.state.authorization.form.did,
+                        send: Address.forward(
+                            send: app.send,
+                            tag: { a in .authorization(.form(.didField(a))) }
+                        ),
+                        caption: Text(
+                            "The DID of the client to authorize"
+                        )
+                    )
+                    .textInputAutocapitalization(.never)
+                    .disableAutocorrection(true)
+                    .autocapitalization(.none)
+                    
+                    ValidatedFormField(
+                        placeholder: "name",
+                        field: app.state.authorization.form.name,
+                        send: Address.forward(
+                            send: app.send,
+                            tag: { a in .authorization(.form(.nameField(a))) }
+                        ),
+                        caption: Text(
+                            "The name for this authorization"
+                        )
+                    )
+                    .textInputAutocapitalization(.never)
+                    .disableAutocorrection(true)
+                    .autocapitalization(.none)
+                    
+                    Button(
+                        action: {
+                            app.send(.authorization(.submitAuthorizeForm))
+                        },
+                        label: {
+                            Text("Authorize")
+                        }
+                    )
+                }, header: {
+                    Text("Authorization Settings")
+                }, footer: {
+                    Text("List authorizations here?")
+                })
+        }
+        .navigationTitle("Authorization Settings")
+    }
+}
+
+struct AuthorizationSettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        AuthorizationSettingsView(
+            app: Store(
+                state: AppModel(),
+                environment: AppEnvironment()
+            )
+        )
+    }
+}
+
+enum AuthorizationSettingsFormAction: Equatable {
+    case didField(FormFieldAction<String>)
+    case nameField(FormFieldAction<String>)
+    case reset
+}
+
+struct AuthorizationSettingsFormModel: ModelProtocol {
+    typealias Action = AuthorizationSettingsFormAction
+    typealias Environment = ()
+    
+    var did: FormField<String, Did> = FormField(
+        value: "",
+        validate: Self.validateDid
+    )
+    
+    var name: FormField<String, String> = FormField(
+        value: "",
+        validate: Self.validateName
+    )
+    
+    static func validateDid(key: String) -> Did? {
+        Did(key)
+    }
+
+    static func validateName(name: String) -> String? {
+        name
+    }
+    
+    static func update(
+        state: Self,
+        action: Action,
+        environment: Environment
+    ) -> Update<Self> {
+        switch action {
+        case .didField(let action):
+            return DidFieldCursor.update(
+                state: state,
+                action: action,
+                environment: FormFieldEnvironment()
+            )
+        case .nameField(let action):
+            return NameFieldCursor.update(
+                state: state,
+                action: action,
+                environment: FormFieldEnvironment()
+            )
+        case .reset:
+            var model = state
+            return update(
+                state: model,
+                actions: [
+                    .didField(.reset),
+                    .nameField(.reset)
+                ],
+                environment: environment
+            )
+        }
+    }
+}
+
+// MARK: Actions
+enum AuthorizationSettingsAction {
+    case form(AuthorizationSettingsFormAction)
+    case submitAuthorizeForm
+    
+    case presentQRCodeScanner(_ isPresented: Bool)
+    case qrCodeScanned(scannedContent: String)
+    case qrCodeScanError(error: String)
+}
+
+typealias AuthorizationSettingsEnvironment = AppEnvironment
+
+// MARK: Model
+struct AuthorizationSettingsModel: ModelProtocol {
+    typealias Action = AuthorizationSettingsAction
+    typealias Environment = FollowNewUserFormSheetEnvironment
+    
+    static let logger = Logger(
+        subsystem: Config.default.rdns,
+        category: "AuthorizationSettingsModel"
+    )
+    
+    var isQrCodeScannerPresented = false
+    
+    var form: AuthorizationSettingsFormModel = AuthorizationSettingsFormModel()
+    
+    var failQRCodeScanErrorMessage: String? = nil
+    
+    static func update(
+        state: Self,
+        action: Action,
+        environment: Environment
+    ) -> Update<Self> {
+        switch (action) {
+        case .form(let action):
+            return AuthorizationSettingsFormCursor.update(
+                state: state,
+                action: action,
+                environment: ()
+            )
+            
+        case .presentQRCodeScanner(let isPresented):
+            var model = state
+            model.failQRCodeScanErrorMessage = nil
+            model.isQrCodeScannerPresented = isPresented
+            return Update(state: model)
+            
+        case .qrCodeScanned(scannedContent: let content):
+            return update(
+                state: state,
+                actions: [
+                    .form(.didField(.reset)),
+                    .form(.didField(.setValue(input: content)))
+                ],
+                environment: environment
+            )
+            
+        case .qrCodeScanError(error: let error):
+            var model = state
+            model.failQRCodeScanErrorMessage = error
+            return Update(state: model)
+            
+        case .submitAuthorizeForm:
+            return Update(state: state)
+        }
+    }
+}
+
+// MARK: Cursors
+
+struct AuthorizationSettingsCursor: CursorProtocol {
+    typealias Model = AppModel
+    typealias ViewModel = AuthorizationSettingsModel
+
+    static func get(state: Model) -> ViewModel {
+        state.authorization
+    }
+    
+    static func set(state: Model, inner: ViewModel) -> Model {
+        var model = state
+        model.authorization = inner
+        return model
+    }
+    
+    static func tag(_ action: ViewModel.Action) -> Model.Action {
+        .authorization(action)
+    }
+}
+
+struct AuthorizationSettingsFormCursor: CursorProtocol {
+    typealias Model = AuthorizationSettingsModel
+    typealias ViewModel = AuthorizationSettingsFormModel
+
+    static func get(state: Model) -> ViewModel {
+        state.form
+    }
+    
+    static func set(state: Model, inner: ViewModel) -> Model {
+        var model = state
+        model.form = inner
+        return model
+    }
+    
+    static func tag(_ action: ViewModel.Action) -> Model.Action {
+        .form(action)
+    }
+}
+
+private struct DidFieldCursor: CursorProtocol {
+    typealias Model = AuthorizationSettingsFormModel
+    typealias ViewModel = FormField<String, Did>
+
+    static func get(state: Model) -> ViewModel {
+        state.did
+    }
+    
+    static func set(state: Model, inner: ViewModel) -> Model {
+        var model = state
+        model.did = inner
+        return model
+    }
+    
+    static func tag(_ action: ViewModel.Action) -> Model.Action {
+        .didField(action)
+    }
+}
+
+private struct NameFieldCursor: CursorProtocol {
+    typealias Model = AuthorizationSettingsFormModel
+    typealias ViewModel = FormField<String, String>
+
+    static func get(state: Model) -> ViewModel {
+        state.name
+    }
+    
+    static func set(state: Model, inner: ViewModel) -> Model {
+        var model = state
+        model.name = inner
+        return model
+    }
+    
+    static func tag(_ action: ViewModel.Action) -> Model.Action {
+        .nameField(action)
+    }
+}

--- a/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
@@ -68,12 +68,18 @@ struct SettingsView: View {
                             }
                         )
                         
-                        LabeledContent(
-                            "Sphere",
-                            value: app.state.sphereIdentity ?? unknown
+                        NavigationLink(
+                            destination: {
+                                SphereSettingsView(app: app)
+                            },
+                            label: {
+                                LabeledContent(
+                                    "Sphere",
+                                    value: app.state.sphereIdentity ?? unknown
+                                )
+                                .lineLimit(1)
+                            }
                         )
-                        .lineLimit(1)
-                        .textSelection(.enabled)
 
                         LabeledContent(
                             "Version",
@@ -98,9 +104,7 @@ struct SettingsView: View {
                     header: {
                         Text("Noosphere")
                     },
-                    footer: {
-                        Text("Noosphere is a protocol for thought. It's decentralized, so your data belongs to you.")
-                    }
+                    footer: { }
                 )
                 
                 SwiftUI.Link(

--- a/xcode/Subconscious/Shared/Components/Settings/SphereSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/SphereSettingsView.swift
@@ -1,0 +1,49 @@
+//
+//  SphereSettingsView.swift
+//  Subconscious (iOS)
+//
+//  Created by Ben Follington on 19/7/2023.
+//
+
+import SwiftUI
+import ObservableStore
+import os
+
+struct SphereSettingsView: View {
+    @ObservedObject var app: Store<AppModel>
+
+    var body: some View {
+        Form {
+            NavigationLink(
+                destination: {
+                    AuthorizationSettingsView(app: app)
+                },
+                label: {
+                    Text("Authorization")
+                }
+            )
+            
+            if let did = Did(app.state.sphereIdentity ?? "") {
+                Section(header: Text("Your DID")) {
+                    DidView(did: did)
+                }
+                
+                Section(header: Text("Your QR Code")) {
+                    ShareableDidQrCodeView(did: did, color: Color.gray)
+                }
+            }
+        }
+        .navigationTitle("Sphere Settings")
+    }
+}
+
+struct SphereSettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        SphereSettingsView(
+            app: Store(
+                state: AppModel(),
+                environment: AppEnvironment()
+            )
+        )
+    }
+}

--- a/xcode/Subconscious/Shared/Config.swift
+++ b/xcode/Subconscious/Shared/Config.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftNoosphere
 
 /// Feature flags and settings
 struct Config: Equatable, Codable {
@@ -70,12 +71,11 @@ extension Config {
 
 // MARK: Noosphere configuration
 struct NoosphereConfig: Equatable, Codable {
-    /// Hard-coded version number for Noosphere.
-    /// NOTE: be sure to update this when we update Noosphere.
-    /// We include this here so we can display it in settings.
-    /// In future, Noosphere may expose an FFI to dynamically query for the
-    /// version.
-    var version = "v0.13.0"
+    /// Noosphere package version in semver format.
+    var version: String {
+        "\(NOOSPHERE_VERSION_MAJOR).\(NOOSPHERE_VERSION_MINOR).\(NOOSPHERE_VERSION_PATCH)"
+    }
+    
     /// Name of directory used for Noosphere storage
     var globalStoragePath = "noosphere"
     /// Name of directory used for sphere storage.

--- a/xcode/Subconscious/Shared/Config.swift
+++ b/xcode/Subconscious/Shared/Config.swift
@@ -75,7 +75,7 @@ struct NoosphereConfig: Equatable, Codable {
     /// We include this here so we can display it in settings.
     /// In future, Noosphere may expose an FFI to dynamically query for the
     /// version.
-    var version = "v0.12.1"
+    var version = "v0.13.0"
     /// Name of directory used for Noosphere storage
     var globalStoragePath = "noosphere"
     /// Name of directory used for sphere storage.

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -439,6 +439,10 @@ actor NoosphereService:
         try await self.sphere().listAuthorizations()
     }
     
+    func verify(authorization: Authorization) async throws -> Bool {
+        try await self.sphere().verify(authorization: authorization)
+    }
+    
     /// Intelligently open a sphere by traversing or, if this is our address, returning the default sphere.
     func sphere(address: Slashlink) async throws -> Sphere {
         let identity = try await self.identity()

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -423,6 +423,22 @@ actor NoosphereService:
         try await self.sphere().traverse(petname: petname)
     }
     
+    func authorize(name: String, did: Did) async throws -> Authorization {
+        try await self.sphere().authorize(name: name, did: did)
+    }
+    
+    func revoke(authorization: Authorization) async throws -> Void {
+        try await self.sphere().revoke(authorization: authorization)
+    }
+    
+    func escalateAuthority(mnemonic: String) async throws -> Sphere {
+        try await self.sphere().escalateAuthority(mnemonic: mnemonic)
+    }
+    
+    func listAuthorizations() async throws -> [Authorization] {
+        try await self.sphere().listAuthorizations()
+    }
+    
     /// Intelligently open a sphere by traversing or, if this is our address, returning the default sphere.
     func sphere(address: Slashlink) async throws -> Sphere {
         let identity = try await self.identity()

--- a/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
@@ -64,6 +64,11 @@ public protocol SphereProtocol {
     /// `sphere().traverse(petname: "alice").traverse(petname: "bob").traverse(petname: "alice)` etc.
     ///
     func traverse(petname: Petname) async throws -> Sphere
+    
+    func escalateAuthority(mnemonic: String) async throws -> Sphere
+    func authorize(name: String, did: Did) async throws -> Authorization
+    func revoke(authorization: Authorization) async throws -> Void
+    func listAuthorizations() async throws -> [Authorization]
 }
 
 extension SphereProtocol {

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		B5C918FB2A68D0F3004C6CD5 /* Development.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = B5C918F92A68D0F3004C6CD5 /* Development.xcconfig */; };
 		B5C918EE2A67A16A004C6CD5 /* AuthorizationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C918ED2A67A16A004C6CD5 /* AuthorizationSettingsView.swift */; };
 		B5C918F02A67ADEF004C6CD5 /* SphereSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C918EF2A67ADEF004C6CD5 /* SphereSettingsView.swift */; };
+		B5C918F62A67BB35004C6CD5 /* EllipsisLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C918F52A67BB35004C6CD5 /* EllipsisLabelView.swift */; };
 		B5CA12A029FF732A00860E9E /* GatewayProvisioningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CA129F29FF732A00860E9E /* GatewayProvisioningService.swift */; };
 		B5CA12A129FF732A00860E9E /* GatewayProvisioningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CA129F29FF732A00860E9E /* GatewayProvisioningService.swift */; };
 		B5CA448929D6A1C7002FD83C /* DummyDataUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CA448829D6A1C7002FD83C /* DummyDataUtilities.swift */; };
@@ -513,6 +514,7 @@
 		B5C918F92A68D0F3004C6CD5 /* Development.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Development.xcconfig; sourceTree = "<group>"; };
 		B5C918ED2A67A16A004C6CD5 /* AuthorizationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationSettingsView.swift; sourceTree = "<group>"; };
 		B5C918EF2A67ADEF004C6CD5 /* SphereSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SphereSettingsView.swift; sourceTree = "<group>"; };
+		B5C918F52A67BB35004C6CD5 /* EllipsisLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EllipsisLabelView.swift; sourceTree = "<group>"; };
 		B5CA129F29FF732A00860E9E /* GatewayProvisioningService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayProvisioningService.swift; sourceTree = "<group>"; };
 		B5CA448829D6A1C7002FD83C /* DummyDataUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyDataUtilities.swift; sourceTree = "<group>"; };
 		B5CFC7FD29E5403900178631 /* FollowUserSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowUserSheet.swift; sourceTree = "<group>"; };
@@ -1382,6 +1384,7 @@
 				B532F8C129B1750F00CE9256 /* Transclude */,
 				B8A41D4D2811E81E0096D2E7 /* WikilinkBarView.swift */,
 				B528CB3A2A5BB8C0001E3B8F /* FabSpacerView.swift */,
+				B5C918F52A67BB35004C6CD5 /* EllipsisLabelView.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1896,6 +1899,7 @@
 				B58FE48C28DED9B600E000CC /* StoryCombo.swift in Sources */,
 				B86DFF3727C09CA2002E57ED /* DateUtilities.swift in Sources */,
 				B8E1A9572A16E98D00B757A5 /* PeerRecord.swift in Sources */,
+				B5C918F62A67BB35004C6CD5 /* EllipsisLabelView.swift in Sources */,
 				B8CC434927A0CA8D0079D2F9 /* AnimationUtilities.swift in Sources */,
 				B54187B829EF5CA00056E4A9 /* FollowUserFormSheet.swift in Sources */,
 				B89966C728B6EE2300DF1F8C /* Notebook.swift in Sources */,

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -2624,7 +2624,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/subconsciousnetwork/noosphere";
 			requirement = {
-				branch = "swift-noosphere-v0.13.0";
+				branch = "swift-noosphere-v0.13.1";
 				kind = branch;
 			};
 		};

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -69,6 +69,8 @@
 		B5A7AD332A0D0B0E007C3535 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A7AD312A0D0B0E007C3535 /* EmptyStateView.swift */; };
 		B5C918FA2A68D0F3004C6CD5 /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = B5C918F82A68D0F3004C6CD5 /* Release.xcconfig */; };
 		B5C918FB2A68D0F3004C6CD5 /* Development.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = B5C918F92A68D0F3004C6CD5 /* Development.xcconfig */; };
+		B5C918EE2A67A16A004C6CD5 /* AuthorizationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C918ED2A67A16A004C6CD5 /* AuthorizationSettingsView.swift */; };
+		B5C918F02A67ADEF004C6CD5 /* SphereSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C918EF2A67ADEF004C6CD5 /* SphereSettingsView.swift */; };
 		B5CA12A029FF732A00860E9E /* GatewayProvisioningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CA129F29FF732A00860E9E /* GatewayProvisioningService.swift */; };
 		B5CA12A129FF732A00860E9E /* GatewayProvisioningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CA129F29FF732A00860E9E /* GatewayProvisioningService.swift */; };
 		B5CA448929D6A1C7002FD83C /* DummyDataUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CA448829D6A1C7002FD83C /* DummyDataUtilities.swift */; };
@@ -509,6 +511,8 @@
 		B5A7AD312A0D0B0E007C3535 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		B5C918F82A68D0F3004C6CD5 /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		B5C918F92A68D0F3004C6CD5 /* Development.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Development.xcconfig; sourceTree = "<group>"; };
+		B5C918ED2A67A16A004C6CD5 /* AuthorizationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationSettingsView.swift; sourceTree = "<group>"; };
+		B5C918EF2A67ADEF004C6CD5 /* SphereSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SphereSettingsView.swift; sourceTree = "<group>"; };
 		B5CA129F29FF732A00860E9E /* GatewayProvisioningService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayProvisioningService.swift; sourceTree = "<group>"; };
 		B5CA448829D6A1C7002FD83C /* DummyDataUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyDataUtilities.swift; sourceTree = "<group>"; };
 		B5CFC7FD29E5403900178631 /* FollowUserSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowUserSheet.swift; sourceTree = "<group>"; };
@@ -1050,12 +1054,14 @@
 		B88B1CDC298DE65E0062CB7F /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				B5C918ED2A67A16A004C6CD5 /* AuthorizationSettingsView.swift */,
 				B848FDA82991836900245115 /* DeveloperSettingsView.swift */,
 				B58FD6702A4E4BF000826548 /* GatewayProvisioningSettingsSection.swift */,
 				B88B1CE6298EEC240062CB7F /* GatewayURLSettingsView.swift */,
 				B58FD6722A4E4C0E00826548 /* InviteCodeSettingsSection.swift */,
 				B88B1CDD298DE66E0062CB7F /* SettingsView.swift */,
 				B8E00A2F2992DAA9003B40C1 /* ProfileSettingsView.swift */,
+				B5C918EF2A67ADEF004C6CD5 /* SphereSettingsView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -1767,6 +1773,7 @@
 				B86DFF2827BF02F0002E57ED /* CollectionUtilities.swift in Sources */,
 				B82F053728D60EE60025A8B5 /* AppTabView.swift in Sources */,
 				B8B4251828FDE8AA0081B8D5 /* MemoData.swift in Sources */,
+				B5C918F02A67ADEF004C6CD5 /* SphereSettingsView.swift in Sources */,
 				B8E2B02B29AD0E4D004A78B3 /* Slug.swift in Sources */,
 				B58FE48E28DEDAEA00E000CC /* StoryComboView.swift in Sources */,
 				B57701962A650C92001F874F /* ProfileHeaderButtonStyle.swift in Sources */,
@@ -1835,6 +1842,7 @@
 				B8CAA6CB2A02FA7000F4A0F6 /* Link.swift in Sources */,
 				B8B3EE77297AEE8B00779B7F /* FirstRunDoneView.swift in Sources */,
 				B8099F002A3B5A820014FC2E /* MemoRecord.swift in Sources */,
+				B5C918EE2A67A16A004C6CD5 /* AuthorizationSettingsView.swift in Sources */,
 				B85A805E296F08720007F957 /* AudienceMenuButtonView.swift in Sources */,
 				B8AE34C8276BF77000777FF0 /* SearchTextField.swift in Sources */,
 				B85EC469296F11F000558761 /* BylineSmView.swift in Sources */,

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -2624,7 +2624,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/subconsciousnetwork/noosphere";
 			requirement = {
-				branch = "swift-noosphere-v0.12.1";
+				branch = "swift-noosphere-v0.13.0";
 				kind = branch;
 			};
 		};

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/subconsciousnetwork/noosphere",
       "state" : {
-        "branch" : "swift-noosphere-v0.13.0",
-        "revision" : "54b7c41399f8b6c6fcd8209194e57dd2132ebaf2"
+        "branch" : "swift-noosphere-v0.13.1",
+        "revision" : "3dd515c2ac781754855b46e82fb28c86c3cf2e2e"
       }
     },
     {

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/subconsciousnetwork/noosphere",
       "state" : {
-        "branch" : "swift-noosphere-v0.12.1",
-        "revision" : "fa990ab1d675e2b6a9cbb89e2c7db6e3cd790511"
+        "branch" : "swift-noosphere-v0.13.0",
+        "revision" : "54b7c41399f8b6c6fcd8209194e57dd2132ebaf2"
       }
     },
     {

--- a/xcode/Subconscious/SubconsciousTests/Tests_Sphere.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Sphere.swift
@@ -612,8 +612,19 @@ final class Tests_Sphere: XCTestCase {
         
         let authorization = try await sphere.authorize(name: "ben", did: did)
         
-        let version = try await sphere.save()
+        let _ = try await sphere.save()
+        
+        let authorizations = try await sphere.listAuthorizations()
+        XCTAssertEqual(authorizations.count, 2)
+        XCTAssertTrue(authorizations.contains(where: { auth in auth == authorization }))
         
         try await sphere.revoke(authorization: authorization)
+        
+        let _ = try await sphere.save()
+        
+        let authorizations2 = try await sphere.listAuthorizations()
+        XCTAssertEqual(authorizations2.count, 1)
+        XCTAssertFalse(authorizations2.contains(where: { auth in auth == authorization }))
+        
     }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_Sphere.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Sphere.swift
@@ -584,4 +584,36 @@ final class Tests_Sphere: XCTestCase {
 
         XCTAssertEqual(did, bobKey, "Resolves did")
     }
+    
+    func testAuthorize() async throws {
+        let base = UUID()
+        
+        let globalStoragePath = try createTmpDir(path: "\(base)/noosphere")
+            .path()
+        
+        let sphereStoragePath = try createTmpDir(path: "\(base)/sphere")
+            .path()
+        
+        let noosphere = try Noosphere(
+            globalStoragePath: globalStoragePath,
+            sphereStoragePath: sphereStoragePath
+        )
+        
+        let sphereReceipt = try await noosphere.createSphere(
+            ownerKeyName: "bob"
+        )
+                
+        let sphere = try Sphere(
+            noosphere: noosphere,
+            identity: sphereReceipt.identity
+        )
+        
+        let did = Did.dummyData()
+        
+        let authorization = try await sphere.authorize(name: "ben", did: did)
+        
+        let version = try await sphere.save()
+        
+        try await sphere.revoke(authorization: authorization)
+    }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_Sphere.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Sphere.swift
@@ -618,6 +618,12 @@ final class Tests_Sphere: XCTestCase {
         XCTAssertEqual(authorizations.count, 2)
         XCTAssertTrue(authorizations.contains(where: { auth in auth == authorization }))
         
+        let verified = try await sphere.verify(authorization: authorization)
+        XCTAssertTrue(verified)
+        
+        let verified2 = try await sphere.verify(authorization: "blah")
+        XCTAssertFalse(verified2)
+        
         try await sphere.revoke(authorization: authorization)
         
         let _ = try await sphere.save()


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/815
Fixes https://github.com/subconsciousnetwork/subconscious/issues/495

https://github.com/subconsciousnetwork/subconscious/assets/5009316/144c6695-d6a5-4f17-99ed-77c8daa87082

- Add authorization FFI methods to `SphereProtocol` and implement on `Sphere`/`Noosphere`
- Tests for authorization methods
- Read Noosphere version from FFI
- Introduce new `Sphere Settings` section in `Settings`
  - Another way to access your DID in shareable form, text and QR code
- Within `Sphere Settings`, introduce `Authorization Settings`
  - Form to authorize a DID + name combination
  - List of current authorizations
  - Ability to revoke authorizations (revoking the root will throw an error)
  - Error handling
  - Convenient `ShareLink` with the auth code 

---

- [x] Revoke authorizations
- [x] Show names 
- [x] Fix form captions
- [x] Add a small guide about orb?
- [x] Reset form fields after success
- [x] Error message presentation
- [x] Confirmation for revoke

---

Let’s say I create a sphere with orb and authorize it via authority_authorize on my mobile app. Now I have my authorization, how would I proceed to use orb to edit the sphere?

Sync with your phone (authorization moves up to gateway)
Copy sphere identity
Create a directory for sphere, move into it and do:

```
orb key create somekeyname
orb sphere create --owner-key somekeyname
orb sphere join --local-key $SOME_DEVICE_KEY $SPHERE_ID
orb config set gateway-url $SAME_GATEWAY_URL_AS_PHONE
orb sync
```