### PR TITLE
Show draft icon as pfp for local transcludes

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/Byline/BylineSmView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Byline/BylineSmView.swift
@@ -14,9 +14,7 @@ struct BylineSmView: View {
     
     var body: some View {
         HStack {
-            if let pfp = pfp {
-                ProfilePic(pfp: pfp, size: .small)
-            }
+            ProfilePic(pfp: pfp, size: .small)
             SlashlinkDisplayView(slashlink: slashlink)
                 .theme(slug: .secondary)
         }
@@ -25,9 +23,16 @@ struct BylineSmView: View {
 
 struct BylineSmView_Previews: PreviewProvider {
     static var previews: some View {
-        BylineSmView(
-            pfp: .image("pfp-dog"),
-            slashlink: Slashlink("@name/path")!
-        )
+        VStack {
+            BylineSmView(
+                pfp: .image("pfp-dog"),
+                slashlink: Slashlink("@name/path")!
+            )
+            
+            BylineSmView(
+                pfp: .none,
+                slashlink: Slashlink("@name/path")!
+            )
+        }
     }
 }

--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -126,7 +126,7 @@ struct EditProfileSheet: View {
     var onDismissError: () -> Void
     
     func makePreview(nickname: Petname.Name) -> UserProfile {
-        let pfp: ProfilePicVariant = ProfilePicVariant.none(user.did)
+        let pfp: ProfilePicVariant = ProfilePicVariant.generated(user.did)
         
         return UserProfile(
             did: user.did,

--- a/xcode/Subconscious/Shared/Components/Common/Profile/ProfilePic.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/ProfilePic.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 enum ProfilePicVariant: Equatable, Codable, Hashable {
-    case none(Did)
+    case generated(Did)
     case image(String)
 }
 
@@ -19,7 +19,7 @@ enum ProfilePicSize {
 }
 
 struct ProfilePic: View {
-    var pfp: ProfilePicVariant
+    var pfp: ProfilePicVariant?
     var size: ProfilePicSize
 
     private var imageSize: CGFloat {
@@ -45,14 +45,24 @@ struct ProfilePic: View {
     }
 
     var body: some View {
-        switch pfp {
-        case .none(let did):
-            GenerativeProfilePic(did: did, size: imageSize)
-                .profilePicFrame(size: imageSize, lineWidth: lineWidth)
-        case .image(let img):
-            Image(img)
+        if let pfp = pfp {
+            switch pfp {
+            case .generated(let did):
+                GenerativeProfilePic(did: did, size: imageSize)
+                    .profilePicFrame(size: imageSize, lineWidth: lineWidth)
+            case .image(let img):
+                Image(img)
+                    .resizable()
+                    .profilePicFrame(size: imageSize, lineWidth: lineWidth)
+            }
+        } else {
+            Image(audience: .local)
                 .resizable()
-                .profilePicFrame(size: imageSize, lineWidth: lineWidth)
+                .foregroundStyle(Color.separator)
+                .frame(
+                    width: imageSize,
+                    height: imageSize
+                )
         }
     }
 }
@@ -61,12 +71,16 @@ struct ProfilePic_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
             ProfilePic(
-                pfp: .none(Did.dummyData()),
+                pfp: .generated(Did.dummyData()),
                 size: .small
             )
             ProfilePic(
                 pfp: .image("pfp-dog"),
                 size: .large
+            )
+            ProfilePic(
+                pfp: .none,
+                size: .small
             )
         }
     }

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -198,7 +198,7 @@ actor UserProfileService {
             did: did,
             nickname: Petname.Name(userProfileData?.nickname ?? ""),
             address: address,
-            pfp: .none(did),
+            pfp: .generated(did),
             bio: UserProfileBio(userProfileData?.bio ?? ""),
             category: isOurs ? UserCategory.ourself : UserCategory.human,
             resolutionStatus: resolutionStatus,


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/830

If `pfp` is `.none` then the icon for "local" audience is used in its place.

<img width="178" alt="image" src="https://github.com/subconsciousnetwork/subconscious/assets/5009316/ee00a187-b5a4-40a5-8ca1-f2bdd32107f7">

<img width="381" alt="image" src="https://github.com/subconsciousnetwork/subconscious/assets/5009316/9ab02ff9-cb65-46da-856d-fbe437c49909">