### PR TITLE
Replay notebook DetailStack actions on app root

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -259,10 +259,6 @@ enum AppAction: CustomLogStringConvertible {
     case failDeleteMemo(String)
     /// Deletion attempt succeeded
     case succeedDeleteMemo(Slashlink)
-    case succeedMoveMemo(from: Slashlink, to: Slashlink)
-    case succeedMergeMemo(parent: Slashlink, child: Slashlink)
-    case succeedSaveMemo(address: Slashlink, modified: Date)
-    case succeedUpdateAudience(MoveReceipt)
     
     case setSelectedAppTab(AppTab)
     case requestNotebookRoot
@@ -1028,14 +1024,6 @@ struct AppModel: ModelProtocol {
                 environment: environment,
                 enabled: enabled
             )
-        case .succeedMoveMemo:
-            return Update(state: state)
-        case .succeedUpdateAudience:
-            return Update(state: state)
-        case .succeedSaveMemo:
-            return Update(state: state)
-        case .succeedMergeMemo:
-            return Update(state: state)
         }
     }
     

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -259,6 +259,10 @@ enum AppAction: CustomLogStringConvertible {
     case failDeleteMemo(String)
     /// Deletion attempt succeeded
     case succeedDeleteMemo(Slashlink)
+    case succeedMoveMemo(from: Slashlink, to: Slashlink)
+    case succeedMergeMemo(parent: Slashlink, child: Slashlink)
+    case succeedSaveMemo(address: Slashlink, modified: Date)
+    case succeedUpdateAudience(MoveReceipt)
     
     case setSelectedAppTab(AppTab)
     case requestNotebookRoot
@@ -1024,6 +1028,14 @@ struct AppModel: ModelProtocol {
                 environment: environment,
                 enabled: enabled
             )
+        case .succeedMoveMemo:
+            return Update(state: state)
+        case .succeedUpdateAudience:
+            return Update(state: state)
+        case .succeedSaveMemo:
+            return Update(state: state)
+        case .succeedMergeMemo:
+            return Update(state: state)
         }
     }
     

--- a/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
@@ -244,6 +244,7 @@ struct DetailStackModel: Hashable, ModelProtocol {
                 environment: environment,
                 error: error
             )
+        // These act as notifications for parent models to react to
         case .succeedMoveMemo:
             return Update(state: state)
         case .succeedMergeMemo:

--- a/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
@@ -253,13 +253,6 @@ extension AppAction {
         switch action {
         case let .requestDeleteMemo(address):
             return .deleteMemo(address)
-        case let .detailStack(action):
-            switch (action) {
-            case .succeedDeleteMemo(let address):
-                return .succeedDeleteMemo(address)
-            case _:
-                return nil
-            }
         default:
             return nil
         }
@@ -566,8 +559,15 @@ struct NotebookModel: ModelProtocol {
         action: DetailStackAction
     ) -> Update<NotebookModel> {
         switch action {
-        case .succeedMergeMemo, .succeedUpdateAudience, .succeedMoveMemo, .succeedSaveMemo:
-            return update(state: state, action: .refreshLists, environment: environment)
+        case .succeedMergeMemo,
+                .succeedUpdateAudience,
+                .succeedMoveMemo,
+                .succeedSaveMemo:
+            return update(
+                state: state,
+                action: .refreshLists,
+                environment: environment
+            )
         case _:
             return NotebookDetailStackCursor.update(
                 state: state,

--- a/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
@@ -236,14 +236,6 @@ extension NotebookAction {
             return .ready
         case .succeedIndexOurSphere(_):
             return .refreshLists
-        case .succeedSaveMemo:
-            return .refreshLists
-        case .succeedUpdateAudience:
-            return .refreshLists
-        case .succeedMoveMemo:
-            return .refreshLists
-        case .succeedMergeMemo:
-            return .refreshLists
         case let .succeedDeleteMemo(address):
             return .succeedDeleteMemo(address)
         case let .failDeleteMemo(error):
@@ -265,12 +257,6 @@ extension AppAction {
             switch (action) {
             case .succeedDeleteMemo(let address):
                 return .succeedDeleteMemo(address)
-            case .succeedMoveMemo(let from, let to):
-                return .succeedMoveMemo(from: from, to: to)
-            case .succeedSaveMemo(let address, let modified):
-                return .succeedSaveMemo(address: address, modified: modified)
-            case .succeedUpdateAudience(let receipt):
-                return .succeedUpdateAudience(receipt)
             case _:
                 return nil
             }
@@ -367,10 +353,10 @@ struct NotebookModel: ModelProtocol {
                 environment: environment
             )
         case let .detailStack(action):
-            return NotebookDetailStackCursor.update(
+            return detailStack(
                 state: state,
-                action: action,
-                environment: environment
+                environment: environment,
+                action: action
             )
         case .appear:
             return appear(
@@ -572,6 +558,23 @@ struct NotebookModel: ModelProtocol {
         var model = state
         model.isSearchPresented = isPresented
         return Update(state: model)
+    }
+    
+    static func detailStack(
+        state: NotebookModel,
+        environment: AppEnvironment,
+        action: DetailStackAction
+    ) -> Update<NotebookModel> {
+        switch action {
+        case .succeedMergeMemo, .succeedUpdateAudience, .succeedMoveMemo, .succeedSaveMemo:
+            return update(state: state, action: .refreshLists, environment: environment)
+        case _:
+            return NotebookDetailStackCursor.update(
+                state: state,
+                action: action,
+                environment: environment
+            )
+        }
     }
 
     /// Refresh all lists in the notebook tab from database.

--- a/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
@@ -235,7 +235,15 @@ extension NotebookAction {
         case .succeedSyncLocalFilesWithDatabase:
             return .ready
         case .succeedIndexOurSphere(_):
-            return .ready
+            return .refreshLists
+        case .succeedSaveMemo:
+            return .refreshLists
+        case .succeedUpdateAudience:
+            return .refreshLists
+        case .succeedMoveMemo:
+            return .refreshLists
+        case .succeedMergeMemo:
+            return .refreshLists
         case let .succeedDeleteMemo(address):
             return .succeedDeleteMemo(address)
         case let .failDeleteMemo(error):
@@ -253,6 +261,19 @@ extension AppAction {
         switch action {
         case let .requestDeleteMemo(address):
             return .deleteMemo(address)
+        case let .detailStack(action):
+            switch (action) {
+            case .succeedDeleteMemo(let address):
+                return .succeedDeleteMemo(address)
+            case .succeedMoveMemo(let from, let to):
+                return .succeedMoveMemo(from: from, to: to)
+            case .succeedSaveMemo(let address, let modified):
+                return .succeedSaveMemo(address: address, modified: modified)
+            case .succeedUpdateAudience(let receipt):
+                return .succeedUpdateAudience(receipt)
+            case _:
+                return nil
+            }
         default:
             return nil
         }


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/894

As of https://github.com/subconsciousnetwork/subconscious/pull/885 are currently swallowing the actions that should refresh the `NotebookView` inside `DetailStack`. I would normally replay the events from `DetailStack`'s store on the `Notebook` store _but_ we (seemingly) can't do this with a `ViewStore`, there's no `actions` publisher exposed.

Instead, I am listening for `.detailStack()` actions in the `NotebookView` and replaying those on the `App` store and _then_ replaying those actions on the `Notebook` store. 

It fixes the problem but feels janky to me, can you think of a better approach @gordonbrander?
