### PR TITLE
Re-arrange onboarding steps

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppUpgradeView.swift
+++ b/xcode/Subconscious/Shared/Components/AppUpgradeView.swift
@@ -49,13 +49,13 @@ struct AppUpgradeView: View {
                         )
                     )
                 }
-                Spacer()
             }
             .foregroundColor(.primary)
             .multilineTextAlignment(.center)
-            .font(.title3)
+            .font(.body)
             .bold()
-            .frame(height: AppTheme.unit * 32)
+            
+            Spacer()
 
             VStack(alignment: .center) {
                 ProgressTorusView(
@@ -104,7 +104,12 @@ struct AppUpgradeView: View {
             .buttonStyle(PillButtonStyle())
             .disabled(!state.isComplete)
         }
-        .padding()
+        .padding(EdgeInsets(
+            top: AppTheme.unit2,
+            leading: AppTheme.padding,
+            bottom: AppTheme.padding,
+            trailing: AppTheme.padding
+        ))
         .frame(maxWidth: .infinity)
         .background(
             AppTheme.onboarding

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -242,6 +242,7 @@ enum AppAction {
     case submitFirstRunProfileStep
     case submitFirstRunSphereStep
     case submitFirstRunRecoveryStep
+    case submitFirstRunInviteStep
     case submitFirstRunDoneStep
     
     case requestOfflineMode
@@ -461,9 +462,10 @@ enum AppDatabaseState {
 }
 
 enum FirstRunStep {
-    case profile
     case sphere
     case recovery
+    case profile
+    case invite
     case done
 }
 
@@ -677,6 +679,11 @@ struct AppModel: ModelProtocol {
             )
         case .submitFirstRunRecoveryStep:
             return submitFirstRunRecoveryStep(
+                state: state,
+                environment: environment
+            )
+        case .submitFirstRunInviteStep:
+            return submitFirstRunInviteStep(
                 state: state,
                 environment: environment
             )
@@ -1491,7 +1498,7 @@ struct AppModel: ModelProtocol {
         return update(
             state: state,
             actions: [
-                .pushFirstRunStep(.profile)
+                .pushFirstRunStep(.sphere)
             ],
             environment: environment
         )
@@ -1510,7 +1517,7 @@ struct AppModel: ModelProtocol {
             state: state,
             actions: [
                 .submitNickname(nickname),
-                .pushFirstRunStep(.sphere)
+                .pushFirstRunStep(.invite)
             ],
             environment: environment
         )
@@ -1523,6 +1530,7 @@ struct AppModel: ModelProtocol {
         return update(
             state: state,
             actions: [
+                .createSphere,
                 .pushFirstRunStep(.recovery)
             ],
             environment: environment
@@ -1530,6 +1538,19 @@ struct AppModel: ModelProtocol {
     }
     
     static func submitFirstRunRecoveryStep(
+        state: AppModel,
+        environment: AppEnvironment
+    ) -> Update<AppModel> {
+        return update(
+            state: state,
+            actions: [
+                .pushFirstRunStep(.profile)
+            ],
+            environment: environment
+        )
+    }
+    
+    static func submitFirstRunInviteStep(
         state: AppModel,
         environment: AppEnvironment
     ) -> Update<AppModel> {

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -1478,7 +1478,7 @@ struct AppModel: ModelProtocol {
             state: model,
             actions: [
                 .inviteCodeFormField(.reset),
-                .submitFirstRunWelcomeStep
+                .submitFirstRunInviteStep
             ],
             environment: environment
         )

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -1488,13 +1488,6 @@ struct AppModel: ModelProtocol {
         state: AppModel,
         environment: AppEnvironment
     ) -> Update<AppModel> {
-        guard state.inviteCode == nil || // Offline mode: no code
-              state.gatewayId != nil // Otherwise we need an ID to proceed
-        else {
-            logger.error("Missing gateway ID but user is trying to use invite code")
-            return Update(state: state)
-        }
-        
         return update(
             state: state,
             actions: [
@@ -1554,6 +1547,13 @@ struct AppModel: ModelProtocol {
         state: AppModel,
         environment: AppEnvironment
     ) -> Update<AppModel> {
+        guard state.inviteCode == nil || // Offline mode: no code
+              state.gatewayId != nil // Otherwise we need an ID to proceed
+        else {
+            logger.error("Missing gateway ID but user is trying to use invite code")
+            return Update(state: state)
+        }
+
         return update(
             state: state,
             actions: [

--- a/xcode/Subconscious/Shared/Components/FirstRun/FIrstRunInviteView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FIrstRunInviteView.swift
@@ -1,0 +1,160 @@
+//
+//  FIrstRunInviteView.swift
+//  Subconscious (iOS)
+//
+//  Created by Ben Follington on 2/10/2023.
+//
+
+import ObservableStore
+import SwiftUI
+
+struct InviteCodeRedeemedView: View {
+    var gatewayId: String
+    
+    var body: some View {
+        VStack(spacing: AppTheme.unit2) {
+            HStack(spacing: AppTheme.unit2) {
+                Image(systemName: "checkmark.circle")
+                    .resizable()
+                    .frame(width: 16, height: 16)
+                    .opacity(0.5)
+                Text("Invitation accepted")
+            }
+            .font(.body)
+            .bold()
+            
+            HStack(spacing: AppTheme.unit) {
+                Text("Gateway ID")
+                    .bold()
+                Text(gatewayId)
+            }
+            .font(.caption)
+        }
+        .foregroundColor(.secondary)
+    }
+}
+
+struct FirstRunInviteView: View {
+    @ObservedObject var app: Store<AppModel>
+    @Environment(\.colorScheme) var colorScheme
+    
+    var inviteCodeCaption: String {
+        switch app.state.inviteCodeRedemptionStatus {
+        case .failed(_):
+            return String(localized: "Could not redeem invite code")
+        case _:
+            return String(localized: "You can find your invite code in your welcome email")
+        }
+    }
+    
+    var body: some View {
+        VStack(spacing: AppTheme.padding) {
+            Spacer()
+            
+            if !app.state.inviteCodeFormField.hasFocus {
+                StackedGlowingImage() {
+                    Image("ns_logo").resizable()
+                }
+                .aspectRatio(contentMode: .fit)
+                .frame(
+                    minWidth: 32,
+                    maxWidth: AppTheme.onboarding.heroIconSize,
+                    minHeight: 32,
+                    maxHeight: AppTheme.onboarding.heroIconSize
+                )
+            }
+            
+            Text("Subconscious is powered by Noosphere, a decentralized protocol, so your data is accessible anywhere and belongs to you.")
+                .foregroundColor(.secondary)
+                .font(.callout)
+                .multilineTextAlignment(.center)
+            
+            Text("Enter your invite code to create your Noosphere gateway:")
+                .foregroundColor(.secondary)
+                .font(.callout)
+                .multilineTextAlignment(.center)
+            
+            if let gatewayId = app.state.gatewayId {
+                InviteCodeRedeemedView(
+                    gatewayId: gatewayId
+                )
+            } else {
+                ValidatedFormField(
+                    alignment: .center,
+                    placeholder: "Enter your invite code",
+                    field: app.state.inviteCodeFormField,
+                    send: Address.forward(
+                        send: app.send,
+                        tag: AppAction.inviteCodeFormField
+                    ),
+                    caption: inviteCodeCaption,
+                    onFocusChanged: { focused in
+                        // User finished editing the field
+                        if !focused {
+                            app.send(.submitInviteCodeForm)
+                        }
+                    }
+                )
+                .textFieldStyle(.roundedBorder)
+                .textInputAutocapitalization(.never)
+                .disableAutocorrection(true)
+                .disabled(app.state.gatewayOperationInProgress)
+            }
+            
+            if !app.state.inviteCodeFormField.hasFocus {
+                Spacer()
+                
+                Button(action: {
+                    app.send(.submitFirstRunInviteStep)
+                }, label: {
+                    Text("Continue")
+                })
+                .buttonStyle(PillButtonStyle())
+                .disabled(app.state.gatewayId == nil)
+            }
+            
+            // MARK: Use Offline
+            VStack {
+                if app.state.gatewayId == .none {
+                    HStack(spacing: AppTheme.unit) {
+                        Text("No invite code?")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        
+                        Button(action: {
+                            app.send(.requestOfflineMode)
+                        }, label: {
+                            Text("Use offline")
+                                .font(.caption)
+                        })
+                    }
+                }
+            }.padding(
+                .init(
+                    top: 0,
+                    leading: 0,
+                    bottom: AppTheme.tightPadding,
+                    trailing: 0
+                )
+            )
+        }
+        .navigationTitle("Invite Code")
+        .navigationBarTitleDisplayMode(.inline)
+        .padding()
+        .background(
+            AppTheme.onboarding
+                .appBackgroundGradient(colorScheme)
+        )
+    }
+}
+
+struct FirstRunInviteView_Previews: PreviewProvider {
+    static var previews: some View {
+        FirstRunInviteView(
+            app: Store(
+                state: AppModel(),
+                environment: AppEnvironment()
+            )
+        )
+    }
+}

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunDoneView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunDoneView.swift
@@ -62,10 +62,14 @@ struct FirstRunDoneView: View {
     }
 
     var body: some View {
-        VStack(spacing: AppTheme.padding * 4) {
+        VStack(spacing: AppTheme.padding) {
             Spacer()
+            
             Text(statusLabel)
                 .foregroundColor(.secondary)
+            
+            Spacer()
+            
             StackedGlowingImage() {
                 HStack(
                     alignment: .center,
@@ -87,9 +91,13 @@ struct FirstRunDoneView: View {
                 }
                 .frame(height: 64)
             }
+            Spacer()
+            
             Text(guidanceLabel)
                 .foregroundColor(.secondary)
+            
             Spacer()
+            
             Button(
                 action: {
                     app.send(.submitFirstRunDoneStep)

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunDoneView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunDoneView.swift
@@ -51,13 +51,13 @@ struct FirstRunDoneView: View {
     var guidanceLabel: String {
         switch (status) {
         case .pending:
-            return "You can start exploring the app offline."
+            return "You can start exploring offline."
         case .succeeded:
             return "Welcome to Subconscious."
             
         // Shown if the user skips the invite code step OR we fail to provision
         case .initial, .failed:
-            return "Don't worry, you can still explore the app."
+            return "Don't worry, you can still start exploring."
         }
     }
 

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunDoneView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunDoneView.swift
@@ -37,14 +37,14 @@ struct FirstRunDoneView: View {
     var statusLabel: String {
         switch (status) {
         case .pending:
-            return "Creating your sphere..."
+            return "Creating your gateway..."
         case .succeeded:
             return "Connected!"
         case .initial:
             // Shown if the user skips the invite code step
             return "You are offline."
         case .failed:
-            return "Failed to create sphere."
+            return "Failed to create gateway."
         }
     }
     

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunDoneView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunDoneView.swift
@@ -83,6 +83,13 @@ struct FirstRunDoneView: View {
                     }
                     dottedLine
                     ResourceSyncBadge(status: status)
+                        .foregroundColor(Func.run {
+                            if case .failed = status {
+                                return .red
+                            }
+                            
+                            return .secondary
+                        })
                     dottedLine
                     Image("ns_logo")
                         .resizable()

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunInviteView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunInviteView.swift
@@ -74,9 +74,9 @@ struct FirstRunInviteView: View {
             }
             
             VStack(spacing: AppTheme.padding) {
-                Text("Subconscious is powered by Noosphere, a decentralized protocol, so your data is accessible anywhere and belongs to you.")
+                Text("Get connected to Noosphere.")
                 
-                Text("Enter your invite code to create your Noosphere gateway:")
+                Text("Enter your invite code to create your gateway:")
             }
             .foregroundColor(.secondary)
             .font(.callout)

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunInviteView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunInviteView.swift
@@ -1,5 +1,5 @@
 //
-//  FIrstRunInviteView.swift
+//  FirstRunInviteView.swift
 //  Subconscious (iOS)
 //
 //  Created by Ben Follington on 2/10/2023.
@@ -63,6 +63,8 @@ struct FirstRunInviteView: View {
                     maxHeight: AppTheme.onboarding.heroIconSize
                 )
             }
+            
+            Spacer()
             
             Text("Subconscious is powered by Noosphere, a decentralized protocol, so your data is accessible anywhere and belongs to you.")
                 .foregroundColor(.secondary)

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunInviteView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunInviteView.swift
@@ -62,19 +62,18 @@ struct FirstRunInviteView: View {
                     minHeight: 32,
                     maxHeight: AppTheme.onboarding.heroIconSize
                 )
+            
+                Spacer()
             }
             
-            Spacer()
-            
-            Text("Subconscious is powered by Noosphere, a decentralized protocol, so your data is accessible anywhere and belongs to you.")
-                .foregroundColor(.secondary)
-                .font(.callout)
-                .multilineTextAlignment(.center)
-            
-            Text("Enter your invite code to create your Noosphere gateway:")
-                .foregroundColor(.secondary)
-                .font(.callout)
-                .multilineTextAlignment(.center)
+            Group {
+                Text("Subconscious is powered by Noosphere, a decentralized protocol, so your data is accessible anywhere and belongs to you.")
+                
+                Text("Enter your invite code to create your Noosphere gateway:")
+            }
+            .foregroundColor(.secondary)
+            .font(.callout)
+            .multilineTextAlignment(.center)
             
             if let gatewayId = app.state.gatewayId {
                 InviteCodeRedeemedView(

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunInviteView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunInviteView.swift
@@ -47,26 +47,33 @@ struct FirstRunInviteView: View {
         }
     }
     
+    var keyboardVisible: Bool {
+        app.state.inviteCodeFormField.hasFocus
+    }
+    
     var body: some View {
         VStack(spacing: AppTheme.padding) {
             Spacer()
             
-            if !app.state.inviteCodeFormField.hasFocus {
+            if !keyboardVisible {
                 StackedGlowingImage() {
                     Image("ns_logo").resizable()
                 }
                 .aspectRatio(contentMode: .fit)
                 .frame(
-                    minWidth: 32,
-                    maxWidth: AppTheme.onboarding.heroIconSize,
-                    minHeight: 32,
-                    maxHeight: AppTheme.onboarding.heroIconSize
+                    width: AppTheme.onboarding.heroIconSize,
+                    height: AppTheme.onboarding.heroIconSize
                 )
-            
+                // hide the noosphere logo when the form is focused to maximise space
+                // animate the transition so it's not so jarring
+                .offset(y: keyboardVisible ? -AppTheme.onboarding.heroIconSize / 4 : 0)
+                .opacity(keyboardVisible ? 0 : 1)
+                .frame(height: keyboardVisible ? 0 : AppTheme.onboarding.heroIconSize)
+        
                 Spacer()
             }
             
-            Group {
+            VStack(spacing: AppTheme.padding) {
                 Text("Subconscious is powered by Noosphere, a decentralized protocol, so your data is accessible anywhere and belongs to you.")
                 
                 Text("Enter your invite code to create your Noosphere gateway:")
@@ -102,7 +109,7 @@ struct FirstRunInviteView: View {
                 .disabled(app.state.gatewayOperationInProgress)
             }
             
-            if !app.state.inviteCodeFormField.hasFocus {
+            if !keyboardVisible {
                 Spacer()
                 
                 Button(action: {

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunOrbitEffectView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunOrbitEffectView.swift
@@ -1,5 +1,5 @@
 //
-//  MetalTest.swift
+//  FirstRunOrbitEffectView.swift
 //  Subconscious (iOS)
 //
 //  Created by Ben Follington on 1/7/2023.
@@ -18,15 +18,26 @@ struct RotatingRingView<Content: View>: View {
         Group {
             ForEach(0..<content.count, id: \.self) { index in
                 content[index]
+                    // distribute around circle
                     .rotationEffect(Angle(degrees: Double(index) / Double(content.count) * 360))
+                    // rotate each individual item to counteract overall orbit rotation
+                    // this keeps the orbs oriented correctly
                     .rotationEffect(Angle(degrees: isAnimating ? 0 : 360))
-                    .offset(y: -radius) // Adjust this value based on your needs.
+                    .offset(y: -radius)
+                    // undistribute
                     .rotationEffect(Angle(degrees: -Double(index) / Double(content.count) * 360))
             }
         }
+        // rotate the overall ring, causing it to orbit
         .rotationEffect(Angle(degrees: isAnimating ? 360 : 0))
-        .animation(Animation.linear(duration: 10/speed).repeatForever(autoreverses: false), value: self.isAnimating)
+        .animation(
+            .linear(duration: 10/speed)
+                .repeatForever(autoreverses: false),
+            value: self.isAnimating
+        )
         .task {
+            // must use .task to begin animation instead of .onAppear
+            // otherwise the animation uses incorrect layout dimensions
             self.isAnimating = true
         }
     }
@@ -37,6 +48,10 @@ struct RotatingRingView<Content: View>: View {
 struct FirstRunOrbitEffectView: View {
     @Environment(\.colorScheme) var colorScheme
     
+    var shadow: Color {
+        Color.brandDropShadow(colorScheme).opacity(0.25)
+    }
+    
     var body: some View {
         ZStack(alignment: .center) {
             StackedGlowingImage() {
@@ -44,47 +59,39 @@ struct FirstRunOrbitEffectView: View {
             }
             .aspectRatio(contentMode: .fit)
             .frame(
-                minWidth: 32,
-                maxWidth: 80,
-                minHeight: 32,
-                maxHeight: 80
+                width: 80,
+                height: 80
             )
                 
-            RotatingRingView(radius: 64, speed: 0.3, content: [
-                    GenerativeProfilePic(did: Did.dummyData(), size: 32),
-                    GenerativeProfilePic(did: Did.dummyData(), size: 32),
-                    GenerativeProfilePic(did: Did.dummyData(), size: 32),
-                    GenerativeProfilePic(did: Did.dummyData(), size: 32),
-                    GenerativeProfilePic(did: Did.dummyData(), size: 32),
-                    GenerativeProfilePic(did: Did.dummyData(), size: 32),
-                    GenerativeProfilePic(did: Did.dummyData(), size: 32),
-                    GenerativeProfilePic(did: Did.dummyData(), size: 32),
-                ])
-                .opacity(0.75)
-                .shadow(color: Color.brandDropShadow(colorScheme).opacity(0.25), radius: 4, x:0, y: 5)
+            RotatingRingView(
+                radius: 64,
+                speed: 0.3,
+                content: [Int](
+                    repeating: 0,
+                    count: 8
+                ).map { _ in
+                    GenerativeProfilePic(did: Did.dummyData(), size: 32)
+                }
+            )
+            .opacity(0.75)
+            .shadow(color: shadow, radius: 4, x:0, y: 5)
                 
-            RotatingRingView(radius: 100, speed: 0.15, content: [
-                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
-                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
-                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
-                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
-                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
-                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
-                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
-                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
-                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
-                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
-                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
-                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
-                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
-                ])
-                .opacity(0.4)
-                .shadow(color: Color.brandDropShadow(colorScheme).opacity(0.25), radius: 4, x:0, y: 5)
-            }
-            .frame(width: 256, height: 256)
+            RotatingRingView(
+                radius: 100,
+                speed: 0.15,
+                content: [Int](
+                    repeating: 0,
+                    count: 15
+                ).map { _ in
+                    GenerativeProfilePic(did: Did.dummyData(), size: 20)
+                }
+            )
+            .opacity(0.4)
+            .shadow(color: shadow, radius: 4, x:0, y: 5)
         }
+        .frame(width: 244, height: 244)
     }
-//}
+}
 
 struct FirstRunOrbitEffectView_Previews: PreviewProvider {
     static var previews: some View {

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunOrbitEffectView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunOrbitEffectView.swift
@@ -1,0 +1,93 @@
+//
+//  MetalTest.swift
+//  Subconscious (iOS)
+//
+//  Created by Ben Follington on 1/7/2023.
+//
+
+import Foundation
+import SwiftUI
+
+struct RotatingRingView<Content: View>: View {
+    var radius: CGFloat = 150
+    var speed: CGFloat = 1
+    let content: [Content]
+    @State private var isAnimating = false
+
+    var body: some View {
+        Group {
+            ForEach(0..<content.count, id: \.self) { index in
+                content[index]
+                    .rotationEffect(Angle(degrees: Double(index) / Double(content.count) * 360))
+                    .rotationEffect(Angle(degrees: isAnimating ? 0 : 360))
+                    .offset(y: -radius) // Adjust this value based on your needs.
+                    .rotationEffect(Angle(degrees: -Double(index) / Double(content.count) * 360))
+            }
+        }
+        .rotationEffect(Angle(degrees: isAnimating ? 360 : 0))
+        .animation(Animation.linear(duration: 10/speed).repeatForever(autoreverses: false), value: self.isAnimating)
+        .task {
+            self.isAnimating = true
+        }
+    }
+}
+
+
+
+struct FirstRunOrbitEffectView: View {
+    @Environment(\.colorScheme) var colorScheme
+    
+    var body: some View {
+        ZStack(alignment: .center) {
+            StackedGlowingImage() {
+                Image("sub_logo").resizable()
+            }
+            .aspectRatio(contentMode: .fit)
+            .frame(
+                minWidth: 32,
+                maxWidth: 80,
+                minHeight: 32,
+                maxHeight: 80
+            )
+                
+            RotatingRingView(radius: 64, speed: 0.3, content: [
+                    GenerativeProfilePic(did: Did.dummyData(), size: 32),
+                    GenerativeProfilePic(did: Did.dummyData(), size: 32),
+                    GenerativeProfilePic(did: Did.dummyData(), size: 32),
+                    GenerativeProfilePic(did: Did.dummyData(), size: 32),
+                    GenerativeProfilePic(did: Did.dummyData(), size: 32),
+                    GenerativeProfilePic(did: Did.dummyData(), size: 32),
+                    GenerativeProfilePic(did: Did.dummyData(), size: 32),
+                    GenerativeProfilePic(did: Did.dummyData(), size: 32),
+                ])
+                .opacity(0.75)
+                .shadow(color: Color.brandDropShadow(colorScheme).opacity(0.25), radius: 4, x:0, y: 5)
+                
+            RotatingRingView(radius: 100, speed: 0.15, content: [
+                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
+                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
+                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
+                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
+                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
+                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
+                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
+                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
+                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
+                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
+                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
+                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
+                    GenerativeProfilePic(did: Did.dummyData(), size: 20),
+                ])
+                .opacity(0.4)
+                .shadow(color: Color.brandDropShadow(colorScheme).opacity(0.25), radius: 4, x:0, y: 5)
+            }
+            .frame(width: 256, height: 256)
+        }
+    }
+//}
+
+struct FirstRunOrbitEffectView_Previews: PreviewProvider {
+    static var previews: some View {
+        FirstRunOrbitEffectView()
+    }
+}

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunOrbitEffectView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunOrbitEffectView.swift
@@ -24,7 +24,7 @@ struct RotatingRingView<Content: View>: View {
                     // this keeps the orbs oriented correctly
                     .rotationEffect(Angle(degrees: isAnimating ? 0 : 360))
                     .offset(y: -radius)
-                    // undistribute
+                    // unrotate, preserving translation from .offset
                     .rotationEffect(Angle(degrees: -Double(index) / Double(content.count) * 360))
             }
         }
@@ -52,6 +52,24 @@ struct FirstRunOrbitEffectView: View {
         Color.brandDropShadow(colorScheme).opacity(0.25)
     }
     
+    var innerRing: [GenerativeProfilePic] {
+        [Int](
+            repeating: 0,
+            count: 8
+        ).map { _ in
+            GenerativeProfilePic(did: Did.dummyData(), size: 32)
+        }
+    }
+    
+    var outerRing: [GenerativeProfilePic] {
+        [Int](
+            repeating: 0,
+            count: 15
+        ).map { _ in
+            GenerativeProfilePic(did: Did.dummyData(), size: 20)
+        }
+    }
+    
     var body: some View {
         ZStack(alignment: .center) {
             StackedGlowingImage() {
@@ -66,12 +84,7 @@ struct FirstRunOrbitEffectView: View {
             RotatingRingView(
                 radius: 64,
                 speed: 0.3,
-                content: [Int](
-                    repeating: 0,
-                    count: 8
-                ).map { _ in
-                    GenerativeProfilePic(did: Did.dummyData(), size: 32)
-                }
+                content: innerRing
             )
             .opacity(0.75)
             .shadow(color: shadow, radius: 4, x:0, y: 5)
@@ -79,12 +92,7 @@ struct FirstRunOrbitEffectView: View {
             RotatingRingView(
                 radius: 100,
                 speed: 0.15,
-                content: [Int](
-                    repeating: 0,
-                    count: 15
-                ).map { _ in
-                    GenerativeProfilePic(did: Did.dummyData(), size: 20)
-                }
+                content: outerRing
             )
             .opacity(0.4)
             .shadow(color: shadow, radius: 4, x:0, y: 5)

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
@@ -43,7 +43,7 @@ struct FirstRunProfileView: View {
             
             Spacer()
             
-            Text("Choose a nickname for your sphere:")
+            Text("Give your sphere a nickname:")
                 .foregroundColor(.secondary)
             
             VStack(alignment: .leading, spacing: AppTheme.unit4) {

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
@@ -12,11 +12,27 @@ struct FirstRunProfileView: View {
     @ObservedObject var app: Store<AppModel>
     @Environment(\.colorScheme) var colorScheme
     
+    var did: Did? {
+        Did(app.state.sphereIdentity ?? "")
+    }
+    
     var body: some View {
         VStack(spacing: AppTheme.padding) {
             Spacer()
-            Text("What should we call you?")
+            
+            if let did = did {
+                StackedGlowingImage() {
+                    GenerativeProfilePic(
+                        did: did,
+                        size: 100
+                    )
+                }
+                .padding(AppTheme.padding)
+            }
+            
+            Text("Choose a nickname for your sphere:")
                 .foregroundColor(.secondary)
+            
             VStack(alignment: .leading, spacing: AppTheme.unit4) {
                 ValidatedFormField(
                     alignment: .center,

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
@@ -28,7 +28,20 @@ struct FirstRunProfileView: View {
                     )
                 }
                 .padding(AppTheme.padding)
+                
+                if let nickname = app.state.nicknameFormField.validated  {
+                    HStack(spacing: 0) {
+                        Text("Hi, ")
+                            .foregroundColor(.secondary)
+                        Text(nickname.toPetname().markup)
+                            .lineLimit(1)
+                        Text(".")
+                            .foregroundColor(.secondary)
+                    }
+                }
             }
+            
+            Spacer()
             
             Text("Choose a nickname for your sphere:")
                 .foregroundColor(.secondary)

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunRecoveryView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunRecoveryView.swift
@@ -20,7 +20,7 @@ struct FirstRunRecoveryView: View {
         VStack(spacing: AppTheme.padding) {
             Spacer()
         
-            Text("This is your secret recovery phrase. You can use it to recover your data if you lose access.")
+            Text("This is your sphere's secret recovery phrase. You can use it to recover your data if you lose access.")
                 .foregroundColor(.secondary)
                 .multilineTextAlignment(.center)
             
@@ -37,7 +37,7 @@ struct FirstRunRecoveryView: View {
                 radius: AppTheme.onboarding.shadowSize
             )
             
-            Text("It's for your eyes only. We don't store it.\n Write it down or add it to your password manager. Keep it secret, keep it safe.")
+            Text("It's for your eyes only. We don't store it. Write it down or add it to your password manager.")
                 .foregroundColor(.secondary)
                 .multilineTextAlignment(.center)
             Spacer()

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunSphereView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunSphereView.swift
@@ -19,31 +19,13 @@ struct FirstRunSphereView: View {
         VStack {
             Spacer()
             VStack(spacing: AppTheme.padding) {
-                if let nickname = app.state.nicknameFormField.validated  {
-                    HStack(spacing: 0) {
-                        Text("Hi, ")
-                            .foregroundColor(.secondary)
-                        Text(nickname.toPetname().markup)
-                            .lineLimit(1)
-                        Text(".")
-                            .foregroundColor(.secondary)
-                    }
-                }
+                // Should have orbiting spheres
+                FirstRunOrbitEffectView()
                 
-                if let did = did {
-                    StackedGlowingImage() {
-                        GenerativeProfilePic(
-                            did: did,
-                            size: 80
-                        )
-                    }
-                    .padding(AppTheme.padding)
-                }
-                
-                Text("This is your sphere. It stores your data.")
+                Text("Subconscious stores your notes in your personal sphere.")
                     .foregroundColor(.secondary)
                 
-                Text("Your sphere connects to Noosphere allowing you to explore and follow other spheres.")
+                Text("Your sphere connects to other spheres, allowing you to follow other users.")
                     .foregroundColor(.secondary)
             }
             .multilineTextAlignment(.center)
@@ -53,7 +35,7 @@ struct FirstRunSphereView: View {
             Button(action: {
                 app.send(.submitFirstRunSphereStep)
             }, label: {
-                Text("Got it")
+                Text("Create Sphere")
             })
             .buttonStyle(PillButtonStyle())
         }
@@ -62,7 +44,7 @@ struct FirstRunSphereView: View {
             AppTheme.onboarding
                 .appBackgroundGradient(colorScheme)
         )
-        .navigationTitle("Your Sphere")
+        .navigationTitle("Create Sphere")
         .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunSphereView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunSphereView.swift
@@ -28,7 +28,7 @@ struct FirstRunSphereView: View {
                 Text("Subconscious stores your notes in your personal sphere.")
                     .foregroundColor(.secondary)
                 
-                Text("Your sphere connects to other spheres, allowing you to follow other users.")
+                Text("Your sphere is stored on your device, and connects to other spheres over a decentralized network.")
                     .foregroundColor(.secondary)
             }
             .multilineTextAlignment(.center)

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunSphereView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunSphereView.swift
@@ -16,11 +16,14 @@ struct FirstRunSphereView: View {
     }
     
     var body: some View {
-        VStack {
+        VStack(spacing: AppTheme.padding) {
             Spacer()
-            VStack(spacing: AppTheme.padding) {
-                // Should have orbiting spheres
-                FirstRunOrbitEffectView()
+            
+            FirstRunOrbitEffectView()
+            
+            Spacer()
+            
+            Group {
                 
                 Text("Subconscious stores your notes in your personal sphere.")
                     .foregroundColor(.secondary)

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
@@ -41,7 +41,7 @@ struct FirstRunView: View {
                     .font(.callout)
                     .multilineTextAlignment(.center)
                     
-                Text("It's a personal notebook designed to help you discover connections and think new thoughts.")
+                Text("It’s powered by Noosphere, a decentralized protocol, so your data belongs to you.")
                     .foregroundColor(.secondary)
                     .font(.callout)
                     .multilineTextAlignment(.center)

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
@@ -34,6 +34,8 @@ struct FirstRunView: View {
                 )
                 .padding(AppTheme.padding)
                 
+                Spacer()
+                
                 Text("Subconscious is a place to garden thoughts and share them with others.")
                     .foregroundColor(.secondary)
                     .font(.callout)

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
@@ -32,6 +32,7 @@ struct FirstRunView: View {
                     minHeight: 32,
                     maxHeight: AppTheme.onboarding.heroIconSize
                 )
+                .padding(AppTheme.padding)
                 
                 Text("Subconscious is a place to garden thoughts and share them with others.")
                     .foregroundColor(.secondary)

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunView.swift
@@ -7,44 +7,9 @@
 import ObservableStore
 import SwiftUI
 
-struct InviteCodeRedeemedView: View {
-    var gatewayId: String
-    
-    var body: some View {
-        VStack(spacing: AppTheme.unit2) {
-            HStack(spacing: AppTheme.unit2) {
-                Image(systemName: "checkmark.circle")
-                    .resizable()
-                    .frame(width: 16, height: 16)
-                    .opacity(0.5)
-                Text("Invitation accepted")
-            }
-            .font(.body)
-            .bold()
-            
-            HStack(spacing: AppTheme.unit) {
-                Text("Gateway ID")
-                    .bold()
-                Text(gatewayId)
-            }
-            .font(.caption)
-        }
-        .foregroundColor(.secondary)
-    }
-}
-
 struct FirstRunView: View {
     @ObservedObject var app: Store<AppModel>
     @Environment(\.colorScheme) var colorScheme
-    
-    var inviteCodeCaption: String {
-        switch app.state.inviteCodeRedemptionStatus {
-        case .failed(_):
-            return String(localized: "Could not redeem invite code")
-        case _:
-            return String(localized: "You can find your invite code in your welcome email")
-        }
-    }
     
     var body: some View {
         NavigationStack(
@@ -57,96 +22,35 @@ struct FirstRunView: View {
             VStack(spacing: AppTheme.padding) {
                 Spacer()
                 
-                if !app.state.inviteCodeFormField.hasFocus {
-                    StackedGlowingImage() {
-                        Image("sub_logo").resizable()
-                    }
-                    .aspectRatio(contentMode: .fit)
-                    .frame(
-                        minWidth: 32,
-                        maxWidth: AppTheme.onboarding.heroIconSize,
-                        minHeight: 32,
-                        maxHeight: AppTheme.onboarding.heroIconSize
-                    )
-                    
-                    Spacer()
+                StackedGlowingImage() {
+                    Image("sub_logo").resizable()
                 }
+                .aspectRatio(contentMode: .fit)
+                .frame(
+                    minWidth: 32,
+                    maxWidth: AppTheme.onboarding.heroIconSize,
+                    minHeight: 32,
+                    maxHeight: AppTheme.onboarding.heroIconSize
+                )
                 
                 Text("Subconscious is a place to garden thoughts and share them with others.")
                     .foregroundColor(.secondary)
                     .font(.callout)
                     .multilineTextAlignment(.center)
                     
-                Text("It’s powered by Noosphere, a decentralized protocol, so your data belongs to you.")
+                Text("It's a personal notebook designed to help you discover connections and think new thoughts.")
                     .foregroundColor(.secondary)
                     .font(.callout)
                     .multilineTextAlignment(.center)
                 
                 Spacer()
                 
-                if let gatewayId = app.state.gatewayId {
-                    InviteCodeRedeemedView(
-                        gatewayId: gatewayId
-                    )
-                } else {
-                    ValidatedFormField(
-                        alignment: .center,
-                        placeholder: "Enter your invite code",
-                        field: app.state.inviteCodeFormField,
-                        send: Address.forward(
-                            send: app.send,
-                            tag: AppAction.inviteCodeFormField
-                        ),
-                        caption: inviteCodeCaption,
-                        onFocusChanged: { focused in
-                            // User finished editing the field
-                            if !focused {
-                                app.send(.submitInviteCodeForm)
-                            }
-                        }
-                    )
-                    .textFieldStyle(.roundedBorder)
-                    .textInputAutocapitalization(.never)
-                    .disableAutocorrection(true)
-                    .disabled(app.state.gatewayOperationInProgress)
-                }
-                
-                if !app.state.inviteCodeFormField.hasFocus {
-                    Spacer()
-                    
-                    Button(action: {
-                        app.send(.submitFirstRunWelcomeStep)
-                    }, label: {
-                        Text("Get Started")
-                    })
-                    .buttonStyle(PillButtonStyle())
-                    .disabled(app.state.gatewayId == nil)
-                }
-                
-                // MARK: Use Offline
-                VStack {
-                    if app.state.gatewayId == .none {
-                        HStack(spacing: AppTheme.unit) {
-                            Text("No invite code?")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                            
-                            Button(action: {
-                                app.send(.requestOfflineMode)
-                            }, label: {
-                                Text("Use offline")
-                                    .font(.caption)
-                            })
-                        }
-                    }
-                }.padding(
-                    .init(
-                        top: 0,
-                        leading: 0,
-                        bottom: AppTheme.tightPadding,
-                        trailing: 0
-                    )
-                )
+                Button(action: {
+                    app.send(.submitFirstRunWelcomeStep)
+                }, label: {
+                    Text("Get Started")
+                })
+                .buttonStyle(PillButtonStyle())
             }
             .navigationTitle("Welcome to Subconscious")
             .navigationBarTitleDisplayMode(.inline)
@@ -165,12 +69,11 @@ struct FirstRunView: View {
                     FirstRunSphereView(app: app)
                 case .recovery:
                     FirstRunRecoveryView(app: app)
+                case .invite:
+                    FirstRunInviteView(app: app)
                 case .done:
                     FirstRunDoneView(app: app)
                 }
-            }
-            .onAppear {
-                app.send(.createSphere)
             }
         }
     }

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -18,7 +18,7 @@
 		B51359262AC113F9004385A7 /* RecoveryModeFormPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51359252AC113F9004385A7 /* RecoveryModeFormPanelView.swift */; };
 		B51359282AC11570004385A7 /* ErrorDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51359272AC11570004385A7 /* ErrorDetailView.swift */; };
 		B513592A2AC2723E004385A7 /* GatewayURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51359292AC2723E004385A7 /* GatewayURL.swift */; };
-		B515E9D72ACA8DD20067A329 /* FIrstRunInviteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B515E9D62ACA8DD20067A329 /* FIrstRunInviteView.swift */; };
+		B515E9D72ACA8DD20067A329 /* FirstRunInviteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B515E9D62ACA8DD20067A329 /* FirstRunInviteView.swift */; };
 		B515E9D92ACA93D00067A329 /* FirstRunOrbitEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B515E9D82ACA93D00067A329 /* FirstRunOrbitEffectView.swift */; };
 		B51EEAA129F0C37B0055887B /* AppIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51EEAA029F0C37B0055887B /* AppIcon.swift */; };
 		B528CB3B2A5BB8C0001E3B8F /* FabSpacerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B528CB3A2A5BB8C0001E3B8F /* FabSpacerView.swift */; };
@@ -483,7 +483,7 @@
 		B51359252AC113F9004385A7 /* RecoveryModeFormPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryModeFormPanelView.swift; sourceTree = "<group>"; };
 		B51359272AC11570004385A7 /* ErrorDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorDetailView.swift; sourceTree = "<group>"; };
 		B51359292AC2723E004385A7 /* GatewayURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayURL.swift; sourceTree = "<group>"; };
-		B515E9D62ACA8DD20067A329 /* FIrstRunInviteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FIrstRunInviteView.swift; sourceTree = "<group>"; };
+		B515E9D62ACA8DD20067A329 /* FirstRunInviteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstRunInviteView.swift; sourceTree = "<group>"; };
 		B515E9D82ACA93D00067A329 /* FirstRunOrbitEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstRunOrbitEffectView.swift; sourceTree = "<group>"; };
 		B51EEAA029F0C37B0055887B /* AppIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIcon.swift; sourceTree = "<group>"; };
 		B528CB3A2A5BB8C0001E3B8F /* FabSpacerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FabSpacerView.swift; sourceTree = "<group>"; };
@@ -1137,7 +1137,7 @@
 				B549B16A2A0CDAC10070C6AD /* FirstRunRecoveryView.swift */,
 				B88B1CE4298EB10D0062CB7F /* RecoveryPhraseView.swift */,
 				B8B3EE76297AEE8B00779B7F /* FirstRunDoneView.swift */,
-				B515E9D62ACA8DD20067A329 /* FIrstRunInviteView.swift */,
+				B515E9D62ACA8DD20067A329 /* FirstRunInviteView.swift */,
 				B515E9D82ACA93D00067A329 /* FirstRunOrbitEffectView.swift */,
 			);
 			path = FirstRun;
@@ -1962,7 +1962,7 @@
 				B57D63BB29B1CA8B008BBB62 /* DidView.swift in Sources */,
 				B83E91D727692EC600045C6A /* FAB.swift in Sources */,
 				B848FDAA2991837900245115 /* DeveloperSettingsView.swift in Sources */,
-				B515E9D72ACA8DD20067A329 /* FIrstRunInviteView.swift in Sources */,
+				B515E9D72ACA8DD20067A329 /* FirstRunInviteView.swift in Sources */,
 				B8545F0D2970577600BC4EA1 /* BacklinkReacts.swift in Sources */,
 				B8E2B02929AD0E23004A78B3 /* Petname.swift in Sources */,
 				B550E04029AF219100050F19 /* Did.swift in Sources */,

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		B51359282AC11570004385A7 /* ErrorDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51359272AC11570004385A7 /* ErrorDetailView.swift */; };
 		B513592A2AC2723E004385A7 /* GatewayURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51359292AC2723E004385A7 /* GatewayURL.swift */; };
 		B515E9D72ACA8DD20067A329 /* FIrstRunInviteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B515E9D62ACA8DD20067A329 /* FIrstRunInviteView.swift */; };
+		B515E9D92ACA93D00067A329 /* FirstRunOrbitEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B515E9D82ACA93D00067A329 /* FirstRunOrbitEffectView.swift */; };
 		B51EEAA129F0C37B0055887B /* AppIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51EEAA029F0C37B0055887B /* AppIcon.swift */; };
 		B528CB3B2A5BB8C0001E3B8F /* FabSpacerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B528CB3A2A5BB8C0001E3B8F /* FabSpacerView.swift */; };
 		B528CB3C2A5BB8C0001E3B8F /* FabSpacerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B528CB3A2A5BB8C0001E3B8F /* FabSpacerView.swift */; };
@@ -483,6 +484,7 @@
 		B51359272AC11570004385A7 /* ErrorDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorDetailView.swift; sourceTree = "<group>"; };
 		B51359292AC2723E004385A7 /* GatewayURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayURL.swift; sourceTree = "<group>"; };
 		B515E9D62ACA8DD20067A329 /* FIrstRunInviteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FIrstRunInviteView.swift; sourceTree = "<group>"; };
+		B515E9D82ACA93D00067A329 /* FirstRunOrbitEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstRunOrbitEffectView.swift; sourceTree = "<group>"; };
 		B51EEAA029F0C37B0055887B /* AppIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIcon.swift; sourceTree = "<group>"; };
 		B528CB3A2A5BB8C0001E3B8F /* FabSpacerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FabSpacerView.swift; sourceTree = "<group>"; };
 		B5293B882A426645001C4DA7 /* Sentry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sentry.swift; sourceTree = "<group>"; };
@@ -1136,6 +1138,7 @@
 				B88B1CE4298EB10D0062CB7F /* RecoveryPhraseView.swift */,
 				B8B3EE76297AEE8B00779B7F /* FirstRunDoneView.swift */,
 				B515E9D62ACA8DD20067A329 /* FIrstRunInviteView.swift */,
+				B515E9D82ACA93D00067A329 /* FirstRunOrbitEffectView.swift */,
 			);
 			path = FirstRun;
 			sourceTree = "<group>";
@@ -1935,6 +1938,7 @@
 				B85652202975BA9000B7FCA0 /* MetaTableView.swift in Sources */,
 				B86BC75A29B24BEF005B5833 /* MemoEditorDetailMetaSheetView.swift in Sources */,
 				B8B6BCB529CCDDF6000DB410 /* ResourceStatus.swift in Sources */,
+				B515E9D92ACA93D00067A329 /* FirstRunOrbitEffectView.swift in Sources */,
 				B58FE48C28DED9B600E000CC /* StoryCombo.swift in Sources */,
 				B86DFF3727C09CA2002E57ED /* DateUtilities.swift in Sources */,
 				B8E1A9572A16E98D00B757A5 /* PeerRecord.swift in Sources */,

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		B51359262AC113F9004385A7 /* RecoveryModeFormPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51359252AC113F9004385A7 /* RecoveryModeFormPanelView.swift */; };
 		B51359282AC11570004385A7 /* ErrorDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51359272AC11570004385A7 /* ErrorDetailView.swift */; };
 		B513592A2AC2723E004385A7 /* GatewayURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51359292AC2723E004385A7 /* GatewayURL.swift */; };
+		B515E9D72ACA8DD20067A329 /* FIrstRunInviteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B515E9D62ACA8DD20067A329 /* FIrstRunInviteView.swift */; };
 		B51EEAA129F0C37B0055887B /* AppIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51EEAA029F0C37B0055887B /* AppIcon.swift */; };
 		B528CB3B2A5BB8C0001E3B8F /* FabSpacerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B528CB3A2A5BB8C0001E3B8F /* FabSpacerView.swift */; };
 		B528CB3C2A5BB8C0001E3B8F /* FabSpacerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B528CB3A2A5BB8C0001E3B8F /* FabSpacerView.swift */; };
@@ -383,9 +384,6 @@
 		B8CC433E27A07CE10079D2F9 /* ScrimView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8CC433C27A07CE10079D2F9 /* ScrimView.swift */; };
 		B8CC434927A0CA8D0079D2F9 /* AnimationUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8CC434827A0CA8D0079D2F9 /* AnimationUtilities.swift */; };
 		B8CC434A27A0CA8D0079D2F9 /* AnimationUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8CC434827A0CA8D0079D2F9 /* AnimationUtilities.swift */; };
-		B8D328B529A640F200850A37 /* Tests_RecoveryPhrase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D328B429A640F200850A37 /* Tests_RecoveryPhrase.swift */; };
-		B8CE40E728D2707D00819064 /* QueryPromptGeist.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8CE40E628D2707D00819064 /* QueryPromptGeist.swift */; };
-		B8CE40E828D2707D00819064 /* QueryPromptGeist.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8CE40E628D2707D00819064 /* QueryPromptGeist.swift */; };
 		B8D328B529A640F200850A37 /* Tests_RecoveryPhraseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D328B429A640F200850A37 /* Tests_RecoveryPhraseView.swift */; };
 		B8D328B729A671DA00850A37 /* TranscludeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D328B629A671DA00850A37 /* TranscludeView.swift */; };
 		B8D328B829A671DA00850A37 /* TranscludeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D328B629A671DA00850A37 /* TranscludeView.swift */; };
@@ -484,6 +482,7 @@
 		B51359252AC113F9004385A7 /* RecoveryModeFormPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryModeFormPanelView.swift; sourceTree = "<group>"; };
 		B51359272AC11570004385A7 /* ErrorDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorDetailView.swift; sourceTree = "<group>"; };
 		B51359292AC2723E004385A7 /* GatewayURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayURL.swift; sourceTree = "<group>"; };
+		B515E9D62ACA8DD20067A329 /* FIrstRunInviteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FIrstRunInviteView.swift; sourceTree = "<group>"; };
 		B51EEAA029F0C37B0055887B /* AppIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIcon.swift; sourceTree = "<group>"; };
 		B528CB3A2A5BB8C0001E3B8F /* FabSpacerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FabSpacerView.swift; sourceTree = "<group>"; };
 		B5293B882A426645001C4DA7 /* Sentry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sentry.swift; sourceTree = "<group>"; };
@@ -740,8 +739,6 @@
 		B8CBAFA8299580E50079107E /* StoreProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreProtocol.swift; sourceTree = "<group>"; };
 		B8CC433C27A07CE10079D2F9 /* ScrimView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrimView.swift; sourceTree = "<group>"; };
 		B8CC434827A0CA8D0079D2F9 /* AnimationUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationUtilities.swift; sourceTree = "<group>"; };
-		B8D328B429A640F200850A37 /* Tests_RecoveryPhrase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_RecoveryPhrase.swift; sourceTree = "<group>"; };
-		B8CE40E628D2707D00819064 /* QueryPromptGeist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryPromptGeist.swift; sourceTree = "<group>"; };
 		B8D328B429A640F200850A37 /* Tests_RecoveryPhraseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_RecoveryPhraseView.swift; sourceTree = "<group>"; };
 		B8D328B629A671DA00850A37 /* TranscludeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscludeView.swift; sourceTree = "<group>"; };
 		B8D328B929A69D2D00850A37 /* Tests_URLUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_URLUtilities.swift; sourceTree = "<group>"; };
@@ -1138,6 +1135,7 @@
 				B549B16A2A0CDAC10070C6AD /* FirstRunRecoveryView.swift */,
 				B88B1CE4298EB10D0062CB7F /* RecoveryPhraseView.swift */,
 				B8B3EE76297AEE8B00779B7F /* FirstRunDoneView.swift */,
+				B515E9D62ACA8DD20067A329 /* FIrstRunInviteView.swift */,
 			);
 			path = FirstRun;
 			sourceTree = "<group>";
@@ -1960,6 +1958,7 @@
 				B57D63BB29B1CA8B008BBB62 /* DidView.swift in Sources */,
 				B83E91D727692EC600045C6A /* FAB.swift in Sources */,
 				B848FDAA2991837900245115 /* DeveloperSettingsView.swift in Sources */,
+				B515E9D72ACA8DD20067A329 /* FIrstRunInviteView.swift in Sources */,
 				B8545F0D2970577600BC4EA1 /* BacklinkReacts.swift in Sources */,
 				B8E2B02929AD0E23004A78B3 /* Petname.swift in Sources */,
 				B550E04029AF219100050F19 /* Did.swift in Sources */,


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/910

> (Informational) Welcome to subconscious [Next]
> (Informational) "Your sphere stores all your data" [Create sphere]
> (Sphere created) Show mnemonic [I've written it down]
> Nickname [Next]
> Invite code [Redeem]

# Changes
- Extract invite code form to new `FirstRunInviteView` step
- Re-order steps based on above description
- Wait to `.createSphere` until the `FIrstRunSphereView` step is submitted
- Introduce a new visualization `FirstRunOrbitEffectView`
- Normalize spacing between all "FirstRun" type screens
- Reduce jank when showing/hiding logo based on keyboard focus

# TODO
- [x] Tidy code in `FirstRunOrbitEffectView`
- [ ] Finalize copy

# Demo

https://github.com/subconsciousnetwork/subconscious/assets/5009316/a19e58e8-81f9-4efc-a4ea-8ef37dc02e94
