### PR TITLE
Fix merging notes

### DIFF
--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -513,8 +513,12 @@ actor DataService {
         var memo = memo
         memo.modified = Date.now
         
+        let identity = try await noosphere.identity()
+        
         switch address.peer {
         case .none:
+            return try await writeSphereMemo(slug: address.slug, memo: memo)
+        case let .did(did) where did == identity:
             return try await writeSphereMemo(slug: address.slug, memo: memo)
         case let .did(did) where did == Did.local:
             return try await writeLocalMemo(slug: address.slug, memo: memo)

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -513,12 +513,8 @@ actor DataService {
         var memo = memo
         memo.modified = Date.now
         
-        let identity = try await noosphere.identity()
-        
         switch address.peer {
         case .none:
-            return try await writeSphereMemo(slug: address.slug, memo: memo)
-        case let .did(did) where did == identity:
             return try await writeSphereMemo(slug: address.slug, memo: memo)
         case let .did(did) where did == Did.local:
             return try await writeLocalMemo(slug: address.slug, memo: memo)

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -834,7 +834,10 @@ final class DatabaseService {
                 ]
             )
             .compactMap({ row in
-                row.col(0)?.toString()?.toSlashlink()
+                row.col(0)?
+                    .toString()?
+                    .toSlashlink()?
+                    .relativizeIfNeeded(did: owner)
             })
         
         return Self.collateRenameSuggestions(

--- a/xcode/Subconscious/SubconsciousTests/Tests_DatabaseService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DatabaseService.swift
@@ -902,4 +902,137 @@ class Tests_DatabaseService: XCTestCase {
             )
         )
     }
+    
+    func testSearchRenameSuggestions() throws {
+        let service = try createDatabaseService()
+        _ = try service.migrate()
+        
+        // Add some entries to DB
+        let now = Date.now
+        
+        // This is a peer we are following
+        let alice = Petname("alice")!
+        let source = PeerRecord(
+            petname: alice,
+            identity: Did("did:key:alice")!,
+            since: "bafyfakefakefake"
+        )
+        
+        try service.writePeer(source)
+        
+        // Create a note, we will attempt to merge this into another note
+        let current = Slashlink("/foo")!
+        let foo = Memo(
+            contentType: "text/subtext",
+            created: now,
+            modified: now,
+            fileExtension: "subtext",
+            additionalHeaders: [],
+            body: "Foo, published note, starting point."
+        )
+        
+        let did = Did("did:key:abc123")!
+        try service.writeMemo(
+            MemoRecord(
+                did: did,
+                petname: nil,
+                slug: current.slug,
+                memo: foo
+            )
+        )
+        
+        // Contains link to /foo, should show up in merge results, local memo
+        let bar = Memo(
+            contentType: "text/subtext",
+            created: now,
+            modified: now,
+            fileExtension: "subtext",
+            additionalHeaders: [],
+            body: "Bar /foo should appear in results, local draft."
+        )
+        try service.writeMemo(
+            MemoRecord(
+                did: Did.local,
+                petname: nil,
+                slug: Slug("bar")!,
+                memo: bar,
+                size: bar.toHeaderSubtext().size()!
+            )
+        )
+        
+        // Contains link to /foo, should show up in merge results, published memo
+        let baz = Memo(
+            contentType: "text/subtext",
+            created: now,
+            modified: now,
+            fileExtension: "subtext",
+            additionalHeaders: [],
+            body: "Bar /foo should appear in results, local draft."
+        )
+        try service.writeMemo(
+            MemoRecord(
+                did: did,
+                petname: Petname("abc")!,
+                slug: Slug("bar2")!,
+                memo: baz,
+                size: baz.toHeaderSubtext().size()!
+            )
+        )
+        
+        // Someone else's content, never possible to merge, should be filtered out.
+        let qux = Memo(
+            contentType: "text/subtext",
+            created: now,
+            modified: now,
+            fileExtension: "subtext",
+            additionalHeaders: [],
+            body: "This /foo should not appear in results, 3P."
+        )
+        try service.writeMemo(
+            MemoRecord(
+                did: source.identity,
+                petname: alice,
+                slug: Slug("food")!,
+                memo: qux
+            )
+        )
+        
+        let search = try service.searchRenameSuggestions(owner: did, query: "fo", current: current)
+        XCTAssert(search.count == 3)
+        
+        let first = search[0]
+        switch first {
+        case let .move(from, to):
+            XCTAssert(from == current)
+            XCTAssert(to.isOurs)
+            XCTAssert(to.slug == Slug("fo"))
+            break
+        default:
+            XCTFail("expected move result first")
+        }
+        
+        let second = search[1]
+        switch second {
+        case let .merge(parent, child):
+            XCTAssert(child == current)
+            XCTAssert(parent.isOurs)
+            XCTAssert(parent.isLocal)
+            XCTAssert(parent.slug == Slug("bar"))
+            break
+        default:
+            XCTFail("expected local merge result second")
+        }
+        
+        let third = search[2]
+        switch third {
+        case let .merge(parent, child):
+            XCTAssert(child == current)
+            XCTAssert(parent.isOurs)
+            XCTAssertFalse(parent.isLocal)
+            XCTAssert(parent.slug == Slug("bar2"))
+            break
+        default:
+            XCTFail("expected public merge result third")
+        }
+    }
 }


### PR DESCRIPTION
Working on https://github.com/subconsciousnetwork/subconscious/pull/912 I realised that merging notes was broken. 

The addresses for merge suggestions were not being relativized when retrieved from SQLite, so they had a `peer` of `.did()` which made `writeMemo` blow up thinking it couldn't write to that path.

I've changed `searchRenameSuggestions` to relativize addresses.