### PR TITLE
Use `Slashlink.verbatim` when changing audience

### DIFF
--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -1714,7 +1714,7 @@ struct MemoEditorDetailModel: ModelProtocol {
             through: { markup in
                 switch markup {
                 case .slashlink(let slashlink):
-                    let replacement = link.address.verbatimMarkup
+                    let replacement = link.address.markup
                     let range = NSRange(
                         slashlink.span.range,
                         in: state.editor.text
@@ -1728,7 +1728,7 @@ struct MemoEditorDetailModel: ModelProtocol {
                                     text: link.linkableTitle
                                 ).markup
                             case _:
-                                return link.address.verbatimMarkup
+                                return link.address.markup
                         }
                     }
                     let range = NSRange(
@@ -1737,7 +1737,7 @@ struct MemoEditorDetailModel: ModelProtocol {
                     )
                     return (range, replacement)
                 case .none:
-                    let replacement = link.address.verbatimMarkup
+                    let replacement = link.address.markup
                     return (state.editor.selection, replacement)
                 }
             }

--- a/xcode/Subconscious/Shared/Models/Slashlink.swift
+++ b/xcode/Subconscious/Shared/Models/Slashlink.swift
@@ -31,9 +31,9 @@ public struct Slashlink:
     
     public var description: String {
         guard let peer = peer else {
-            return slug.markup
+            return slug.description
         }
-        return "\(peer.markup)\(slug.markup)"
+        return "\(peer.description)\(slug.markup)"
     }
 
     public var verbatim: String {
@@ -43,10 +43,15 @@ public struct Slashlink:
         return "\(peer.verbatimMarkup)\(slug.verbatimMarkup)"
     }
 
-    public var id: String { verbatim }
+    public var id: String { description }
     
     // The normalized markup form of the slashlink
-    public var markup: String { description }
+    public var markup: String {
+        guard let peer = peer else {
+            return slug.markup
+        }
+        return "\(peer.markup)\(slug.markup)"
+    }
 
     // The non-normalized markup form of the slashlink
     public var verbatimMarkup: String { verbatim }

--- a/xcode/Subconscious/Shared/Models/Slashlink.swift
+++ b/xcode/Subconscious/Shared/Models/Slashlink.swift
@@ -31,7 +31,7 @@ public struct Slashlink:
     
     public var description: String {
         guard let peer = peer else {
-            return slug.description
+            return slug.markup
         }
         return "\(peer.description)\(slug.markup)"
     }

--- a/xcode/Subconscious/Shared/Models/Slashlink.swift
+++ b/xcode/Subconscious/Shared/Models/Slashlink.swift
@@ -43,7 +43,7 @@ public struct Slashlink:
         return "\(peer.verbatimMarkup)\(slug.verbatimMarkup)"
     }
 
-    public var id: String { description }
+    public var id: String { verbatim }
     
     // The normalized markup form of the slashlink
     public var markup: String { description }

--- a/xcode/Subconscious/Shared/Models/Slashlink.swift
+++ b/xcode/Subconscious/Shared/Models/Slashlink.swift
@@ -30,10 +30,7 @@ public struct Slashlink:
     let slug: Slug
     
     public var description: String {
-        guard let peer = peer else {
-            return slug.markup
-        }
-        return "\(peer.description)\(slug.markup)"
+        verbatim.lowercased()
     }
 
     public var verbatim: String {

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -588,10 +588,10 @@ actor DataService {
         let from = from.relativizeIfNeeded(did: identity)
         let to = to.relativizeIfNeeded(did: identity)
         guard from != to else {
-            throw DataServiceError.fileExists(to.description)
+            throw DataServiceError.fileExists(to.verbatim)
         }
         guard await !self.exists(to) else {
-            throw DataServiceError.fileExists(to.description)
+            throw DataServiceError.fileExists(to.verbatim)
         }
         let fromMemo = try await readMemo(address: from)
         // Make a copy representing new location and set new title and slug

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -588,10 +588,10 @@ actor DataService {
         let from = from.relativizeIfNeeded(did: identity)
         let to = to.relativizeIfNeeded(did: identity)
         guard from != to else {
-            throw DataServiceError.fileExists(to.verbatim)
+            throw DataServiceError.fileExists(to.description)
         }
         guard await !self.exists(to) else {
-            throw DataServiceError.fileExists(to.verbatim)
+            throw DataServiceError.fileExists(to.description)
         }
         let fromMemo = try await readMemo(address: from)
         // Make a copy representing new location and set new title and slug

--- a/xcode/Subconscious/SubconsciousTests/Tests_DataService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DataService.swift
@@ -277,7 +277,7 @@ final class Tests_DataService: XCTestCase {
         
         let addressA2 = await environment.data
             .findUniqueAddressFor(title, audience: .local)
-        XCTAssertEqual(addressA2?.description, "/a-2")
+        XCTAssertEqual(addressA2?.markup, "/a-2")
     }
     
     func testReadMemoDetail() async throws {

--- a/xcode/Subconscious/SubconsciousTests/Tests_Slashlink.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Slashlink.swift
@@ -340,4 +340,12 @@ final class Tests_Slashlink: XCTestCase {
         
         XCTAssertEqual(combined, Slashlink(petname: Petname("jordan.chris.ben.gordon")!, slug: Slug("ok")!))
     }
+    
+    func testLocalAddressIsNotEqualToPublicAddress() {
+        let slug = Slug("lmao")!
+        let a = Slashlink(peer: .did(Did.local), slug: slug)
+        let b = Slashlink(peer: .none, slug: slug)
+        
+        XCTAssertFalse(a == b)
+    }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_Slashlink.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Slashlink.swift
@@ -350,22 +350,22 @@ final class Tests_Slashlink: XCTestCase {
     }
     
     func testLocalAddressStringFormatting() {
-        let slug = Slug("lmao")!
+        let slug = Slug("LmAo")!
         let link = Slashlink(peer: .did(Did.local), slug: slug)
         
         XCTAssertEqual(link.markup, "/lmao")
         XCTAssertEqual(link.description, "did:subconscious:local/lmao")
-        XCTAssertEqual(link.verbatim, "did:subconscious:local/lmao")
-        XCTAssertEqual(link.verbatimMarkup, "did:subconscious:local/lmao")
+        XCTAssertEqual(link.verbatim, "did:subconscious:local/LmAo")
+        XCTAssertEqual(link.verbatimMarkup, "did:subconscious:local/LmAo")
     }
     
     func testPeerlessPublicAddressStringFormatting() {
-        let slug = Slug("lmao")!
+        let slug = Slug("LmAo")!
         let link = Slashlink(peer: nil, slug: slug)
         
         XCTAssertEqual(link.markup, "/lmao")
         XCTAssertEqual(link.description, "/lmao")
-        XCTAssertEqual(link.verbatim, "/lmao")
-        XCTAssertEqual(link.verbatimMarkup, "/lmao")
+        XCTAssertEqual(link.verbatim, "/LmAo")
+        XCTAssertEqual(link.verbatimMarkup, "/LmAo")
     }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_Slashlink.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Slashlink.swift
@@ -348,4 +348,14 @@ final class Tests_Slashlink: XCTestCase {
         
         XCTAssertFalse(a == b)
     }
+    
+    func testLocalAddressStringFormatting() {
+        let slug = Slug("lmao")!
+        let link = Slashlink(peer: .did(Did.local), slug: slug)
+        
+        XCTAssertEqual(link.markup, "/lmao")
+        XCTAssertEqual(link.description, "did:subconscious:local/lmao")
+        XCTAssertEqual(link.verbatim, "did:subconscious:local/lmao")
+        XCTAssertEqual(link.verbatimMarkup, "did:subconscious:local/lmao")
+    }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_Slashlink.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Slashlink.swift
@@ -358,4 +358,14 @@ final class Tests_Slashlink: XCTestCase {
         XCTAssertEqual(link.verbatim, "did:subconscious:local/lmao")
         XCTAssertEqual(link.verbatimMarkup, "did:subconscious:local/lmao")
     }
+    
+    func testPeerlessPublicAddressStringFormatting() {
+        let slug = Slug("lmao")!
+        let link = Slashlink(peer: nil, slug: slug)
+        
+        XCTAssertEqual(link.markup, "/lmao")
+        XCTAssertEqual(link.description, "/lmao")
+        XCTAssertEqual(link.verbatim, "/lmao")
+        XCTAssertEqual(link.verbatimMarkup, "/lmao")
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/836

You were right @gordonbrander, we were looking at `description` here. It was actually quite subtle, since Slashlink uses `description` to meet the `Identifiable` protocol we were treating local addresses as being _equal to_ public ones.

`Slashlink.description` preserves the old behaviour, `Slashlink.markup` strips the local prefix (`did:subconscious:local`) but `verbatim` and `verbatimMarkup` preserve the prefix. My logic is:

- Description is human readable and detail preserving
- Verbatim is case preserving and detail preserving
- Markup is designed to be rendered in UI and inserted into text