### PR TITLE
Retrieve sphere ID from UserDefaults and run recovery check earlier

### DIFF
--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -142,7 +142,7 @@ actor NoosphereService:
         if let noosphere = self._noosphere {
             return noosphere
         }
-        logger.debug("init Noosphere")
+        logger.debug("Initializing Noosphere")
         let noosphere = try Noosphere(
             globalStoragePath: globalStorageURL.path(percentEncoded: false),
             sphereStoragePath: sphereStorageURL.path(percentEncoded: false),
@@ -150,6 +150,7 @@ actor NoosphereService:
             noosphereLogLevel: _noosphereLogLevel
         )
         self._noosphere = noosphere
+        logger.debug("Initialized and cached Noosphere")
         return noosphere
     }
     
@@ -163,12 +164,13 @@ actor NoosphereService:
         }
         
         let noosphere = try noosphere()
-        logger.debug("init Sphere with identity: \(identity)")
+        logger.debug("Initializing Sphere with identity: \(identity)")
         let sphere = try Sphere(
             noosphere: noosphere,
             identity: identity
         )
         self._sphere = sphere
+        logger.debug("Initialized and cached Sphere with identity: \(identity)")
         return sphere
     }
     


### PR DESCRIPTION
Previously, we were reading the known sphere identity from the SQLite database. This is suboptimal for a couple reasons:

- The database is an index, not a source of truth, and can be thrown away and re-built at any time. 
- The source of truth for the known sphere identity is `AppDefaults.standard.sphereIdentity` (UserDefaults)
    - We store the identity here upon sphere creation
    - UserDefaults persist for the life of the app container
- Relying on the database meant we had to wait until database migration was complete before checking for recovery state.

This PR makes the following changes:

- Read known sphere identity from `AppDefaults.standard.sphereIdentity`
- Run recovery check as early as possible (`.start`)

Additionally, I added some logs to `NoosphereService` to make it clearer when we experience a cache miss due to failure to construct sphere.