### PR TITLE
Fix stale audience in navigation stack

### DIFF
--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -987,7 +987,7 @@ struct MemoEditorDetailModel: ModelProtocol {
         info: MemoEditorDetailDescription
     ) -> Update<MemoEditorDetailModel> {
         // No address? This is a draft.
-        guard let address = state.address ?? info.address else {
+        guard let address = info.address ?? state.address else {
             return update(
                 state: state,
                 action: .setDraftDetail(


### PR DESCRIPTION
Relies on https://github.com/subconsciousnetwork/subconscious/pull/837
Fixes https://github.com/subconsciousnetwork/subconscious/issues/798

Prefer updated address to stale address after changing audience.

Interestingly, this _also_ fixes https://github.com/subconsciousnetwork/subconscious/issues/583
