### PR TITLE
Don't overwrite default Geist petname

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -1986,7 +1986,8 @@ struct AppModel: ModelProtocol {
         let fx: Fx<AppAction> = environment.addressBook
             .followUserPublisher(
                 did: Config.default.subconsciousGeistDid,
-                petname: Config.default.subconsciousGeistPetname
+                petname: Config.default.subconsciousGeistPetname,
+                preventOverwrite: true
             )
             .map {
                 AppAction.succeedFollowDefaultGeist


### PR DESCRIPTION
...if it already exists. We only run this code when the sphere is first created, so in theory it should not ever overwrite the default geist petname entry. However, let's toggle the "don't overwrite" option for further safety.