### PR TITLE
Extract DetailStackView

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppTabView.swift
+++ b/xcode/Subconscious/Shared/Components/AppTabView.swift
@@ -15,13 +15,6 @@ struct AppTabView: View {
 
     var body: some View {
         TabView {
-            VStack {
-                Text("To come")
-            }
-            .tabItem {
-                Label("Profile", systemImage: "person.crop.circle")
-            }
-            
             FeedView(parent: store)
                 .tabItem {
                     Label("Feed", systemImage: "newspaper")

--- a/xcode/Subconscious/Shared/Components/AppTabView.swift
+++ b/xcode/Subconscious/Shared/Components/AppTabView.swift
@@ -15,6 +15,13 @@ struct AppTabView: View {
 
     var body: some View {
         TabView {
+            VStack {
+                Text("To come")
+            }
+            .tabItem {
+                Label("Profile", systemImage: "person.crop.circle")
+            }
+            
             FeedView(parent: store)
                 .tabItem {
                     Label("Feed", systemImage: "newspaper")

--- a/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
@@ -1,0 +1,511 @@
+//
+//  DetailStack.swift
+//  Subconscious (iOS)
+//
+//  Created by Gordon Brander on 7/6/23.
+import SwiftUI
+import os
+import Combine
+import ObservableStore
+
+struct DetailStackView<Root: View>: View {
+    @ObservedObject var app: Store<AppModel>
+    var store: ViewStore<DetailStackModel>
+    var root: () -> Root
+
+    var body: some View {
+        NavigationStack(
+            path: Binding(
+                get: { store.state.details },
+                send: store.send,
+                tag: DetailStackAction.setDetails
+            )
+        ) {
+            root().navigationDestination(
+                for: MemoDetailDescription.self
+            ) { detail in
+                switch detail {
+                case .editor(let description):
+                    MemoEditorDetailView(
+                        description: description,
+                        notify: Address.forward(
+                            send: store.send,
+                            tag: DetailStackAction.tag
+                        )
+                    )
+                case .viewer(let description):
+                    MemoViewerDetailView(
+                        description: description,
+                        notify: Address.forward(
+                            send: store.send,
+                            tag: DetailStackAction.tag
+                        )
+                    )
+                case .profile(let description):
+                    UserProfileDetailView(
+                        app: app,
+                        description: description,
+                        notify: Address.forward(
+                            send: store.send,
+                            tag: DetailStackAction.tag
+                        )
+                    )
+                }
+            }
+        }
+    }
+}
+
+enum DetailStackAction: Hashable {
+    /// Set entire navigation stack
+    case setDetails([MemoDetailDescription])
+
+    /// Find a detail a given slashlink.
+    /// If slashlink has a peer part, this will request
+    /// a detail for 3p content.
+    /// If slashlink does not have a peer part, this will
+    /// request an editor detail.
+    case findAndPushDetail(
+        address: Slashlink,
+        link: SubSlashlinkLink
+    )
+
+    /// Find a detail for content that belongs to us.
+    /// Detail could exist in either local or sphere content.
+    case findAndPushMemoEditorDetail(
+        slug: Slug,
+        fallback: String
+    )
+
+    /// Push detail onto navigation stack
+    case pushDetail(MemoDetailDescription)
+
+    case requestOurProfileDetail
+    case pushOurProfileDetail(UserProfile)
+    case failPushDetail(_ message: String)
+
+    case pushRandomDetail(autofocus: Bool)
+    case failPushRandomDetail(String)
+
+    /// Request delete memo.
+    /// Gets forwarded up to parent for handling.
+    case requestDeleteMemo(Slashlink?)
+    /// Deletion attempt failed. Forwarded down from parent.
+    case failDeleteMemo(String)
+    /// Deletion attempt succeeded. Forwarded down from parent.
+    case succeedDeleteMemo(Slashlink)
+
+    case succeedMoveMemo(from: Slashlink, to: Slashlink)
+    case succeedMergeMemo(parent: Slashlink, child: Slashlink)
+    case succeedSaveMemo(address: Slashlink, modified: Date)
+    case succeedUpdateAudience(MoveReceipt)
+
+    /// Synonym for `.pushDetail` that wraps editor detail in `.editor()`
+    static func pushDetail(
+        _ detail: MemoEditorDetailDescription
+    ) -> Self {
+        .pushDetail(.editor(detail))
+    }
+
+    /// Synonym for `.pushDetail` that wraps viewer detail in `.viewer()`
+    static func pushDetail(
+        _ detail: MemoViewerDetailDescription
+    ) -> Self {
+        .pushDetail(.viewer(detail))
+    }
+}
+
+struct DetailStackModel: Hashable, ModelProtocol {
+    typealias Action = DetailStackAction
+    typealias Environment = AppEnvironment
+
+    var details: [MemoDetailDescription] = []
+
+    // Logger for actions
+    static let logger = Logger(
+        subsystem: Config.default.rdns,
+        category: "DetailStackModel"
+    )
+
+    static func update(
+        state: Self,
+        action: Action,
+        environment: Environment
+    ) -> Update<DetailStackModel> {
+        switch action {
+        case let .setDetails(details):
+            return setDetails(
+                state: state,
+                environment: environment,
+                details: details
+            )
+        case let .findAndPushDetail(address, link):
+            return findAndPushDetail(
+                state: state,
+                environment: environment,
+                address: address,
+                link: link
+            )
+        case let .findAndPushMemoEditorDetail(slug, fallback):
+            return findAndPushMemoEditorDetail(
+                state: state,
+                environment: environment,
+                slug: slug,
+                fallback: fallback
+            )
+        case let .pushDetail(detail):
+            return pushDetail(
+                state: state,
+                environment: environment,
+                detail: detail
+            )
+        case let .failPushDetail(error):
+            return failPushDetail(
+                state: state,
+                environment: environment,
+                error: error
+            )
+        case let .pushRandomDetail(autofocus):
+            return pushRandomDetail(
+                state: state,
+                environment: environment,
+                autofocus: autofocus
+            )
+        case let .failPushRandomDetail(error):
+            return failPushRandomDetail(
+                state: state,
+                environment: environment,
+                error: error
+            )
+        case .requestOurProfileDetail:
+            return requestOurProfileDetail(
+                state: state,
+                environment: environment
+            )
+        case .pushOurProfileDetail(let user):
+            return pushOurProfileDetail(
+                state: state,
+                environment: environment,
+                user: user
+            )
+        case let .requestDeleteMemo(address):
+            return requestDeleteMemo(
+                state: state,
+                environment: environment,
+                address: address
+            )
+        case let .succeedDeleteMemo(address):
+            return succeedDeleteMemo(
+                state: state,
+                environment: environment,
+                address: address
+            )
+        case let .failDeleteMemo(error):
+            return failDeleteMemo(
+                state: state,
+                environment: environment,
+                error: error
+            )
+        case .succeedMoveMemo:
+            return Update(state: state)
+        case .succeedMergeMemo:
+            return Update(state: state)
+        case .succeedSaveMemo:
+            return Update(state: state)
+        case .succeedUpdateAudience:
+            return Update(state: state)
+        }
+    }
+
+    static func setDetails(
+        state: Self,
+        environment: Environment,
+        details: [MemoDetailDescription]
+    ) -> Update<Self> {
+        guard state.details != details else {
+            return Update(state: state)
+        }
+        var model = state
+        model.details = details
+        return Update(state: model)
+    }
+
+    static func findAndPushDetail(
+        state: Self,
+        environment: Environment,
+        address: Slashlink,
+        link: SubSlashlinkLink
+    ) -> Update<Self> {
+        // Stitch the base address on to the tapped link, making any
+        // bare slashlinks relative to the sphere they belong to.
+        //
+        // This is needed in the viewer but address will always based
+        // on our sphere in the editor case.
+        let slashlink: Slashlink = Func.run {
+            guard case let .petname(basePetname) = address.peer else {
+                return link.slashlink
+            }
+            return link.slashlink.rebaseIfNeeded(petname: basePetname)
+        }
+
+        // Intercept profile visits and use the correct view
+        guard !slashlink.slug.isProfile else {
+            return update(
+                state: state,
+                action: .pushDetail(
+                    .profile(
+                        UserProfileDetailDescription(
+                            address: slashlink
+                        )
+                    )
+                ),
+                environment: environment
+            )
+        }
+
+        // If slashlink pointing to our sphere, dispatch findAndPushEditDetail
+        // to find in local or sphere content and then push editor detail.
+        guard slashlink.peer != nil else {
+            return update(
+                state: state,
+                action: .findAndPushMemoEditorDetail(
+                    slug: slashlink.toSlug(),
+                    fallback: link.fallback
+                ),
+                environment: environment
+            )
+        }
+
+        // If slashlink pointing to other sphere, dispatch action
+        // for viewer.
+        return update(
+            state: state,
+            action: .pushDetail(
+                .viewer(
+                    MemoViewerDetailDescription(
+                        address: slashlink
+                    )
+                )
+            ),
+            environment: environment
+        )
+    }
+
+    /// Find and push a specific detail for slug
+    static func findAndPushMemoEditorDetail(
+        state: Self,
+        environment: Environment,
+        slug: Slug,
+        fallback: String
+    ) -> Update<Self> {
+        let fallbackAddress = slug.toLocalSlashlink()
+        let fx: Fx<Action> = environment.data
+            .findAddressInOursPublisher(slug: slug)
+            .map({ address in
+                Action.pushDetail(
+                    MemoEditorDetailDescription(
+                        address: address ?? fallbackAddress,
+                        fallback: fallback
+                    )
+                )
+            })
+            .eraseToAnyPublisher()
+        return Update(state: state, fx: fx)
+    }
+
+    /// Push a detail view onto the stack
+    static func pushDetail(
+        state: Self,
+        environment: Environment,
+        detail: MemoDetailDescription
+    ) -> Update<Self> {
+        var model = state
+        model.details.append(detail)
+        return Update(state: model)
+    }
+
+
+    /// Push a detail view onto the stack
+    static func failPushDetail(
+        state: Self,
+        environment: Environment,
+        error: String
+    ) -> Update<Self> {
+        logger.log("Attempt to push invalid detail: \(error)")
+        return Update(state: state)
+    }
+
+    /// Request detail for a random entry
+    static func pushRandomDetail(
+        state: Self,
+        environment: Environment,
+        autofocus: Bool
+    ) -> Update<Self> {
+        let fx: Fx<Action> = environment.data
+            .readRandomEntryLinkPublisher().map({ link in
+                Action.pushDetail(
+                    MemoEditorDetailDescription(
+                        address: link.address,
+                        fallback: link.title
+                    )
+                )
+            }).catch({ error in
+                Just(
+                    Action.failPushRandomDetail(
+                        error.localizedDescription
+                    )
+                )
+            }).eraseToAnyPublisher()
+
+        return Update(state: state, fx: fx)
+    }
+
+    static func failPushRandomDetail(
+        state: Self,
+        environment: Environment,
+        error: String
+    ) -> Update<Self> {
+        logger.log("Failed to get random note: \(error)")
+        return Update(state: state)
+    }
+
+    static func requestOurProfileDetail(
+        state: Self,
+        environment: Environment
+    ) -> Update<Self> {
+        let fx: Fx<Action> = environment.userProfile
+            .loadOurProfileFromMemoPublisher()
+            .map { user in
+                Action.pushOurProfileDetail(user)
+            }
+            .recover { error in
+                Action.failPushDetail(error.localizedDescription)
+            }
+            .eraseToAnyPublisher()
+
+        return Update(state: state, fx: fx)
+    }
+
+    static func pushOurProfileDetail(
+        state: Self,
+        environment: Environment,
+        user: UserProfile
+    ) -> Update<Self> {
+        let detail = UserProfileDetailDescription(
+            address: Slashlink.ourProfile,
+            user: user,
+            // Focus following list by default
+            // We can already see our recent notes in our notebook so no
+            // point showing it again
+            initialTabIndex: UserProfileDetailModel.followingTabIndex
+        )
+        return update(
+            state: state,
+            action: .pushDetail(.profile(detail)),
+            environment: environment
+        )
+    }
+
+    static func requestDeleteMemo(
+        state: Self,
+        environment: Environment,
+        address: Slashlink?
+    ) -> Update<Self> {
+        // No-op. Should be handled by parent.
+        return Update(state: state)
+    }
+
+    static func succeedDeleteMemo(
+        state: Self,
+        environment: Environment,
+        address: Slashlink
+    ) -> Update<Self> {
+        logger.debug(
+            "Removing deleted memo from detail stack",
+            metadata: [
+                "address": address.description
+            ]
+        )
+        var model = state
+        let details = state.details.filter({ detail in
+            detail.address != address
+        })
+        model.details = details
+        return Update(state: model)
+    }
+
+    static func failDeleteMemo(
+        state: Self,
+        environment: Environment,
+        error: String
+    ) -> Update<Self> {
+        return Update(state: state)
+    }
+}
+
+extension DetailStackAction {
+    static func tag(_ action: MemoEditorDetailNotification) -> Self {
+        switch action {
+        case .requestDelete(let address):
+            return .requestDeleteMemo(address)
+        case let .requestDetail(detail):
+            return .pushDetail(detail)
+        case let .requestFindLinkDetail(link):
+            return .findAndPushDetail(
+                address: Slashlink.ourProfile,
+                link: link
+            )
+        case let .succeedMoveEntry(from, to):
+            return .succeedMoveMemo(from: from, to: to)
+        case let .succeedMergeEntry(parent, child):
+            return .succeedMergeMemo(parent: parent, child: child)
+        case let .succeedSaveEntry(address, modified):
+            return .succeedSaveMemo(address: address, modified: modified)
+        case let .succeedUpdateAudience(receipt):
+            return .succeedUpdateAudience(receipt)
+        }
+    }
+
+    static func tag(_ action: MemoViewerDetailNotification) -> Self {
+        switch action {
+        case let .requestDetail(detail):
+            return .pushDetail(detail)
+        case let .requestFindLinkDetail(address, link):
+            return .findAndPushDetail(
+                address: address,
+                link: link
+            )
+        }
+    }
+
+    static func tag(_ action: UserProfileDetailNotification) -> Self {
+        switch action {
+        case let .requestDetail(detail):
+            return .pushDetail(detail)
+        case let .requestNavigateToProfile(user):
+            let user = Func.run {
+                switch (user.category, user.ourFollowStatus) {
+                case (.ourself, _):
+                    // Loop back to our profile
+                    return user.overrideAddress(Slashlink.ourProfile)
+                case (_, .following(let name)):
+                    // Rewrite address using our name
+                    return user.overrideAddress(Slashlink(petname: name.toPetname()))
+                case _:
+                    return user
+                }
+            }
+
+
+            guard user.resolutionStatus.isReady else {
+                return .failPushDetail("Attempted to navigate to unresolved user")
+            }
+            return .pushDetail(.profile(
+                UserProfileDetailDescription(
+                    address: user.address,
+                    user: user
+                )
+            ))
+        }
+    }
+}

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -612,7 +612,7 @@ struct MemoEditorDetailModel: ModelProtocol {
     
     static let logger = Logger(
         subsystem: Config.default.rdns,
-        category: "detail"
+        category: "MemoEditorDetail"
     )
     
     //  MARK: Update

--- a/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
@@ -14,8 +14,7 @@ struct NotebookNavigationView: View {
     var body: some View {
         DetailStackView(
             app: app,
-            store: ViewStore(
-                store: store,
+            store: store.viewStore(
                 get: NotebookDetailStackCursor.get,
                 tag: NotebookDetailStackCursor.tag
             )

--- a/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
@@ -12,11 +12,12 @@ struct NotebookNavigationView: View {
     @ObservedObject var store: Store<NotebookModel>
 
     var body: some View {
-        NavigationStack(
-            path: Binding(
-                get: { store.state.details },
-                send: store.send,
-                tag: NotebookAction.setDetails
+        DetailStackView(
+            app: app,
+            store: ViewStore(
+                store: store,
+                get: NotebookDetailStackCursor.get,
+                tag: NotebookDetailStackCursor.tag
             )
         ) {
             VStack(spacing: 0) {
@@ -60,37 +61,6 @@ struct NotebookNavigationView: View {
                     }
                 }
             }
-            .navigationDestination(
-                for: MemoDetailDescription.self
-            ) { detail in
-                switch detail {
-                case .editor(let description):
-                    MemoEditorDetailView(
-                        description: description,
-                        notify: Address.forward(
-                            send: store.send,
-                            tag: NotebookAction.tag
-                        )
-                    )
-                case .viewer(let description):
-                    MemoViewerDetailView(
-                        description: description,
-                        notify: Address.forward(
-                            send: store.send,
-                            tag: NotebookAction.tag
-                        )
-                    )
-                case .profile(let description):
-                    UserProfileDetailView(
-                        app: app,
-                        description: description,
-                        notify: Address.forward(
-                            send: store.send,
-                            tag: NotebookAction.tag
-                        )
-                    )
-                }
-            }
             .navigationTitle("Notes")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -112,7 +82,7 @@ struct NotebookNavigationView: View {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button(
                         action: {
-                            store.send(.requestOurProfileDetail)
+                            store.send(.detailStack(.requestOurProfileDetail))
                         }
                     ) {
                         Image(systemName: "person")

--- a/xcode/Subconscious/Shared/Models/StoryUser.swift
+++ b/xcode/Subconscious/Shared/Models/StoryUser.swift
@@ -24,7 +24,7 @@ struct StoryUser:
         \(String(describing: user.nickname))
         Following? \(user.isFollowedByUs)
         
-        \(user.bio)
+        \(user.bio?.text ?? "")
         """
     }
 }

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -252,7 +252,7 @@ actor DataService {
                     //
                     // If this peer is not been indexed before, write it to DB
                     // with nil version, since we have never yet indexed it.
-                    if var existingPeer = try database.readPeer(
+                    if let existingPeer = try database.readPeer(
                         petname: peer.petname
                     ) {
                         let updatedPeer = existingPeer.update(
@@ -310,7 +310,6 @@ actor DataService {
             // Then index memo changes from our sphere.
             let memoChanges = try await sphere.changes(since: since)
             for change in memoChanges {
-                let link = Link(did: identity, slug: change)
                 let slashlink = Slashlink(slug: change)
                 // If memo does exist, write it to database.
                 // If memo does not exist, that means change was a remove.

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		B59D556329BBFF56007915E2 /* FormField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59D556229BBFF56007915E2 /* FormField.swift */; };
 		B5A7AD322A0D0B0E007C3535 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A7AD312A0D0B0E007C3535 /* EmptyStateView.swift */; };
 		B5A7AD332A0D0B0E007C3535 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A7AD312A0D0B0E007C3535 /* EmptyStateView.swift */; };
+		B5AD5C8E2AA6C37900FC5BC5 /* DetailStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AD5C8D2AA6C37900FC5BC5 /* DetailStackView.swift */; };
 		B5BBA7352A89E20300864220 /* UserProfileSheets.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BBA7342A89E20300864220 /* UserProfileSheets.swift */; };
 		B5BBA7362A89E20300864220 /* UserProfileSheets.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BBA7342A89E20300864220 /* UserProfileSheets.swift */; };
 		B5C918EE2A67A16A004C6CD5 /* AuthorizationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C918ED2A67A16A004C6CD5 /* AuthorizationSettingsView.swift */; };
@@ -512,6 +513,7 @@
 		B5908BEA29DAB05B00225B1A /* TestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUtilities.swift; sourceTree = "<group>"; };
 		B59D556229BBFF56007915E2 /* FormField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormField.swift; sourceTree = "<group>"; };
 		B5A7AD312A0D0B0E007C3535 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
+		B5AD5C8D2AA6C37900FC5BC5 /* DetailStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailStackView.swift; sourceTree = "<group>"; };
 		B5BBA7342A89E20300864220 /* UserProfileSheets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileSheets.swift; sourceTree = "<group>"; };
 		B5C918ED2A67A16A004C6CD5 /* AuthorizationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationSettingsView.swift; sourceTree = "<group>"; };
 		B5C918EF2A67ADEF004C6CD5 /* SphereSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SphereSettingsView.swift; sourceTree = "<group>"; };
@@ -1018,6 +1020,7 @@
 				B8DEBF242798EF6A007CB528 /* RenameSearchView.swift */,
 				B58A46B929D4004B00491E43 /* UserProfileDetailMetaSheet.swift */,
 				B57C0AF429D2865600D352E3 /* UserProfileDetailView.swift */,
+				B5AD5C8D2AA6C37900FC5BC5 /* DetailStackView.swift */,
 			);
 			path = Detail;
 			sourceTree = "<group>";
@@ -1858,6 +1861,7 @@
 				B8249DA027E2668500BCDFBA /* PinTrailingBottom.swift in Sources */,
 				B58A46B129D3C6B300491E43 /* StoryEntry.swift in Sources */,
 				B59D556329BBFF56007915E2 /* FormField.swift in Sources */,
+				B5AD5C8E2AA6C37900FC5BC5 /* DetailStackView.swift in Sources */,
 				B81A535C27275138001A6268 /* Tape.swift in Sources */,
 				B8B3EE7B297AFB9100779B7F /* TextFieldLabel.swift in Sources */,
 				B8B3194D2909E81D00A1E62A /* FileInfo.swift in Sources */,

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		B5A7AD322A0D0B0E007C3535 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A7AD312A0D0B0E007C3535 /* EmptyStateView.swift */; };
 		B5A7AD332A0D0B0E007C3535 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A7AD312A0D0B0E007C3535 /* EmptyStateView.swift */; };
 		B5AD5C8E2AA6C37900FC5BC5 /* DetailStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AD5C8D2AA6C37900FC5BC5 /* DetailStackView.swift */; };
+		B5AD5C902AA7FF1900FC5BC5 /* Tests_DetailStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AD5C8F2AA7FF1900FC5BC5 /* Tests_DetailStack.swift */; };
 		B5BBA7352A89E20300864220 /* UserProfileSheets.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BBA7342A89E20300864220 /* UserProfileSheets.swift */; };
 		B5BBA7362A89E20300864220 /* UserProfileSheets.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BBA7342A89E20300864220 /* UserProfileSheets.swift */; };
 		B5C918EE2A67A16A004C6CD5 /* AuthorizationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C918ED2A67A16A004C6CD5 /* AuthorizationSettingsView.swift */; };
@@ -514,6 +515,7 @@
 		B59D556229BBFF56007915E2 /* FormField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormField.swift; sourceTree = "<group>"; };
 		B5A7AD312A0D0B0E007C3535 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		B5AD5C8D2AA6C37900FC5BC5 /* DetailStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailStackView.swift; sourceTree = "<group>"; };
+		B5AD5C8F2AA7FF1900FC5BC5 /* Tests_DetailStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_DetailStack.swift; sourceTree = "<group>"; };
 		B5BBA7342A89E20300864220 /* UserProfileSheets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileSheets.swift; sourceTree = "<group>"; };
 		B5C918ED2A67A16A004C6CD5 /* AuthorizationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationSettingsView.swift; sourceTree = "<group>"; };
 		B5C918EF2A67ADEF004C6CD5 /* SphereSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SphereSettingsView.swift; sourceTree = "<group>"; };
@@ -935,6 +937,7 @@
 				B56C2D4D2A4962D00062DAC0 /* Tests_TranscludeService.swift */,
 				B509612F2A4CEFCF008E9EDB /* Tests_FirstRun.swift */,
 				B5604DAD2A6A263E004C9590 /* Tests_Config.swift */,
+				B5AD5C8F2AA7FF1900FC5BC5 /* Tests_DetailStack.swift */,
 			);
 			path = SubconsciousTests;
 			sourceTree = "<group>";
@@ -1683,6 +1686,7 @@
 				B5E60C8D2A146838007065A1 /* Tests_UserProfileBio.swift in Sources */,
 				B8AAAADB28CBDED800DBC8A9 /* Tests_Search.swift in Sources */,
 				B809AFF428D8E7BC00D0589A /* Tests_MarkupText.swift in Sources */,
+				B5AD5C902AA7FF1900FC5BC5 /* Tests_DetailStack.swift in Sources */,
 				B88A76D729E0AA44005F3422 /* Tests_MemoViewerDetailMetaSheet.swift in Sources */,
 				B85DF78F29B7B5440042D725 /* Tests_Prose.swift in Sources */,
 				B85D5E3D28BE4B2C00EE0078 /* Tests_NotebookUpdate.swift in Sources */,

--- a/xcode/Subconscious/SubconsciousTests/Tests_DetailStack.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DetailStack.swift
@@ -1,0 +1,69 @@
+//
+//  Tests_DetailStack.swift
+//  SubconsciousTests
+//
+//  Created by Ben Follington on 6/9/2023.
+//
+
+import XCTest
+import ObservableStore
+@testable import Subconscious
+
+class Tests_DetailStack: XCTestCase {
+    let environment = AppEnvironment()
+
+    func testViewerSlashlinkConstruction() throws {
+        let model = DetailStackModel()
+        
+        let slashlink = Slashlink(petname: Petname("bob.alice")!, slug: Slug("hello")!)
+        let link = SubSlashlinkLink(slashlink: slashlink)
+        
+        let action = MemoViewerDetailNotification.requestFindLinkDetail(
+            address: Slashlink(petname: Petname("origin")!),
+            link: link
+        )
+        
+        let newAction = DetailStackAction.tag(action)
+        let update = DetailStackModel.update(
+            state: model,
+            action: newAction,
+            environment: environment
+        )
+        
+        if let detail = update.state.details.first?.address,
+           let petname = detail.petname {
+            XCTAssertEqual(petname, Petname("bob.alice.origin")!)
+            XCTAssertEqual(detail.slug, Slug("hello")!)
+        } else {
+            XCTFail("No detail")
+            return
+        }
+    }
+
+    func testEditorSlashlinkConstruction() throws {
+        let model = DetailStackModel()
+        
+        let slashlink = Slashlink(petname: Petname("bob.alice")!, slug: Slug("hello")!)
+        let link = SubSlashlinkLink(slashlink: slashlink)
+        
+        let action = MemoEditorDetailNotification.requestFindLinkDetail(
+            link: link
+        )
+        
+        let newAction = DetailStackAction.tag(action)
+        let update = DetailStackModel.update(
+            state: model,
+            action: newAction,
+            environment: environment
+        )
+        
+        if let detail = update.state.details.first?.address,
+           let petname = detail.petname {
+            XCTAssertEqual(petname, Petname("bob.alice")!)
+            XCTAssertEqual(detail.slug, Slug("hello")!)
+        } else {
+            XCTFail("No detail")
+            return
+        }
+    }
+}

--- a/xcode/Subconscious/SubconsciousTests/Tests_NotebookUpdate.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_NotebookUpdate.swift
@@ -75,58 +75,5 @@ class Tests_NotebookUpdate: XCTestCase {
         )
     }
     
-    func testViewerSlashlinkConstruction() throws {
-        let model = DetailStackModel()
-        
-        let slashlink = Slashlink(petname: Petname("bob.alice")!, slug: Slug("hello")!)
-        let link = SubSlashlinkLink(slashlink: slashlink)
-        
-        let action = MemoViewerDetailNotification.requestFindLinkDetail(
-            address: Slashlink(petname: Petname("origin")!),
-            link: link
-        )
-        
-        let newAction = DetailStackAction.tag(action)
-        let update = DetailStackModel.update(
-            state: model,
-            action: newAction,
-            environment: environment
-        )
-        
-        if let detail = update.state.details.first?.address,
-           let petname = detail.petname {
-            XCTAssertEqual(petname, Petname("bob.alice.origin")!)
-            XCTAssertEqual(detail.slug, Slug("hello")!)
-        } else {
-            XCTFail("No detail")
-            return
-        }
-    }
     
-    func testEditorSlashlinkConstruction() throws {
-        let model = DetailStackModel()
-        
-        let slashlink = Slashlink(petname: Petname("bob.alice")!, slug: Slug("hello")!)
-        let link = SubSlashlinkLink(slashlink: slashlink)
-        
-        let action = MemoEditorDetailNotification.requestFindLinkDetail(
-            link: link
-        )
-        
-        let newAction = DetailStackAction.tag(action)
-        let update = DetailStackModel.update(
-            state: model,
-            action: newAction,
-            environment: environment
-        )
-        
-        if let detail = update.state.details.first?.address,
-           let petname = detail.petname {
-            XCTAssertEqual(petname, Petname("bob.alice")!)
-            XCTAssertEqual(detail.slug, Slug("hello")!)
-        } else {
-            XCTFail("No detail")
-            return
-        }
-    }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_NotebookUpdate.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_NotebookUpdate.swift
@@ -76,7 +76,7 @@ class Tests_NotebookUpdate: XCTestCase {
     }
     
     func testViewerSlashlinkConstruction() throws {
-        let model = NotebookModel()
+        let model = DetailStackModel()
         
         let slashlink = Slashlink(petname: Petname("bob.alice")!, slug: Slug("hello")!)
         let link = SubSlashlinkLink(slashlink: slashlink)
@@ -86,8 +86,8 @@ class Tests_NotebookUpdate: XCTestCase {
             link: link
         )
         
-        let newAction = NotebookAction.tag(action)
-        let update = NotebookModel.update(
+        let newAction = DetailStackAction.tag(action)
+        let update = DetailStackModel.update(
             state: model,
             action: newAction,
             environment: environment
@@ -104,7 +104,7 @@ class Tests_NotebookUpdate: XCTestCase {
     }
     
     func testEditorSlashlinkConstruction() throws {
-        let model = NotebookModel()
+        let model = DetailStackModel()
         
         let slashlink = Slashlink(petname: Petname("bob.alice")!, slug: Slug("hello")!)
         let link = SubSlashlinkLink(slashlink: slashlink)
@@ -113,8 +113,8 @@ class Tests_NotebookUpdate: XCTestCase {
             link: link
         )
         
-        let newAction = NotebookAction.tag(action)
-        let update = NotebookModel.update(
+        let newAction = DetailStackAction.tag(action)
+        let update = DetailStackModel.update(
             state: model,
             action: newAction,
             environment: environment


### PR DESCRIPTION
Porting the work from https://github.com/subconsciousnetwork/subconscious/pull/784, moving towards https://github.com/subconsciousnetwork/subconscious/issues/641 and https://github.com/subconsciousnetwork/subconscious/issues/322.

This PR extracts the `NavigationStack` logic from `NotebookNavigationView` and shifts it to the re-usable component `DetailStackView`. This is a drop-in replacement in terms of the user experience, a stepping stone towards introducing the profile and feed as app tabs (next PRs).

I also snuck a couple fixes to warnings in, sorry if the diff is slightly more confusing as a result.
