### PR TITLE
Exclude local drafts from recent memos list

### DIFF
--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -653,9 +653,7 @@ actor DataService {
         return try self.database.listRecentMemos(owner: identity, includeDrafts: true)
     }
     
-    nonisolated func listRecentMemosPublisher(
-        includeDrafts: Bool
-    ) -> AnyPublisher<[EntryStub], Error> {
+    nonisolated func listRecentMemosPublisher() -> AnyPublisher<[EntryStub], Error> {
         Future.detached {
             try await self.listRecentMemos()
         }

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -650,10 +650,12 @@ actor DataService {
     
     func listRecentMemos() async throws -> [EntryStub] {
         let identity = try? await noosphere.identity()
-        return try self.database.listRecentMemos(owner: identity)
+        return try self.database.listRecentMemos(owner: identity, includeDrafts: true)
     }
     
-    nonisolated func listRecentMemosPublisher() -> AnyPublisher<[EntryStub], Error> {
+    nonisolated func listRecentMemosPublisher(
+        includeDrafts: Bool
+    ) -> AnyPublisher<[EntryStub], Error> {
         Future.detached {
             try await self.listRecentMemos()
         }

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -485,12 +485,15 @@ final class DatabaseService {
     }
     
     /// List recent entries
-    func listRecentMemos(owner: Did?) throws -> [EntryStub] {
+    func listRecentMemos(owner: Did?, includeDrafts: Bool = false) throws -> [EntryStub] {
         guard self.state == .ready else {
             throw DatabaseServiceError.notReady
         }
         
-        var dids = [Did.local.description]
+        var dids: [String] = []
+        if includeDrafts {
+            dids.append(Did.local.description)
+        }
         if let owner = owner {
             dids.append(owner.description)
         }

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -406,7 +406,7 @@ actor UserProfileService {
             // Read from DB if we follow this user
             case .following(let name):
                 return try
-                    self.database.listRecentMemos(owner: did)
+                    self.database.listRecentMemos(owner: did, includeDrafts: false)
                     .map { memo in
                         memo.withAddress(
                             Slashlink(

--- a/xcode/Subconscious/SubconsciousTests/Tests_DatabaseService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DatabaseService.swift
@@ -218,7 +218,7 @@ class Tests_DatabaseService: XCTestCase {
             )
         )
         
-        let recent = try service.listRecentMemos(owner: Did("did:key:abc123")!)
+        let recent = try service.listRecentMemos(owner: Did("did:key:abc123")!, includeDrafts: true)
         
         XCTAssertEqual(recent.count, 3)
         
@@ -313,7 +313,7 @@ class Tests_DatabaseService: XCTestCase {
             )
         )
         
-        let recent = try service.listRecentMemos(owner: nil)
+        let recent = try service.listRecentMemos(owner: nil, includeDrafts: true)
         
         XCTAssertEqual(recent.count, 2)
         
@@ -892,7 +892,7 @@ class Tests_DatabaseService: XCTestCase {
         let syncInfo = try service.readPeer(identity: did)
         XCTAssertNil(syncInfo)
         
-        let recent = try service.listRecentMemos(owner: did)
+        let recent = try service.listRecentMemos(owner: did, includeDrafts: true)
         XCTAssertEqual(recent.count, 1)
         XCTAssertEqual(
             recent.first?.address,


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/851

Maybe not the cleanest API, we have to differentiate between the case where we are listing the _user's_ recent notes vs someone they follow. We should only include local drafts when dealing with _our_ content.