### PR TITLE
Log privacy (protect PII)

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -1043,7 +1043,7 @@ struct AppModel: ModelProtocol {
             metadata: [
                 "documents": environment.documentURL.absoluteString,
                 "database": environment.database.database.path,
-                "sphereIdentity": state.sphereIdentity
+                "sphereIdentity": state.sphereIdentity?.description
             ]
         )
         return update(
@@ -1260,7 +1260,7 @@ struct AppModel: ModelProtocol {
         var model = state
         model.sphereIdentity = sphereIdentity
         if let sphereIdentity = sphereIdentity {
-            logger.debug("Set sphere ID: \(sphereIdentity)")
+            logger.info("Set sphere ID: \(sphereIdentity.did, privacy: .private(mask: .hash))")
         }
         return Update(state: model)
     }
@@ -1581,7 +1581,7 @@ struct AppModel: ModelProtocol {
             logger.log(
                 "Last index for our sphere",
                 metadata: [
-                    "identity": info.identity,
+                    "identity": info.identity.description,
                     "version": info.since
                 ]
             )
@@ -1709,7 +1709,7 @@ struct AppModel: ModelProtocol {
         logger.log(
             "Indexed our sphere",
             metadata: [
-                "identity": receipt.identity,
+                "identity": receipt.identity.description,
                 "version": receipt.since
             ]
         )
@@ -1893,8 +1893,8 @@ struct AppModel: ModelProtocol {
         logger.log(
             "Indexed peer",
             metadata: [
-                "petname": peer.petname,
-                "identity": peer.identity,
+                "petname": peer.petname.description,
+                "identity": peer.identity.description,
                 "since": peer.since ?? "nil"
             ]
         )

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunDoneView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunDoneView.swift
@@ -31,7 +31,7 @@ struct FirstRunDoneView: View {
     }
     
     private var did: Did? {
-        Did(app.state.sphereIdentity ?? "")
+        app.state.sphereIdentity
     }
     
     var statusLabel: String {

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunRecoveryView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunRecoveryView.swift
@@ -12,10 +12,6 @@ struct FirstRunRecoveryView: View {
     @ObservedObject var app: Store<AppModel>
     @Environment(\.colorScheme) var colorScheme
     
-    var did: Did? {
-        Did(app.state.sphereIdentity ?? "")
-    }
-    
     var body: some View {
         VStack(spacing: AppTheme.padding) {
             Spacer()

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunSphereView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunSphereView.swift
@@ -12,7 +12,7 @@ struct FirstRunSphereView: View {
     @Environment(\.colorScheme) var colorScheme
     
     var did: Did? {
-        Did(app.state.sphereIdentity ?? "")
+        app.state.sphereIdentity
     }
     
     var body: some View {

--- a/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
@@ -75,7 +75,7 @@ struct SettingsView: View {
                             label: {
                                 LabeledContent(
                                     "Sphere",
-                                    value: app.state.sphereIdentity ?? unknown
+                                    value: app.state.sphereIdentity?.did ?? unknown
                                 )
                                 .lineLimit(1)
                             }

--- a/xcode/Subconscious/Shared/Components/Settings/SphereSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/SphereSettingsView.swift
@@ -23,7 +23,7 @@ struct SphereSettingsView: View {
                 }
             )
             
-            if let did = Did(app.state.sphereIdentity ?? "") {
+            if let did = app.state.sphereIdentity {
                 Section(header: Text("Your DID")) {
                     DidView(did: did)
                 }

--- a/xcode/Subconscious/Shared/Config.swift
+++ b/xcode/Subconscious/Shared/Config.swift
@@ -11,7 +11,7 @@ import SwiftNoosphere
 /// Feature flags and settings
 struct Config: Equatable, Codable {
     /// App version.
-    var rdns = "com.subconscious.Subconscious"
+    var rdns = Bundle.main.bundleIdentifier ?? "com.subconscious.Subconscious"
     var debug = (Bundle.main.object(forInfoDictionaryKey: "DEBUG") as! String == "YES")
     
     var noosphere = NoosphereConfig()

--- a/xcode/Subconscious/Shared/Library/LogFmt.swift
+++ b/xcode/Subconscious/Shared/Library/LogFmt.swift
@@ -57,9 +57,33 @@ extension Logger {
             metadata: metadata
         )
         
+        for kv in metadata {
+            self.log(
+                level: level,
+                """
+                \(message, privacy: .public) \
+                [\(kv.key): \(String(describing: kv.value), privacy: .private(mask: .hash))]
+                """
+            )
+        }
+    }
+    
+    /// Log `parameters` to JSON string, using given log `level`
+    func log_old(
+        level: OSLogType,
+        message: String,
+        metadata: LoggingMetadata
+    ) {
+        let string = LogFmt.format(
+            message: message,
+            metadata: metadata
+        )
+        
+        let msg = LogFmt.formatParameter(key: "msg", value: message)
+        
         self.log(
             level: level,
-            "\(LogFmt.formatParameter(key: "msg", value: message), privacy: .public) \(string, privacy: .private(mask: .hash))"
+            "\(msg, privacy: .public) \(string, privacy: .private(mask: .hash))"
         )
     }
     

--- a/xcode/Subconscious/Shared/Library/LogFmt.swift
+++ b/xcode/Subconscious/Shared/Library/LogFmt.swift
@@ -59,7 +59,7 @@ extension Logger {
         
         self.log(
             level: level,
-            "\(LogFmt.formatParameter(key: "msg", value: message)) \(string, privacy: .private(mask: .hash))"
+            "\(LogFmt.formatParameter(key: "msg", value: message), privacy: .public) \(string, privacy: .private(mask: .hash))"
         )
     }
     

--- a/xcode/Subconscious/Shared/Library/LogFmt.swift
+++ b/xcode/Subconscious/Shared/Library/LogFmt.swift
@@ -13,11 +13,11 @@ struct LogFmt {
         value.replacingOccurrences(of: #"""#, with: #"\""#)
     }
     
-    private static func formatParameter(
+    public static func formatParameter(
         key: String,
-        value: String
+        value: String?
     ) -> String {
-        let value = Self.escapeValuePart(value)
+        let value = Self.escapeValuePart(value ?? "nil")
         return #"\#(key)="\#(value)""#
     }
 
@@ -30,9 +30,9 @@ struct LogFmt {
     /// See https://brandur.org/logfmt
     static func format(
         message: String,
-        metadata: KeyValuePairs<String, String>
+        metadata: KeyValuePairs<String, String?>
     ) -> String {
-        var parameters = [formatParameter(key: "msg", value: message)]
+        var parameters: [String] = []
         for (key, value) in metadata {
             let parameter = Self.formatParameter(key: key, value: value)
             parameters.append(parameter)
@@ -41,6 +41,8 @@ struct LogFmt {
     }
 }
 
+typealias LoggingMetadata = KeyValuePairs<String, String?>
+
 /// Extend logger to provide a LogFmt variant that allows you to log
 /// `KeyValuePairs` as a LogFmt string.
 extension Logger {
@@ -48,37 +50,41 @@ extension Logger {
     func log(
         level: OSLogType,
         message: String,
-        metadata: KeyValuePairs<String, String>
+        metadata: LoggingMetadata
     ) {
         let string = LogFmt.format(
             message: message,
             metadata: metadata
         )
-        self.log(level: level, "\(string)")
+        
+        self.log(
+            level: level,
+            "\(LogFmt.formatParameter(key: "msg", value: message)) \(string, privacy: .private(mask: .hash))"
+        )
     }
     
     /// Log `parameters` at default log level.
-    func log(_ message: String, metadata: KeyValuePairs<String, String>) {
+    func log(_ message: String, metadata: LoggingMetadata) {
         log(level: .default, message: message, metadata: metadata)
     }
     
     /// Log `parameters` at info log level.
-    func info(_ message: String, metadata: KeyValuePairs<String, String>) {
+    func info(_ message: String, metadata: LoggingMetadata) {
         log(level: .info, message: message, metadata: metadata)
     }
     
     /// Log `parameters` at debug log level.
-    func debug(_ message: String, metadata: KeyValuePairs<String, String>) {
+    func debug(_ message: String, metadata: LoggingMetadata) {
         log(level: .debug, message: message, metadata: metadata)
     }
     
     /// Log `parameters` at error log level.
-    func error(_ message: String, metadata: KeyValuePairs<String, String>) {
+    func error(_ message: String, metadata: LoggingMetadata) {
         log(level: .error, message: message, metadata: metadata)
     }
     
     /// Log `parameters` at fault log level.
-    func fault(_ message: String, metadata: KeyValuePairs<String, String>) {
+    func fault(_ message: String, metadata: LoggingMetadata) {
         log(level: .fault, message: message, metadata: metadata)
     }
 }

--- a/xcode/Subconscious/Shared/Library/LogFmt.swift
+++ b/xcode/Subconscious/Shared/Library/LogFmt.swift
@@ -47,16 +47,11 @@ typealias LoggingMetadata = KeyValuePairs<String, String?>
 /// `KeyValuePairs` as a LogFmt string.
 extension Logger {
     /// Log `parameters` to JSON string, using given log `level`
-    func log(
+    func log_lines(
         level: OSLogType,
         message: String,
         metadata: LoggingMetadata
     ) {
-        let string = LogFmt.format(
-            message: message,
-            metadata: metadata
-        )
-        
         for kv in metadata {
             self.log(
                 level: level,
@@ -69,7 +64,7 @@ extension Logger {
     }
     
     /// Log `parameters` to JSON string, using given log `level`
-    func log_old(
+    func log(
         level: OSLogType,
         message: String,
         metadata: LoggingMetadata

--- a/xcode/Subconscious/Shared/Library/Sentry.swift
+++ b/xcode/Subconscious/Shared/Library/Sentry.swift
@@ -51,10 +51,6 @@ extension SentryIntegration {
                     continue
                 }
                 
-                guard item.subsystem == Bundle.main.bundleIdentifier else {
-                    continue
-                }
-                
                 let crumb = Breadcrumb(
                     level: item.level.toSentry(),
                     category: item.category

--- a/xcode/Subconscious/Shared/Library/Sentry.swift
+++ b/xcode/Subconscious/Shared/Library/Sentry.swift
@@ -51,6 +51,10 @@ extension SentryIntegration {
                     continue
                 }
                 
+                guard item.subsystem == Bundle.main.bundleIdentifier else {
+                    continue
+                }
+                
                 let crumb = Breadcrumb(
                     level: item.level.toSentry(),
                     category: item.category

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -200,8 +200,8 @@ actor DataService {
             logger.log(
                 "Indexed peer",
                 metadata: [
-                    "petname": petname,
-                    "identity": identity,
+                    "petname": petname.description,
+                    "identity": identity.description,
                     "version": version,
                     "since": peer?.since ?? "nil"
                 ]
@@ -211,8 +211,8 @@ actor DataService {
             logger.log(
                 "Failed to index peer. Rolling back.",
                 metadata: [
-                    "petname": petname,
-                    "identity": identity,
+                    "petname": petname.description,
+                    "identity": identity.description,
                     "version": version,
                     "since": peer?.since ?? "nil"
                 ]
@@ -350,7 +350,7 @@ actor DataService {
             logger.log(
                 "Indexed our sphere",
                 metadata: [
-                    "identity": identity,
+                    "identity": identity.description,
                     "version": version
                 ]
             )
@@ -364,7 +364,7 @@ actor DataService {
             logger.log(
                 "Failed to index our sphere. Rolling back.",
                 metadata: [
-                    "identity": identity,
+                    "identity": identity.description,
                     "version": version
                 ]
             )

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -87,7 +87,7 @@ actor NoosphereService:
                 "globalStorageURL": globalStorageURL.absoluteString,
                 "sphereStorageURL": sphereStorageURL.absoluteString,
                 "gatewayURL": gatewayURL?.absoluteString ?? "nil",
-                "sphereIdentity": sphereIdentity
+                "sphereIdentity": sphereIdentity?.description
             ]
         )
 

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -39,7 +39,7 @@ protocol NoosphereServiceProtocol {
     func createSphere(ownerKeyName: String) async throws -> SphereReceipt
 
     /// Set a new default sphere
-    func resetSphere(_ identity: String?) async
+    func resetSphere(_ identity: Did?) async
     
     /// Update Gateway.
     /// Resets memoized Noosphere and Sphere instances.
@@ -69,7 +69,7 @@ actor NoosphereService:
     /// Memoized Noosphere instance
     private var _noosphere: Noosphere?
     /// Identity of default sphere
-    private var _sphereIdentity: String?
+    private var _sphereIdentity: Did?
     /// Memoized Sphere instance
     private var _sphere: Sphere?
     
@@ -77,7 +77,7 @@ actor NoosphereService:
         globalStorageURL: URL,
         sphereStorageURL: URL,
         gatewayURL: URL? = nil,
-        sphereIdentity: String? = nil,
+        sphereIdentity: Did? = nil,
         noosphereLogLevel: Noosphere.NoosphereLogLevel = .basic,
         logger: Logger = logger
     ) {
@@ -87,9 +87,10 @@ actor NoosphereService:
                 "globalStorageURL": globalStorageURL.absoluteString,
                 "sphereStorageURL": sphereStorageURL.absoluteString,
                 "gatewayURL": gatewayURL?.absoluteString ?? "nil",
-                "sphereIdentity": sphereIdentity ?? "nil"
+                "sphereIdentity": sphereIdentity
             ]
         )
+
         self.globalStorageURL = globalStorageURL
         self.sphereStorageURL = sphereStorageURL
         self.gatewayURL = gatewayURL
@@ -108,8 +109,13 @@ actor NoosphereService:
     }
     
     /// Set a new default sphere
-    func resetSphere(_ identity: String?) {
-        logger.debug("Reset sphere identity: \(identity ?? "none")")
+    func resetSphere(_ identity: Did?) {
+        if let identity = identity {
+            logger.debug("Reset sphere identity: \(identity)")
+        } else {
+            logger.debug("Cleared sphere identity")
+        }
+        
         self._sphereIdentity = identity
         self._sphere = nil
     }
@@ -164,7 +170,7 @@ actor NoosphereService:
         logger.debug("init Sphere with identity: \(identity)")
         let sphere = try Sphere(
             noosphere: noosphere,
-            identity: identity
+            identity: identity.did
         )
         self._sphere = sphere
         return sphere


### PR DESCRIPTION
This has been a bit of an adventure. Things I've learned:

[`OSLogPrivacy`](https://developer.apple.com/documentation/os/oslogprivacy) does what we want already, masking sensitive values in release builds. It will only censor values when running on hardware and not connected to a debugging session. 

Additionally, anything which interpolates a _string_ or _object_ will be treated as `OSLogPrivacy.private`, logs containing static text and interpolating _numbers_ are treated as public. See https://developer.apple.com/documentation/os/logging/generating_log_messages_from_your_code#3665948

> The unified logging system uses privacy options to hide or show interpolated variables in a message. By default, the system doesn’t redact integer, floating-point and Boolean values, but it does redact the contents of dynamic strings and complex dynamic objects. To make a private value public again, configure the privacy of the variable using appropriate modifiers in your message string or interpolated variable. For example, the following code shows how to make a dynamic string visible again using the public modifier:

_This means that, before this PR, almost all of our interpolations & logs will automatically be classed as `private`._ 

