### PR TITLE
Remove app dependency from recovery mode 

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/Recovery/RecoveryModeExplainPanelView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Recovery/RecoveryModeExplainPanelView.swift
@@ -1,5 +1,5 @@
 //
-//  RecoveryTabExplainView.swift
+//  RecoveryModeExplainPanelView.swift
 //  Subconscious (iOS)
 //
 //  Created by Ben Follington on 25/9/2023.
@@ -11,14 +11,13 @@ import ObservableStore
 
 struct RecoveryModeExplainPanelView: View {
     var store: ViewStore<RecoveryModeModel>
-    var did: Did?
-    var onCancel: () -> Void
+    
+    var did: Did? {
+        store.state.recoveryDidField.validated
+    }
     
     var body: some View {
         VStack(spacing: AppTheme.padding) {
-            Text("Recovery Mode")
-                .bold()
-            
             Spacer()
             
             switch store.state.launchContext {
@@ -87,20 +86,13 @@ struct RecoveryModeExplainPanelView: View {
             
             Spacer()
             
-            Button(
-                action: {
-                    store.send(.setCurrentTab(.form))
-                },
-                label: {
-                    Text("Proceed")
-                }
-            )
-            .buttonStyle(PillButtonStyle())
+            NavigationLink("Proceed", value: RecoveryViewStep.form)
+                .buttonStyle(PillButtonStyle())
             
             if store.state.launchContext == .userInitiated {
                 Button(
                     action: {
-                        onCancel()
+                        store.send(.requestPresent(false))
                     },
                     label: {
                         Text("Cancel")
@@ -109,5 +101,6 @@ struct RecoveryModeExplainPanelView: View {
             }
         }
         .padding(AppTheme.padding)
+        .navigationTitle("Recovery Mode")
     }
 }

--- a/xcode/Subconscious/Shared/Components/Common/Recovery/RecoveryModeFormPanelView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Recovery/RecoveryModeFormPanelView.swift
@@ -1,5 +1,5 @@
 //
-//  RecoveryTabFormView.swift
+//  RecoveryPanelFormView.swift
 //  Subconscious (iOS)
 //
 //  Created by Ben Follington on 25/9/2023.
@@ -11,7 +11,6 @@ import ObservableStore
 
 struct RecoveryModeFormPanelView: View {
     var store: ViewStore<RecoveryModeModel>
-    var onDismiss: () -> Void
     
     var formIsValid: Bool {
         store.state.recoveryDidField.isValid &&
@@ -21,9 +20,6 @@ struct RecoveryModeFormPanelView: View {
     
     var body: some View {
         VStack(alignment: .center) {
-            Text("Recovery")
-                .bold()
-            
             Spacer()
     
             ValidatedFormField(
@@ -80,7 +76,7 @@ struct RecoveryModeFormPanelView: View {
             Button(
                 action: {
                     if store.state.recoveryStatus == .succeeded {
-                        return onDismiss()
+                        store.send(.requestPresent(false))
                     }
                     
                     guard let did = store.state.recoveryDidField.validated else {
@@ -110,5 +106,7 @@ struct RecoveryModeFormPanelView: View {
         }
         .disabled(store.state.recoveryStatus == .pending)
         .padding(AppTheme.padding)
+        .navigationTitle("Recovery")
+
     }
 }


### PR DESCRIPTION
Builds on #892 to address in https://github.com/subconsciousnetwork/subconscious/pull/892#discussion_r1336558463.

- Remove app dependency from recovery mode
- Pass down ViewStore from app level

Other changes:

- Clean up excess view dependencies. There were places where we were requiring passing down properties that the view already had access to through its store
- Move recovery mode presentation flag up to app level (it's an app level concern)
- Use NavigationStack for recovery flow (more appropriate)