### PR TITLE
Fix loadEntries so sphere is only opened once

### DIFF
--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -214,13 +214,13 @@ actor UserProfileService {
         address: Slashlink,
         slugs: [Slug]
     ) async throws -> [EntryStub] {
+        let sphere = try await self.noosphere.sphere(address: address)
         var entries: [EntryStub] = []
         for slug in slugs {
             guard !slug.isHidden else {
                 continue
             }
             
-            let sphere = try await self.noosphere.sphere(address: address)
             let slashlink = Slashlink(slug: slug)
             let memo = try await sphere.read(slashlink: slashlink)
             


### PR DESCRIPTION
`UserProfileService.loadEntries` was previously opening a sphere for the address on every turn of the for loop.

This PR fixes the logic so the sphere is only opened once, at beginning of function call.