### PR TITLE
Fix edit link field cursor behaviour

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
@@ -9,11 +9,6 @@ import SwiftUI
 import Combine
 import ObservableStore
 
-enum FieldCaption {
-    case none
-    case text(String)
-}
-
 struct ValidatedFormField<Output: Equatable>: View {
     @State private var innerText: String = ""
     @FocusState private var focused: Bool
@@ -22,7 +17,7 @@ struct ValidatedFormField<Output: Equatable>: View {
     var placeholder: String
     var field: FormField<String, Output>
     var send: (FormFieldAction<String>) -> Void
-    var caption: FieldCaption = .none
+    var caption: String.LocalizationValue? = nil
     var axis: Axis = .horizontal
     var autoFocus: Bool = false
     var submitLabel: SubmitLabel = .done
@@ -86,20 +81,15 @@ struct ValidatedFormField<Output: Equatable>: View {
                     invalidBadge
                 }
             }
-            Group {
-                switch (caption) {
-                case .text(let caption):
-                    Text(caption)
-                        .lineLimit(1)
-                case _:
-                    EmptyView()
-                }
+            if let caption = caption {
+                Text(String(localized: caption))
+                    .lineLimit(1)
+                    .foregroundColor(
+                        field.shouldPresentAsInvalid ? Color.red : Color.secondary
+                    )
+                    .animation(.default, value: field.shouldPresentAsInvalid)
+                    .font(.caption)
             }
-            .foregroundColor(
-                field.shouldPresentAsInvalid ? Color.red : Color.secondary
-            )
-            .animation(.default, value: field.shouldPresentAsInvalid)
-            .font(.caption)
         }
         .onAppear {
             innerText = field.value
@@ -114,26 +104,26 @@ struct ValidatedTextField_Previews: PreviewProvider {
                 placeholder: "nickname",
                 field: FormField(value: "", validate: { _ in "" }),
                 send: { _ in },
-                caption: .text("Lowercase letters and numbers only.")
+                caption: "Lowercase letters and numbers only."
             )
             ValidatedFormField(
                 placeholder: "nickname",
                 field: FormField(value: "", validate: { _ in nil as String? }),
                 send: { _ in },
-                caption: .text("Lowercase letters and numbers only.")
+                caption: "Lowercase letters and numbers only."
             )
             ValidatedFormField(
                 placeholder: "nickname",
                 field: FormField(value: "", validate: { _ in "" }),
                 send: { _ in },
-                caption: .text("Lowercase letters and numbers only.")
+                caption: "Lowercase letters and numbers only."
             )
             .textFieldStyle(.roundedBorder)
             ValidatedFormField(
                 placeholder: "nickname",
                 field: FormField(value: "A very long run of text to test how this interacts with the icon", validate: { _ in nil as String? }),
                 send: { _ in },
-                caption: .text("Lowercase letters and numbers only.")
+                caption: "Lowercase letters and numbers only."
             )
             .textFieldStyle(.roundedBorder)
             
@@ -145,7 +135,7 @@ struct ValidatedTextField_Previews: PreviewProvider {
                     placeholder: "nickname",
                     field: FormField(value: "", validate: { _ in "" }),
                     send: { _ in },
-                    caption: .text("Lowercase letters and numbers only."),
+                    caption: "Lowercase letters and numbers only.",
                     autoFocus: true
                 )
                 .formField()
@@ -153,7 +143,7 @@ struct ValidatedTextField_Previews: PreviewProvider {
                     placeholder: "nickname",
                     field: FormField(value: "", validate: { _ in nil as String? }),
                     send: { _ in },
-                    caption: .text("Lowercase letters and numbers only.")
+                    caption: "Lowercase letters and numbers only."
                 )
                 .formField()
             }

--- a/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
@@ -17,7 +17,7 @@ struct ValidatedFormField<Output: Equatable>: View {
     var placeholder: String
     var field: FormField<String, Output>
     var send: (FormFieldAction<String>) -> Void
-    var caption: String.LocalizationValue? = nil
+    var caption: String? = nil
     var axis: Axis = .horizontal
     var autoFocus: Bool = false
     var submitLabel: SubmitLabel = .done
@@ -82,7 +82,7 @@ struct ValidatedFormField<Output: Equatable>: View {
                 }
             }
             if let caption = caption {
-                Text(String(localized: caption))
+                Text(verbatim: caption)
                     .lineLimit(1)
                     .foregroundColor(
                         field.shouldPresentAsInvalid ? Color.red : Color.secondary
@@ -104,26 +104,26 @@ struct ValidatedTextField_Previews: PreviewProvider {
                 placeholder: "nickname",
                 field: FormField(value: "", validate: { _ in "" }),
                 send: { _ in },
-                caption: "Lowercase letters and numbers only."
+                caption: String(localized: "Lowercase letters and numbers only.")
             )
             ValidatedFormField(
                 placeholder: "nickname",
                 field: FormField(value: "", validate: { _ in nil as String? }),
                 send: { _ in },
-                caption: "Lowercase letters and numbers only."
+                caption: String(localized: "Lowercase letters and numbers only.")
             )
             ValidatedFormField(
                 placeholder: "nickname",
                 field: FormField(value: "", validate: { _ in "" }),
                 send: { _ in },
-                caption: "Lowercase letters and numbers only."
+                caption: String(localized: "Lowercase letters and numbers only.")
             )
             .textFieldStyle(.roundedBorder)
             ValidatedFormField(
                 placeholder: "nickname",
                 field: FormField(value: "A very long run of text to test how this interacts with the icon", validate: { _ in nil as String? }),
                 send: { _ in },
-                caption: "Lowercase letters and numbers only."
+                caption: String(localized: "Lowercase letters and numbers only.")
             )
             .textFieldStyle(.roundedBorder)
             
@@ -135,7 +135,7 @@ struct ValidatedTextField_Previews: PreviewProvider {
                     placeholder: "nickname",
                     field: FormField(value: "", validate: { _ in "" }),
                     send: { _ in },
-                    caption: "Lowercase letters and numbers only.",
+                    caption: String(localized: "Lowercase letters and numbers only."),
                     autoFocus: true
                 )
                 .formField()
@@ -143,7 +143,7 @@ struct ValidatedTextField_Previews: PreviewProvider {
                     placeholder: "nickname",
                     field: FormField(value: "", validate: { _ in nil as String? }),
                     send: { _ in },
-                    caption: "Lowercase letters and numbers only."
+                    caption: String(localized: "Lowercase letters and numbers only.")
                 )
                 .formField()
             }

--- a/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Forms/ValidatedTextField.swift
@@ -9,7 +9,12 @@ import SwiftUI
 import Combine
 import ObservableStore
 
-struct ValidatedFormField<Output: Equatable, Caption: View>: View {
+enum FieldCaption {
+    case none
+    case text(String)
+}
+
+struct ValidatedFormField<Output: Equatable>: View {
     @State private var innerText: String = ""
     @FocusState private var focused: Bool
     
@@ -17,7 +22,7 @@ struct ValidatedFormField<Output: Equatable, Caption: View>: View {
     var placeholder: String
     var field: FormField<String, Output>
     var send: (FormFieldAction<String>) -> Void
-    var caption: Caption
+    var caption: FieldCaption = .none
     var axis: Axis = .horizontal
     var autoFocus: Bool = false
     var submitLabel: SubmitLabel = .done
@@ -81,12 +86,20 @@ struct ValidatedFormField<Output: Equatable, Caption: View>: View {
                     invalidBadge
                 }
             }
-            caption
-                .foregroundColor(
-                    field.shouldPresentAsInvalid ? Color.red : Color.secondary
-                )
-                .animation(.default, value: field.shouldPresentAsInvalid)
-                .font(.caption)
+            Group {
+                switch (caption) {
+                case .text(let caption):
+                    Text(caption)
+                        .lineLimit(1)
+                case _:
+                    EmptyView()
+                }
+            }
+            .foregroundColor(
+                field.shouldPresentAsInvalid ? Color.red : Color.secondary
+            )
+            .animation(.default, value: field.shouldPresentAsInvalid)
+            .font(.caption)
         }
         .onAppear {
             innerText = field.value
@@ -101,26 +114,26 @@ struct ValidatedTextField_Previews: PreviewProvider {
                 placeholder: "nickname",
                 field: FormField(value: "", validate: { _ in "" }),
                 send: { _ in },
-                caption: Text("Lowercase letters and numbers only.")
+                caption: .text("Lowercase letters and numbers only.")
             )
             ValidatedFormField(
                 placeholder: "nickname",
                 field: FormField(value: "", validate: { _ in nil as String? }),
                 send: { _ in },
-                caption: Text("Lowercase letters and numbers only.")
+                caption: .text("Lowercase letters and numbers only.")
             )
             ValidatedFormField(
                 placeholder: "nickname",
                 field: FormField(value: "", validate: { _ in "" }),
                 send: { _ in },
-                caption: Text("Lowercase letters and numbers only.")
+                caption: .text("Lowercase letters and numbers only.")
             )
             .textFieldStyle(.roundedBorder)
             ValidatedFormField(
                 placeholder: "nickname",
                 field: FormField(value: "A very long run of text to test how this interacts with the icon", validate: { _ in nil as String? }),
                 send: { _ in },
-                caption: Text("Lowercase letters and numbers only.")
+                caption: .text("Lowercase letters and numbers only.")
             )
             .textFieldStyle(.roundedBorder)
             
@@ -132,7 +145,7 @@ struct ValidatedTextField_Previews: PreviewProvider {
                     placeholder: "nickname",
                     field: FormField(value: "", validate: { _ in "" }),
                     send: { _ in },
-                    caption: Text("Lowercase letters and numbers only."),
+                    caption: .text("Lowercase letters and numbers only."),
                     autoFocus: true
                 )
                 .formField()
@@ -140,7 +153,7 @@ struct ValidatedTextField_Previews: PreviewProvider {
                     placeholder: "nickname",
                     field: FormField(value: "", validate: { _ in nil as String? }),
                     send: { _ in },
-                    caption: Text("Lowercase letters and numbers only.")
+                    caption: .text("Lowercase letters and numbers only.")
                 )
                 .formField()
             }

--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -154,7 +154,7 @@ struct EditProfileSheet: View {
                                 send: send,
                                 tag: EditProfileSheetAction.nicknameField
                             ),
-                            caption: Text(
+                            caption: .text(
                                 "Lowercase letters, numbers and dashes only."
                             )
                         )
@@ -174,7 +174,7 @@ struct EditProfileSheet: View {
                                 send: send,
                                 tag: EditProfileSheetAction.bioField
                             ),
-                            caption: Text(
+                            caption: .text(
                                 "A short description of yourself (\(state.bioField.value.count)/280)"
                             ),
                             axis: .vertical

--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -140,10 +140,8 @@ struct EditProfileSheet: View {
         )
     }
     
-    var bioCaption: String.LocalizationValue {
-        String.LocalizationValue(
-            "A short description of yourself (\(state.bioField.value.count)/280)"
-        )
+    var bioCaption: String {
+        "A short description of yourself (\(state.bioField.value.count)/280)"
     }
     
     var body: some View {
@@ -160,7 +158,9 @@ struct EditProfileSheet: View {
                                 send: send,
                                 tag: EditProfileSheetAction.nicknameField
                             ),
-                            caption: "Lowercase letters, numbers and dashes only."
+                            caption: String(
+                                localized: "Lowercase letters, numbers and dashes only."
+                            )
                         )
                         .lineLimit(1)
                         .textInputAutocapitalization(.never)

--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -140,6 +140,12 @@ struct EditProfileSheet: View {
         )
     }
     
+    var bioCaption: String.LocalizationValue {
+        String.LocalizationValue(
+            "A short description of yourself (\(state.bioField.value.count)/280)"
+        )
+    }
+    
     var body: some View {
         NavigationStack {
             Form {
@@ -154,9 +160,7 @@ struct EditProfileSheet: View {
                                 send: send,
                                 tag: EditProfileSheetAction.nicknameField
                             ),
-                            caption: .text(
-                                "Lowercase letters, numbers and dashes only."
-                            )
+                            caption: "Lowercase letters, numbers and dashes only."
                         )
                         .lineLimit(1)
                         .textInputAutocapitalization(.never)
@@ -174,9 +178,7 @@ struct EditProfileSheet: View {
                                 send: send,
                                 tag: EditProfileSheetAction.bioField
                             ),
-                            caption: .text(
-                                "A short description of yourself (\(state.bioField.value.count)/280)"
-                            ),
+                            caption: bioCaption,
                             axis: .vertical
                         )
                         .textInputAutocapitalization(.never)

--- a/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserFormSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserFormSheet.swift
@@ -282,8 +282,8 @@ struct FollowUserFormView: View {
     var state: FollowUserFormModel
     var send: (FollowUserFormAction) -> Void
     
-    var petnameCaption: String.LocalizationValue {
-        String.LocalizationValue(state.failFollowMessage ?? "Lowercase letters, numbers and dashes only.")
+    var petnameCaption: String {
+        state.failFollowMessage ?? "Lowercase letters, numbers and dashes only."
     }
     
     var body: some View {
@@ -299,7 +299,9 @@ struct FollowUserFormView: View {
                         send: send,
                         tag: FollowUserFormAction.didField
                     ),
-                    caption: "e.g. did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7",
+                    caption: String(
+                        localized: "e.g. did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7"
+                    ),
                     axis: .vertical
                 )
                 .lineLimit(12)

--- a/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserFormSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserFormSheet.swift
@@ -295,8 +295,7 @@ struct FollowUserFormView: View {
                         send: send,
                         tag: FollowUserFormAction.didField
                     ),
-                    caption: Text("e.g. did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7")
-                        .lineLimit(1),
+                    caption: .text("e.g. did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7"),
                     axis: .vertical
                 )
                 .lineLimit(12)
@@ -315,7 +314,7 @@ struct FollowUserFormView: View {
                         send: send,
                         tag: FollowUserFormAction.petnameField
                     ),
-                    caption: Text(state.failFollowMessage ?? "Lowercase letters, numbers and dashes only.")
+                    caption: .text(state.failFollowMessage ?? "Lowercase letters, numbers and dashes only.")
                 )
                 .lineLimit(1)
                 .textInputAutocapitalization(.never)

--- a/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserFormSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserFormSheet.swift
@@ -282,6 +282,10 @@ struct FollowUserFormView: View {
     var state: FollowUserFormModel
     var send: (FollowUserFormAction) -> Void
     
+    var petnameCaption: String.LocalizationValue {
+        String.LocalizationValue(state.failFollowMessage ?? "Lowercase letters, numbers and dashes only.")
+    }
+    
     var body: some View {
         Section(header: Text("User To Follow")) {
             HStack(alignment: .top) {
@@ -295,7 +299,7 @@ struct FollowUserFormView: View {
                         send: send,
                         tag: FollowUserFormAction.didField
                     ),
-                    caption: .text("e.g. did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7"),
+                    caption: "e.g. did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7",
                     axis: .vertical
                 )
                 .lineLimit(12)
@@ -314,7 +318,7 @@ struct FollowUserFormView: View {
                         send: send,
                         tag: FollowUserFormAction.petnameField
                     ),
-                    caption: .text(state.failFollowMessage ?? "Lowercase letters, numbers and dashes only.")
+                    caption: petnameCaption
                 )
                 .lineLimit(1)
                 .textInputAutocapitalization(.never)

--- a/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserSheet.swift
@@ -168,6 +168,10 @@ struct FollowUserSheet: View {
     var failFollowError: String?
     var onDismissError: () -> Void
     
+    var caption: String.LocalizationValue {
+        String.LocalizationValue(state.petnameFieldCaption ?? "")
+    }
+    
     var body: some View {
         VStack(alignment: .center, spacing: AppTheme.unit2) {
             if let user = state.user {
@@ -189,7 +193,7 @@ struct FollowUserSheet: View {
                     send: send,
                     tag: { a in FollowUserSheetAction.followUserForm(.petnameField(a)) }
                 ),
-                caption: .text(state.petnameFieldCaption ?? "")
+                caption: caption
             )
             .textFieldStyle(.roundedBorder)
             .lineLimit(1)

--- a/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserSheet.swift
@@ -189,7 +189,7 @@ struct FollowUserSheet: View {
                     send: send,
                     tag: { a in FollowUserSheetAction.followUserForm(.petnameField(a)) }
                 ),
-                caption: Text(verbatim: state.petnameFieldCaption ?? "")
+                caption: .text(state.petnameFieldCaption ?? "")
             )
             .textFieldStyle(.roundedBorder)
             .lineLimit(1)

--- a/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserSheet.swift
@@ -168,8 +168,8 @@ struct FollowUserSheet: View {
     var failFollowError: String?
     var onDismissError: () -> Void
     
-    var caption: String.LocalizationValue {
-        String.LocalizationValue(state.petnameFieldCaption ?? "")
+    var caption: String {
+        state.petnameFieldCaption ?? ""
     }
     
     var body: some View {

--- a/xcode/Subconscious/Shared/Components/Detail/RenameSearchView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/RenameSearchView.swift
@@ -22,7 +22,6 @@ struct RenameSearchView: View {
                     placeholder: String(localized: "Enter link for note"),
                     field: state.queryField,
                     send: { action in send(QueryFieldCursor.tag(action)) },
-                    caption: AnyView(EmptyView()),
                     autoFocus: true
                 )
                 .modifier(RoundedTextFieldViewModifier())

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
@@ -26,7 +26,7 @@ struct FirstRunProfileView: View {
                         send: app.send,
                         tag: AppAction.nicknameFormField
                     ),
-                    caption: Text("Lowercase letters, numbers and dashes only."),
+                    caption: .text("Lowercase letters, numbers and dashes only."),
                     autoFocus: true,
                     submitLabel: .go,
                     onSubmit: {

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
@@ -26,7 +26,7 @@ struct FirstRunProfileView: View {
                         send: app.send,
                         tag: AppAction.nicknameFormField
                     ),
-                    caption: .text("Lowercase letters, numbers and dashes only."),
+                    caption: "Lowercase letters, numbers and dashes only.",
                     autoFocus: true,
                     submitLabel: .go,
                     onSubmit: {

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
@@ -85,14 +85,14 @@ struct FirstRunView: View {
                             send: app.send,
                             tag: AppAction.inviteCodeFormField
                         ),
-                        caption: Group {
+                        caption: .text(Func.run {
                             switch app.state.inviteCodeRedemptionStatus {
                             case .failed(_):
-                                Text("Could not redeem invite code")
+                                return "Could not redeem invite code"
                             case _:
-                                Text("You can find your invite code in your welcome email")
+                                return "You can find your invite code in your welcome email"
                             }
-                        },
+                        }),
                         onFocusChanged: { focused in
                             // User finished editing the field
                             if !focused {

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
@@ -37,6 +37,15 @@ struct FirstRunView: View {
     @ObservedObject var app: Store<AppModel>
     @Environment(\.colorScheme) var colorScheme
     
+    var inviteCodeCaption: String.LocalizationValue {
+        switch app.state.inviteCodeRedemptionStatus {
+        case .failed(_):
+            return "Could not redeem invite code"
+        case _:
+            return "You can find your invite code in your welcome email"
+        }
+    }
+    
     var body: some View {
         NavigationStack(
             path: Binding(
@@ -85,14 +94,7 @@ struct FirstRunView: View {
                             send: app.send,
                             tag: AppAction.inviteCodeFormField
                         ),
-                        caption: .text(Func.run {
-                            switch app.state.inviteCodeRedemptionStatus {
-                            case .failed(_):
-                                return "Could not redeem invite code"
-                            case _:
-                                return "You can find your invite code in your welcome email"
-                            }
-                        }),
+                        caption: inviteCodeCaption,
                         onFocusChanged: { focused in
                             // User finished editing the field
                             if !focused {

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
@@ -37,12 +37,12 @@ struct FirstRunView: View {
     @ObservedObject var app: Store<AppModel>
     @Environment(\.colorScheme) var colorScheme
     
-    var inviteCodeCaption: String.LocalizationValue {
+    var inviteCodeCaption: String {
         switch app.state.inviteCodeRedemptionStatus {
         case .failed(_):
-            return "Could not redeem invite code"
+            return String(localized: "Could not redeem invite code")
         case _:
-            return "You can find your invite code in your welcome email"
+            return String(localized: "You can find your invite code in your welcome email")
         }
     }
     

--- a/xcode/Subconscious/Shared/Components/Settings/AuthorizationSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/AuthorizationSettingsView.swift
@@ -49,7 +49,6 @@ struct AuthorizationSettingsView: View {
             
             Section(
                 content: {
-                    
                     ValidatedFormField(
                         placeholder: "DID",
                         field: state.form.did,
@@ -57,8 +56,9 @@ struct AuthorizationSettingsView: View {
                             send: app.send,
                             tag: { a in .authorization(.form(.didField(a))) }
                         ),
-                        caption: Text(
-                            "e.g. did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7"
+                        caption: String(
+                            localized:
+                                "e.g. did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7"
                         ),
                         axis: .vertical
                     )
@@ -74,8 +74,8 @@ struct AuthorizationSettingsView: View {
                             send: app.send,
                             tag: { a in .authorization(.form(.nameField(a))) }
                         ),
-                        caption: Text(
-                            "The name for this authorization"
+                        caption: String(
+                            localized: "The name for this authorization"
                         )
                     )
                     .textInputAutocapitalization(.never)

--- a/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
@@ -22,9 +22,7 @@ struct GatewayURLSettingsView: View {
                             send: app.send,
                             tag: AppAction.gatewayURLField
                         ),
-                        caption: .text(
-                            "The URL of your preferred Noosphere gateway"
-                        )
+                        caption: "The URL of your preferred Noosphere gateway" 
                     )
                     .textInputAutocapitalization(.never)
                     .disableAutocorrection(true)

--- a/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
@@ -22,7 +22,7 @@ struct GatewayURLSettingsView: View {
                             send: app.send,
                             tag: AppAction.gatewayURLField
                         ),
-                        caption: Text(
+                        caption: .text(
                             "The URL of your preferred Noosphere gateway"
                         )
                     )

--- a/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
@@ -22,7 +22,7 @@ struct GatewayURLSettingsView: View {
                             send: app.send,
                             tag: AppAction.gatewayURLField
                         ),
-                        caption: "The URL of your preferred Noosphere gateway" 
+                        caption: String(localized: "The URL of your preferred Noosphere gateway")
                     )
                     .textInputAutocapitalization(.never)
                     .disableAutocorrection(true)

--- a/xcode/Subconscious/Shared/Components/Settings/InviteCodeSettingsSection.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/InviteCodeSettingsSection.swift
@@ -50,12 +50,12 @@ struct RedeemInviteCodeLabel: View {
 struct ValidatedInviteCodeFormField: View {
     @ObservedObject var app: Store<AppModel>
     
-    var caption: String.LocalizationValue {
+    var caption: String {
         switch app.state.inviteCodeRedemptionStatus {
         case .failed(_):
-            return "Could not redeem invite code"
+            return String(localized: "Could not redeem invite code")
         case _:
-            return "You can find your invite code in your welcome email"
+            return String(localized: "You can find your invite code in your welcome email")
         }
     }
     

--- a/xcode/Subconscious/Shared/Components/Settings/InviteCodeSettingsSection.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/InviteCodeSettingsSection.swift
@@ -50,6 +50,15 @@ struct RedeemInviteCodeLabel: View {
 struct ValidatedInviteCodeFormField: View {
     @ObservedObject var app: Store<AppModel>
     
+    var caption: String.LocalizationValue {
+        switch app.state.inviteCodeRedemptionStatus {
+        case .failed(_):
+            return "Could not redeem invite code"
+        case _:
+            return "You can find your invite code in your welcome email"
+        }
+    }
+    
     var body: some View {
         ValidatedFormField(
             placeholder: "Enter an invite code",
@@ -58,14 +67,7 @@ struct ValidatedInviteCodeFormField: View {
                 send: app.send,
                 tag: AppAction.inviteCodeFormField
             ),
-            caption: .text(Func.run {
-                switch app.state.inviteCodeRedemptionStatus {
-                case .failed(_):
-                    return "Could not redeem invite code"
-                case _:
-                    return "You can find your invite code in your welcome email"
-                }}
-            )
+            caption: caption
         )
         .autocapitalization(.none)
         .autocorrectionDisabled(true)

--- a/xcode/Subconscious/Shared/Components/Settings/InviteCodeSettingsSection.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/InviteCodeSettingsSection.swift
@@ -58,14 +58,14 @@ struct ValidatedInviteCodeFormField: View {
                 send: app.send,
                 tag: AppAction.inviteCodeFormField
             ),
-            caption: Group {
+            caption: .text(Func.run {
                 switch app.state.inviteCodeRedemptionStatus {
                 case .failed(_):
-                    Text("Could not redeem invite code")
+                    return "Could not redeem invite code"
                 case _:
-                    Text("You can find your invite code in your welcome email")
-                }
-            }
+                    return "You can find your invite code in your welcome email"
+                }}
+            )
         )
         .autocapitalization(.none)
         .autocorrectionDisabled(true)

--- a/xcode/Subconscious/Shared/Components/Settings/ProfileSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/ProfileSettingsView.swift
@@ -21,9 +21,7 @@ struct ProfileSettingsView: View {
                         send: app.send,
                         tag: AppAction.nicknameFormField
                     ),
-                    caption: .text(
-                        "Lowercase letters, numbers and dashes only."
-                    )
+                    caption: "Lowercase letters, numbers and dashes only." 
                 )
                 .textInputAutocapitalization(.never)
                 .disableAutocorrection(true)

--- a/xcode/Subconscious/Shared/Components/Settings/ProfileSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/ProfileSettingsView.swift
@@ -21,7 +21,7 @@ struct ProfileSettingsView: View {
                         send: app.send,
                         tag: AppAction.nicknameFormField
                     ),
-                    caption: "Lowercase letters, numbers and dashes only." 
+                    caption: String(localized: "Lowercase letters, numbers and dashes only.")
                 )
                 .textInputAutocapitalization(.never)
                 .disableAutocorrection(true)

--- a/xcode/Subconscious/Shared/Components/Settings/ProfileSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/ProfileSettingsView.swift
@@ -21,7 +21,7 @@ struct ProfileSettingsView: View {
                         send: app.send,
                         tag: AppAction.nicknameFormField
                     ),
-                    caption: Text(
+                    caption: .text(
                         "Lowercase letters, numbers and dashes only."
                     )
                 )

--- a/xcode/Subconscious/Shared/Models/FormField.swift
+++ b/xcode/Subconscious/Shared/Models/FormField.swift
@@ -13,7 +13,9 @@ import Combine
 
 typealias FormFieldValidator<Input, Output> = (Input) -> Output?
 
-enum FormFieldAction<Input: Equatable>: Equatable {
+typealias FormFieldInput = Equatable & Hashable
+
+enum FormFieldAction<Input: FormFieldInput>: FormFieldInput {
     case reset
     /// Intended for triggering validation errors when a user submits a form containing this field
     case markAsTouched
@@ -24,7 +26,7 @@ enum FormFieldAction<Input: Equatable>: Equatable {
 
 typealias FormFieldEnvironment = Void
 
-struct FormField<Input: Equatable, Output>: ModelProtocol {
+struct FormField<Input: FormFieldInput, Output>: ModelProtocol {
     static func == (lhs: FormField<Input, Output>, rhs: FormField<Input, Output>) -> Bool {
         return (
             lhs.value == rhs.value &&


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/796

Port the `RenameSearchView` input field to `ValidatedFormField`. Reworked how `caption` works on `ValidatedTextField` in the process.