### PR TITLE
Silly pathological testcase

### DIFF
--- a/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
@@ -31,6 +31,12 @@ extension UserProfileBio: DummyData {
     }
 }
 
+extension Slug: DummyData {
+    static func dummyData() -> Slug {
+        Slug(String.dummyDataShort())!
+    }
+}
+
 extension Petname.Name: DummyData {
     static func dummyData() -> Petname.Name {
         let options = [


### PR DESCRIPTION
Trying to trigger a bug by suddenly disposing / cancelling tasks. This works with RocksDB but fails with sled (but only sometimes 🫠)

<img width="520" alt="image" src="https://github.com/subconsciousnetwork/subconscious/assets/5009316/15e93e52-37b6-48b9-a009-6001b8033e9d">

```
#3	0x000000010200e6dc in std::sys::unix::abort_internal::h495f9260a1ec85c6 at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/std/src/sys/unix/mod.rs:259
#4	0x00000001020985f8 in std::process::abort::h20c94791ba86606f at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/std/src/process.rs:1980
#5	0x0000000102000ee8 in rust_oom at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/std/src/alloc.rs:330
#6	0x000000010203f048 in __rg_oom at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/alloc/src/alloc.rs:413
#7	0x000000010203efec in alloc::alloc::handle_alloc_error::rt_error::h74196119d0b57c59 at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/alloc/src/alloc.rs:379
#8	0x000000010203ee1c in core::ops::function::FnOnce::call_once::h273d817d05041461 at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/core/src/ops/function.rs:227
#9	0x000000010203f490 in core::intrinsics::const_eval_select::hc5d680dea28aaeac at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/core/src/intrinsics.rs:2345
#10	0x000000010209a054 in alloc::alloc::handle_alloc_error::h0626df85124703e1 at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/alloc/src/alloc.rs:383
#11	0x0000000102098210 in alloc::raw_vec::handle_reserve::h747529c07c143c70 [inlined] at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/alloc/src/raw_vec.rs:490
#12	0x000000010209820c in alloc::raw_vec::RawVec$LT$T$C$A$GT$::reserve::do_reserve_and_handle::h6b3f30f5abb92bc5 at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/alloc/src/raw_vec.rs:287
#13	0x0000000102001bf4 in alloc::raw_vec::RawVec$LT$T$C$A$GT$::reserve::hb7b39e40880e100b [inlined] at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/alloc/src/raw_vec.rs:291
#14	0x0000000102001be4 in alloc::vec::Vec$LT$T$C$A$GT$::reserve::hba0c2ba476b53e97 [inlined] at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/alloc/src/vec/mod.rs:809
#15	0x0000000102001be4 in alloc::vec::Vec$LT$T$C$A$GT$::append_elements::h7140cad422386473 [inlined] at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/alloc/src/vec/mod.rs:1788
#16	0x0000000102001be4 in _$LT$alloc..vec..Vec$LT$T$C$A$GT$$u20$as$u20$alloc..vec..spec_extend..SpecExtend$LT$$RF$T$C$core..slice..iter..Iter$LT$T$GT$$GT$$GT$::spec_extend::he6a507988f54bf9f [inlined] at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/alloc/src/vec/spec_extend.rs:85
#17	0x0000000102001be4 in alloc::vec::Vec$LT$T$C$A$GT$::extend_from_slice::h44c6975b35876da9 [inlined] at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/alloc/src/vec/mod.rs:2223
#18	0x0000000102001be4 in alloc::string::String::push_str::h5c804d06fdd97c6c [inlined] at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/alloc/src/string.rs:850
#19	0x0000000102001be4 in _$LT$alloc..string..String$u20$as$u20$core..fmt..Write$GT$::write_str::h2b0f4020daebc2ea [inlined] at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/alloc/src/string.rs:2727
#20	0x0000000102001be4 in _$LT$$RF$mut$u20$W$u20$as$u20$core..fmt..Write$GT$::write_str::h9ef7ac556250aef5 at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/core/src/fmt/mod.rs:193
#21	0x000000010204af08 in core::fmt::write::h3cb3cfeb281ab967 at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/core/src/fmt/mod.rs:1180
#22	0x00000001020031cc in core::fmt::Write::write_fmt::hd392b28e5c368b21 [inlined] at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/core/src/fmt/mod.rs:186
#23	0x00000001020031a8 in std::panicking::begin_panic_handler::PanicPayload::fill::_$u7b$$u7b$closure$u7d$$u7d$::h4f19bd8b12ff71e2 [inlined] at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/std/src/panicking.rs:464
#24	0x0000000102003190 in core::option::Option$LT$T$GT$::get_or_insert_with::h28cd9d6e43968f4a [inlined] at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/core/src/option.rs:1487
#25	0x0000000102003190 in std::panicking::begin_panic_handler::PanicPayload::fill::hbf76371cca5579f9 [inlined] at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/std/src/panicking.rs:462
#26	0x0000000102003180 in _$LT$std..panicking..begin_panic_handler..PanicPayload$u20$as$u20$core..panic..BoxMeUp$GT$::get::hc9809c45abb560f4 at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/std/src/panicking.rs:480
#27	0x000000010200356c in std::panicking::rust_panic_with_hook::h3e435cdc945ce12a at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/std/src/panicking.rs:605
#28	0x0000000102003304 in std::panicking::begin_panic_handler::_$u7b$$u7b$closure$u7d$$u7d$::hd43c8c7186fefa14 at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/std/src/panicking.rs:502
#29	0x0000000101fff598 in std::sys_common::backtrace::__rust_end_short_backtrace::ha65c2bd0f7c8192d at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/std/src/sys_common/backtrace.rs:139
#30	0x000000010200306c in rust_begin_unwind at /rustc/9d1b2106e23b1abd32fce1f17267604a5102f57a/library/std/src/panicking.rs:498
#31	0x00000001020835c8 in core::panicking::panic_fmt::h03d6efa2083af68e at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/core/src/panicking.rs:67
#32	0x0000000101c5b01c in _$LT$sled..pagecache..snapshot..PageState$u20$as$u20$sled..serialization..Serialize$GT$::serialized_size::hb22544ea3549438c ()
#33	0x0000000101c43b24 in _$LT$core..iter..adapters..map..Map$LT$I$C$F$GT$$u20$as$u20$core..iter..traits..iterator..Iterator$GT$::fold::he308ebfc960fe425 ()
#34	0x0000000101c5ae10 in _$LT$sled..pagecache..snapshot..Snapshot$u20$as$u20$sled..serialization..Serialize$GT$::serialized_size::hb7533ddd625a2ab0 ()
#35	0x0000000101c5ada0 in sled::serialization::Serialize::serialize::hd8f15300b64c0a38 ()
#36	0x0000000101c5a0ec in sled::pagecache::snapshot::read_snapshot_or_default::h423b6365117c3a9d ()
#37	0x0000000101c51910 in sled::pagecache::PageCache::start::h1e39f728533a97da ()
#38	0x0000000101c45a78 in sled::context::Context::start::h53a4ff5e4e2357da ()
#39	0x0000000101c2b168 in sled::db::Db::start_inner::hd6c2f6d3cf40c715 ()
#40	0x0000000101c3f738 in sled::config::Config::open::h8c94ff22c9688c1b ()
#41	0x0000000101bbc140 in sled::db::open::hda54d41bb2ed1fe8 ()
#42	0x0000000101bbe838 in noosphere_storage::implementation::native::NativeStorage::new::h08881b28058378e6 ()
#43	0x000000010188f308 in noosphere::sphere::builder::generate_db::_$u7b$$u7b$closure$u7d$$u7d$::he4fc8507d9464ef1 ()
#44	0x000000010188ceb0 in noosphere::sphere::builder::SphereContextBuilder::build::_$u7b$$u7b$closure$u7d$$u7d$::h9a8de33dbd9a0352 ()
#45	0x000000010188bff0 in noosphere::noosphere::NoosphereContext::get_sphere_channel::_$u7b$$u7b$closure$u7d$$u7d$::h39c5fee723bc3629 ()
#46	0x000000010188aac8 in tokio::runtime::park::CachedParkThread::block_on::hd7bf00999fcdd0ce ()
#47	0x0000000101823fd0 in tokio::runtime::context::blocking::BlockingRegionGuard::block_on::h6ce32a766bcd5d23 ()
#48	0x0000000101773928 in tokio::runtime::context::runtime::enter_runtime::h4d663e6fbbf82389 ()
#49	0x000000010183c8d0 in tokio::runtime::scheduler::multi_thread::MultiThread::block_on::h30e190f26daaa331 ()
#50	0x0000000101824db8 in tokio::runtime::runtime::Runtime::block_on::hbf26acd9a51e075c ()
#51	0x000000010177d49c in noosphere::ffi::error::TryOrInitialize::try_or_initialize::hde4dd8f096598349 ()
#52	0x00000001018e807c in noosphere::ffi::context::ns_sphere_open::h64aabafe34566106 ()
#53	0x00000001018e80ac in ns_sphere_open ()
#54	0x000000010103ae5c in @nonobjc ns_sphere_open(_:_:_:) ()
#55	0x000000010103ae78 in thunk for @escaping @callee_guaranteed (@unowned OpaquePointer?, @unowned UnsafePointer<Int8>?, @unowned UnsafeMutablePointer<OpaquePointer?>?) -> (@unowned OpaquePointer?) ()
#56	0x000000010103aeb4 in thunk for @callee_guaranteed (@unowned OpaquePointer?, @unowned UnsafePointer<Int8>?, @unowned UnsafeMutablePointer<OpaquePointer?>) -> (@unowned OpaquePointer?) ()
#57	0x0000000101358fec in closure #1 in static Noosphere.callWithError<τ_0_0, τ_0_1, τ_0_2>(_:_:_:) at /Users/ben/code/subconscious/xcode/Subconscious/Shared/Services/Noosphere/Noosphere.swift:284
#58	0x0000000101358c7c in static Noosphere.callWithError<τ_0_0>(_:) at /Users/ben/code/subconscious/xcode/Subconscious/Shared/Services/Noosphere/Noosphere.swift:253
#59	0x0000000101357e8c in static Noosphere.callWithError<τ_0_0, τ_0_1, τ_0_2>(_:_:_:) at /Users/ben/code/subconscious/xcode/Subconscious/Shared/Services/Noosphere/Noosphere.swift:284
#60	0x000000010103a4fc in Sphere.init(noosphere:identity:) at /Users/ben/code/subconscious/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift:260
#61	0x0000000101039f98 in Sphere.__allocating_init(noosphere:identity:) ()
#62	0x0000000101529454 in NoosphereService.sphere() at /Users/ben/code/subconscious/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift:165
#63	0x000000010152c8a0 in NoosphereService.list() at /Users/ben/code/subconscious/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift:324

```
