### PR TITLE
Introduce xcconfig build variables based on environment (Release vs. Debug)

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserFormSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserFormSheet.swift
@@ -45,30 +45,28 @@ struct FollowNewUserFormSheetView: View {
                         )
                     )
                     
-                    if Config.default.addByQRCode {
-                        Section(header: Text("Add via QR Code")) {
-                            Button(
-                                action: {
-                                    send(.presentQRCodeScanner(true))
-                                },
-                                label: {
-                                    HStack {
-                                        Image(systemName: "qrcode")
-                                        Text("Scan Code")
-                                    }
-                                    .foregroundColor(.accentColor)
+                    Section(header: Text("Add via QR Code")) {
+                        Button(
+                            action: {
+                                send(.presentQRCodeScanner(true))
+                            },
+                            label: {
+                                HStack {
+                                    Image(systemName: "qrcode")
+                                    Text("Scan Code")
                                 }
-                            )
+                                .foregroundColor(.accentColor)
+                            }
+                        )
+                    }
+                    
+                    if let did = did {
+                        Section(header: Text("Your DID")) {
+                            DidView(did: did)
                         }
                         
-                        if let did = did {
-                            Section(header: Text("Your DID")) {
-                                DidView(did: did)
-                            }
-                            
-                            Section(header: Text("Your QR Code")) {
-                                ShareableDidQrCodeView(did: did, color: Color.gray)
-                            }
+                        Section(header: Text("Your QR Code")) {
+                            ShareableDidQrCodeView(did: did, color: Color.gray)
                         }
                     }
                 }
@@ -100,7 +98,7 @@ struct FollowNewUserFormSheetView: View {
             }
             .fullScreenCover(
                 isPresented: Binding(
-                    get: { state.isQrCodeScannerPresented && Config.default.addByQRCode },
+                    get: { state.isQrCodeScannerPresented },
                     send: send,
                     tag: FollowNewUserFormSheetAction.presentQRCodeScanner
                 )

--- a/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
@@ -109,15 +109,13 @@ struct NotebookNavigationView: View {
                         Image(systemName: "gearshape")
                     }
                 }
-                if Config.default.userProfile {
-                    ToolbarItem(placement: .navigationBarLeading) {
-                        Button(
-                            action: {
-                                store.send(.requestOurProfileDetail)
-                            }
-                        ) {
-                            Image(systemName: "person")
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(
+                        action: {
+                            store.send(.requestOurProfileDetail)
                         }
+                    ) {
+                        Image(systemName: "person")
                     }
                 }
             }

--- a/xcode/Subconscious/Shared/Config.swift
+++ b/xcode/Subconscious/Shared/Config.swift
@@ -34,14 +34,19 @@ struct Config: Equatable, Codable {
             ? "did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7"
             : ""
     }
-    var subconsciousGeistDid: Did = Did("did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")!
-    var subconsciousGeistPetname: Petname = Petname("subconscious")!
+    
+    var subconsciousGeistDid: Did = Did(
+        Bundle.main.object(forInfoDictionaryKey: "DEFAULT_GEIST_DID") as! String
+    )!
+    var subconsciousGeistPetname: Petname = Petname(
+        Bundle.main.object(forInfoDictionaryKey: "DEFAULT_GEIST_PETNAME") as! String
+    )!
     
     /// URL for sending feedback to developers
-    var feedbackURL: URL = URL(string: "https://docs.google.com/forms/d/e/1FAIpQLSeQHRBacSLtE2scIeezlgW6ou_xq_CLBUawJeMmOZv4O9NuEw/viewform?usp=sf_link")!
+    var feedbackURL: URL = URL(string: Bundle.main.object(forInfoDictionaryKey: "FEEDBACK_URL") as! String)!
     
     /// URL for built-in web service
-    var cloudCtlUrl: URL = URL(string: "https://cloudctl.sphere.socrates.subconscious.cloud")!
+    var cloudCtlUrl: URL = URL(string: Bundle.main.object(forInfoDictionaryKey: "CLOUDCTL_URL") as! String)!
     
     /// Standard interval at which to run long-polling services
     var pollingInterval: Double = 15

--- a/xcode/Subconscious/Shared/Config.swift
+++ b/xcode/Subconscious/Shared/Config.swift
@@ -11,13 +11,11 @@ import Foundation
 struct Config: Equatable, Codable {
     /// App version.
     var rdns = "com.subconscious.Subconscious"
-    var debug = false
+    var debug = (Bundle.main.object(forInfoDictionaryKey: "DEBUG") as! String == "YES")
     
     var noosphere = NoosphereConfig()
     
     var appTabs = false
-    var addByQRCode = true
-    var userProfile = true
     
     #if targetEnvironment(simulator)
     /// Are we currently running in the iOS simlator (aka dev mode)
@@ -43,10 +41,14 @@ struct Config: Equatable, Codable {
     )!
     
     /// URL for sending feedback to developers
-    var feedbackURL: URL = URL(string: Bundle.main.object(forInfoDictionaryKey: "FEEDBACK_URL") as! String)!
+    var feedbackURL: URL = URL(
+        string: Bundle.main.object(forInfoDictionaryKey: "FEEDBACK_URL") as! String
+    )!
     
     /// URL for built-in web service
-    var cloudCtlUrl: URL = URL(string: Bundle.main.object(forInfoDictionaryKey: "CLOUDCTL_URL") as! String)!
+    var cloudCtlUrl: URL = URL(
+        string: Bundle.main.object(forInfoDictionaryKey: "CLOUDCTL_URL") as! String
+    )!
     
     /// Standard interval at which to run long-polling services
     var pollingInterval: Double = 15

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		B549B16B2A0CDAC10070C6AD /* FirstRunRecoveryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B549B16A2A0CDAC10070C6AD /* FirstRunRecoveryView.swift */; };
 		B54B922828E669D6003ACA1F /* MementoGeist.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54B922728E669D6003ACA1F /* MementoGeist.swift */; };
 		B550E04029AF219100050F19 /* Did.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D8D30029AF1F9B0011D820 /* Did.swift */; };
+		B5604DAE2A6A263E004C9590 /* Tests_Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5604DAD2A6A263E004C9590 /* Tests_Config.swift */; };
 		B5690C3C29FB4DEF00067580 /* FollowUserViaQRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B569971429B6A0DF003204FC /* FollowUserViaQRCodeView.swift */; };
 		B5690C3D29FB4DEF00067580 /* DidQrCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B569971529B6A0DF003204FC /* DidQrCodeView.swift */; };
 		B569971629B6A0DF003204FC /* FollowUserViaQRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B569971429B6A0DF003204FC /* FollowUserViaQRCodeView.swift */; };
@@ -474,6 +475,7 @@
 		B54930B02A2F0FE300958F12 /* StoryPlaceholderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryPlaceholderView.swift; sourceTree = "<group>"; };
 		B549B16A2A0CDAC10070C6AD /* FirstRunRecoveryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstRunRecoveryView.swift; sourceTree = "<group>"; };
 		B54B922728E669D6003ACA1F /* MementoGeist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MementoGeist.swift; sourceTree = "<group>"; };
+		B5604DAD2A6A263E004C9590 /* Tests_Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_Config.swift; sourceTree = "<group>"; };
 		B569971429B6A0DF003204FC /* FollowUserViaQRCodeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FollowUserViaQRCodeView.swift; sourceTree = "<group>"; };
 		B569971529B6A0DF003204FC /* DidQrCodeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DidQrCodeView.swift; sourceTree = "<group>"; };
 		B56C2D4D2A4962D00062DAC0 /* Tests_TranscludeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_TranscludeService.swift; sourceTree = "<group>"; };
@@ -920,6 +922,7 @@
 				B8099F012A3B6FA50014FC2E /* Tests_MemoRecord.swift */,
 				B56C2D4D2A4962D00062DAC0 /* Tests_TranscludeService.swift */,
 				B509612F2A4CEFCF008E9EDB /* Tests_FirstRun.swift */,
+				B5604DAD2A6A263E004C9590 /* Tests_Config.swift */,
 			);
 			path = SubconsciousTests;
 			sourceTree = "<group>";
@@ -1646,6 +1649,7 @@
 				B8E1A9492A13F49F00B757A5 /* Tests_LogFmt.swift in Sources */,
 				B84AD8E1280F7A19006B3153 /* Tests_StringUtilities.swift in Sources */,
 				B8B604EB29148C82006FCB77 /* Tests_AppMigrations.swift in Sources */,
+				B5604DAE2A6A263E004C9590 /* Tests_Config.swift in Sources */,
 				B8AAAAD928CBD68600DBC8A9 /* Tests_Detail.swift in Sources */,
 				B8E62AE829D61E69008F7E74 /* Tests_UserDefaultProperty.swift in Sources */,
 				B8C7E8C0280A2B7700E439DC /* Test_Markup.swift in Sources */,

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -66,6 +66,8 @@
 		B59D556329BBFF56007915E2 /* FormField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59D556229BBFF56007915E2 /* FormField.swift */; };
 		B5A7AD322A0D0B0E007C3535 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A7AD312A0D0B0E007C3535 /* EmptyStateView.swift */; };
 		B5A7AD332A0D0B0E007C3535 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A7AD312A0D0B0E007C3535 /* EmptyStateView.swift */; };
+		B5C918FA2A68D0F3004C6CD5 /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = B5C918F82A68D0F3004C6CD5 /* Release.xcconfig */; };
+		B5C918FB2A68D0F3004C6CD5 /* Development.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = B5C918F92A68D0F3004C6CD5 /* Development.xcconfig */; };
 		B5CA12A029FF732A00860E9E /* GatewayProvisioningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CA129F29FF732A00860E9E /* GatewayProvisioningService.swift */; };
 		B5CA12A129FF732A00860E9E /* GatewayProvisioningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CA129F29FF732A00860E9E /* GatewayProvisioningService.swift */; };
 		B5CA448929D6A1C7002FD83C /* DummyDataUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CA448829D6A1C7002FD83C /* DummyDataUtilities.swift */; };
@@ -503,6 +505,8 @@
 		B5908BEA29DAB05B00225B1A /* TestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUtilities.swift; sourceTree = "<group>"; };
 		B59D556229BBFF56007915E2 /* FormField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormField.swift; sourceTree = "<group>"; };
 		B5A7AD312A0D0B0E007C3535 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
+		B5C918F82A68D0F3004C6CD5 /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		B5C918F92A68D0F3004C6CD5 /* Development.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Development.xcconfig; sourceTree = "<group>"; };
 		B5CA129F29FF732A00860E9E /* GatewayProvisioningService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayProvisioningService.swift; sourceTree = "<group>"; };
 		B5CA448829D6A1C7002FD83C /* DummyDataUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyDataUtilities.swift; sourceTree = "<group>"; };
 		B5CFC7FD29E5403900178631 /* FollowUserSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowUserSheet.swift; sourceTree = "<group>"; };
@@ -1231,6 +1235,8 @@
 		B8EB29FD26F27797006E97C3 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
+				B5C918F92A68D0F3004C6CD5 /* Development.xcconfig */,
+				B5C918F82A68D0F3004C6CD5 /* Release.xcconfig */,
 				B8EB29FE26F27797006E97C3 /* Info.plist */,
 			);
 			path = iOS;
@@ -1549,8 +1555,10 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B5C918FA2A68D0F3004C6CD5 /* Release.xcconfig in Resources */,
 				B8CA8F1E288F07F9005F8802 /* zettelkasten.json in Resources */,
 				B88C97A22764270000B27DF0 /* LICENSE.txt in Resources */,
+				B5C918FB2A68D0F3004C6CD5 /* Development.xcconfig in Resources */,
 				B88C979D2764266A00B27DF0 /* IBMPlexSans-Light.ttf in Resources */,
 				B88C97972764264300B27DF0 /* IBMPlexSans-BoldItalic.ttf in Resources */,
 				B88C9785276425E900B27DF0 /* IBMPlexMono-Bold.ttf in Resources */,
@@ -2240,6 +2248,7 @@
 		};
 		B8EB2A2A26F27797006E97C3 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B5C918F92A68D0F3004C6CD5 /* Development.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -2281,6 +2290,7 @@
 		};
 		B8EB2A2B26F27797006E97C3 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B5C918F82A68D0F3004C6CD5 /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/xcode/Subconscious/SubconsciousTests/Tests_Config.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Config.swift
@@ -1,0 +1,20 @@
+//
+//  Tests_Config.swift
+//  SubconsciousTests
+//
+//  Created by Ben Follington on 21/7/2023.
+//
+
+import XCTest
+@testable import Subconscious
+
+final class Tests_Config: XCTestCase {
+    func testLoadBuildVars() throws {
+        let _debug = Config.default.debug
+        let _defaultGeistDid = Config.default.subconsciousGeistDid
+        let _defaultGeistPetname = Config.default.subconsciousGeistPetname
+        let _feedbackUrl = Config.default.feedbackURL
+        let _cloudCtlUrl = Config.default.cloudCtlUrl
+    }
+}
+    

--- a/xcode/Subconscious/iOS/Development.xcconfig
+++ b/xcode/Subconscious/iOS/Development.xcconfig
@@ -1,0 +1,15 @@
+//
+//  config.xcconfig
+//  Subconscious
+//
+//  Created by Ben Follington on 20/7/2023.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+APP_BUILD = dev
+DEFAULT_GEIST_PETNAME = subconscious
+DEFAULT_GEIST_DID = did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7
+FEEDBACK_URL = docs.google.com/forms/d/e/1FAIpQLSeQHRBacSLtE2scIeezlgW6ou_xq_CLBUawJeMmOZv4O9NuEw/viewform?usp=sf_link
+CLOUDCTL_URL = cloudctl.sphere.socrates.subconscious.cloud

--- a/xcode/Subconscious/iOS/Development.xcconfig
+++ b/xcode/Subconscious/iOS/Development.xcconfig
@@ -8,7 +8,7 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-APP_BUILD = dev
+DEBUG = YES
 DEFAULT_GEIST_PETNAME = subconscious
 DEFAULT_GEIST_DID = did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7
 FEEDBACK_URL = docs.google.com/forms/d/e/1FAIpQLSeQHRBacSLtE2scIeezlgW6ou_xq_CLBUawJeMmOZv4O9NuEw/viewform?usp=sf_link

--- a/xcode/Subconscious/iOS/Info.plist
+++ b/xcode/Subconscious/iOS/Info.plist
@@ -2,6 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CLOUDCTL_URL</key>
+	<string>https://$(CLOUDCTL_URL)</string>
+	<key>DEFAULT_GEIST_DID</key>
+	<string>$(DEFAULT_GEIST_DID)</string>
+	<key>DEFAULT_GEIST_PETNAME</key>
+	<string>$(DEFAULT_GEIST_PETNAME)</string>
+	<key>FEEDBACK_URL</key>
+	<string>https://$(FEEDBACK_URL)</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>IBMPlexMono-Bold.ttf</string>

--- a/xcode/Subconscious/iOS/Info.plist
+++ b/xcode/Subconscious/iOS/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CLOUDCTL_URL</key>
 	<string>https://$(CLOUDCTL_URL)</string>
+	<key>DEBUG</key>
+	<string>$(DEBUG)</string>
 	<key>DEFAULT_GEIST_DID</key>
 	<string>$(DEFAULT_GEIST_DID)</string>
 	<key>DEFAULT_GEIST_PETNAME</key>

--- a/xcode/Subconscious/iOS/Release.xcconfig
+++ b/xcode/Subconscious/iOS/Release.xcconfig
@@ -8,7 +8,7 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-APP_BUILD = release
+DEBUG = NO
 DEFAULT_GEIST_PETNAME = subconscious
 DEFAULT_GEIST_DID = did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7
 FEEDBACK_URL = docs.google.com/forms/d/e/1FAIpQLSeQHRBacSLtE2scIeezlgW6ou_xq_CLBUawJeMmOZv4O9NuEw/viewform?usp=sf_link

--- a/xcode/Subconscious/iOS/Release.xcconfig
+++ b/xcode/Subconscious/iOS/Release.xcconfig
@@ -1,0 +1,15 @@
+//
+//  config.xcconfig
+//  Subconscious
+//
+//  Created by Ben Follington on 20/7/2023.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+APP_BUILD = release
+DEFAULT_GEIST_PETNAME = subconscious
+DEFAULT_GEIST_DID = did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7
+FEEDBACK_URL = docs.google.com/forms/d/e/1FAIpQLSeQHRBacSLtE2scIeezlgW6ou_xq_CLBUawJeMmOZv4O9NuEw/viewform?usp=sf_link
+CLOUDCTL_URL = cloudctl.sphere.plato.subconscious.cloud


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/816

- Introduce Release.xcconfig and Developent.xcconfig (see https://developer.apple.com/documentation/xcode/adding-a-build-configuration-file-to-your-project)
- Assign each to their respective build targets
- Extract default geist DID & petname, feedback URL and cloudctl URL to config
- Read config via Info.plist substitution
- Tests assert that config can be read 

See https://nshipster.com/xcconfig/ for a more comprehensive breakdown.