### PR TITLE
Logging, PII and Sentry

### DIFF
--- a/xcode/Subconscious/Shared/Library/LogFmt.swift
+++ b/xcode/Subconscious/Shared/Library/LogFmt.swift
@@ -15,9 +15,9 @@ struct LogFmt {
     
     private static func formatParameter(
         key: String,
-        value: String
+        value: String?
     ) -> String {
-        let value = Self.escapeValuePart(value)
+        let value = Self.escapeValuePart(value ?? "nil")
         return #"\#(key)="\#(value)""#
     }
 
@@ -29,10 +29,9 @@ struct LogFmt {
     ///
     /// See https://brandur.org/logfmt
     static func format(
-        message: String,
-        metadata: KeyValuePairs<String, String>
+        metadata: KeyValuePairs<String, String?>
     ) -> String {
-        var parameters = [formatParameter(key: "msg", value: message)]
+        var parameters: [String] = []
         for (key, value) in metadata {
             let parameter = Self.formatParameter(key: key, value: value)
             parameters.append(parameter)
@@ -44,41 +43,46 @@ struct LogFmt {
 /// Extend logger to provide a LogFmt variant that allows you to log
 /// `KeyValuePairs` as a LogFmt string.
 extension Logger {
+    typealias LoggingMetadata = KeyValuePairs<String, String?>
+
     /// Log `parameters` to JSON string, using given log `level`
     func log(
         level: OSLogType,
         message: String,
-        metadata: KeyValuePairs<String, String>
+        metadata: LoggingMetadata
     ) {
         let string = LogFmt.format(
-            message: message,
             metadata: metadata
         )
-        self.log(level: level, "\(string)")
+        
+        self.log(
+            level: level,
+            "\(message, privacy: .public) \(string, privacy: .private(mask: .hash))"
+        )
     }
     
     /// Log `parameters` at default log level.
-    func log(_ message: String, metadata: KeyValuePairs<String, String>) {
+    func log(_ message: String, metadata: LoggingMetadata) {
         log(level: .default, message: message, metadata: metadata)
     }
     
     /// Log `parameters` at info log level.
-    func info(_ message: String, metadata: KeyValuePairs<String, String>) {
+    func info(_ message: String, metadata: LoggingMetadata) {
         log(level: .info, message: message, metadata: metadata)
     }
     
     /// Log `parameters` at debug log level.
-    func debug(_ message: String, metadata: KeyValuePairs<String, String>) {
+    func debug(_ message: String, metadata: LoggingMetadata) {
         log(level: .debug, message: message, metadata: metadata)
     }
     
     /// Log `parameters` at error log level.
-    func error(_ message: String, metadata: KeyValuePairs<String, String>) {
+    func error(_ message: String, metadata: LoggingMetadata) {
         log(level: .error, message: message, metadata: metadata)
     }
     
     /// Log `parameters` at fault log level.
-    func fault(_ message: String, metadata: KeyValuePairs<String, String>) {
+    func fault(_ message: String, metadata: LoggingMetadata) {
         log(level: .fault, message: message, metadata: metadata)
     }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_LogFmt.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_LogFmt.swift
@@ -11,7 +11,6 @@ import XCTest
 final class Tests_LogFmt: XCTestCase {
     func testFormat() throws {
         let string = LogFmt.format(
-            message: "Foo",
             metadata: [
                 "code": "bar",
                 "etc": "baz"
@@ -19,13 +18,12 @@ final class Tests_LogFmt: XCTestCase {
         )
         XCTAssertEqual(
             string,
-            #"msg="Foo" code="bar" etc="baz""#
+            #"code="bar" etc="baz""#
         )
     }
 
     func testFormatEscaping() throws {
         let string = LogFmt.format(
-            message: #""Foo""#,
             metadata: [
                 "code": "bar",
                 "etc": "baz"
@@ -33,7 +31,7 @@ final class Tests_LogFmt: XCTestCase {
         )
         XCTAssertEqual(
             string,
-            #"msg="\"Foo\"" code="bar" etc="baz""#
+            #"code="bar" etc="baz""#
         )
     }
 }


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/858

This has been a bit of an adventure. Things I've learned:

[`OSLogPrivacy`](https://developer.apple.com/documentation/os/oslogprivacy) does what we want already, masking sensitive values in release builds. It will only censor values when running on hardware and not connected to a debugging session. 

Additionally, anything which interpolates a _string_ or _object_ will be treated as `OSLogPrivacy.private`, logs containing static text and interpolating _numbers_ are treated as public. See https://developer.apple.com/documentation/os/logging/generating_log_messages_from_your_code#3665948

> The unified logging system uses privacy options to hide or show interpolated variables in a message. By default, the system doesn’t redact integer, floating-point and Boolean values, but it does redact the contents of dynamic strings and complex dynamic objects. To make a private value public again, configure the privacy of the variable using appropriate modifiers in your message string or interpolated variable. For example, the following code shows how to make a dynamic string visible again using the public modifier:

_This means that, even before this PR, almost all of our interpolations & logs will automatically be classed as `private`._ 

**We'd have to _opt-in_ to making these values public in our logs and, since Sentry reads from the os logs it follows the same rules.**

![image](https://github.com/subconsciousnetwork/subconscious/assets/5009316/4437573d-431f-4d42-9523-6aac32aa51b4)

# Changes

`logger.log(level:message:metadata)` now explicitly formats its log message to make the `message` public and the payload private, without this change we would see `"<private> <mask.hash 12321>"` but with it we see `"My message here <mask.hash 12321>"`

I would be nice to configure privacy for each value in the metadata dictionary but I've burned _way_ too much time on that. I don't think it's possible without exploding each KV pair out on to its own log line. Why? You can only specify privacy in an `OSLogMessage` and `OSLogMessage` can _only_ be constructed by passing a statically typed string interpolation to a logger (which we can't do because the metadata dictionary is of course dynamic). **You cannot compose these `OSLogMessage` at all or combine them with standard string interpolation and make use of the privacy system.**

# TL;DR

The app will do the right thing (block PII from Sentry logs) in production as-is, this PR slightly improves readability.