### PR TITLE
Massively improve profile load times

### DIFF
--- a/xcode/Subconscious/Shared/Models/EntryStub.swift
+++ b/xcode/Subconscious/Shared/Models/EntryStub.swift
@@ -34,6 +34,15 @@ struct EntryStub:
             author: author
         )
     }
+    
+    func withAddress(_ address: Slashlink) -> Self {
+        return Self(
+            address: address,
+            excerpt: excerpt,
+            modified: modified,
+            author: author
+        )
+    }
 }
 
 extension EntryLink {


### PR DESCRIPTION
We were _always_ reading the user's sphere to populate the list of notes on the profile. This PR introduces an optimisation to read notes from the DB index if we follow the user who's profile we're loading. 

Combining this with the existing cache of user profile metadata makes it practically instant to load any profile we follow.