### PR TITLE
Mark Sentry events as "development" in development

### DIFF
--- a/xcode/Subconscious/Shared/Library/Sentry.swift
+++ b/xcode/Subconscious/Shared/Library/Sentry.swift
@@ -22,6 +22,7 @@ extension SentryIntegration {
         SentrySDK.start { options in
             // per https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization this is fine to be public, unless it's abused (e.g. someone sending us /extra/ errors.
             options.dsn = "https://72ea1a54aeb04f60880d75fcffe705ed@o4505393671569408.ingest.sentry.io/4505393756438528"
+            options.environment = Config.default.debug ? "development" : "production"
             options.beforeSend = { event in
                 let ev = event
                 if ev.breadcrumbs == nil {


### PR DESCRIPTION
@justinabrahms noticed that errors from development are showing up in the production stream on Sentry, this is confusing and noisy.

In dev, we do want to record crash events etc. but we should set the `environment` appropriately.