### PR TITLE
Persist selected `AppTab` in `UserDefaults`

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -1091,6 +1091,7 @@ struct AppModel: ModelProtocol {
         model.gatewayURL = AppDefaults.standard.gatewayURL
         model.gatewayId = AppDefaults.standard.gatewayId
         model.inviteCode = InviteCode(AppDefaults.standard.inviteCode ?? "")
+        model.selectedAppTab = AppTab(rawValue: AppDefaults.standard.selectedAppTab) ?? state.selectedAppTab
         
         // Update model from app defaults
         return update(
@@ -2407,6 +2408,8 @@ struct AppModel: ModelProtocol {
         
         var model = state
         model.selectedAppTab = tab
+        AppDefaults.standard.selectedAppTab = tab.rawValue
+        
         return Update(state: model)
     }
     

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -574,7 +574,7 @@ struct AppModel: ModelProtocol {
         self.databaseMigrationStatus == .succeeded
     }
     
-    var selectedAppTab: AppTab = .feed
+    var selectedAppTab: AppTab = .notebook
     
     // Logger for actions
     static let logger = Logger(

--- a/xcode/Subconscious/Shared/Services/AppDefaults.swift
+++ b/xcode/Subconscious/Shared/Services/AppDefaults.swift
@@ -25,4 +25,10 @@ struct AppDefaults {
     
     @UserDefaultsProperty(forKey: "inviteCode")
     var inviteCode: String? = nil
+    
+    @UserDefaultsProperty(forKey: "selectedAppTab")
+    // default to the notebook on first run because there will be nothing in the feed
+    // enums must be serialized when stored as AppDefaults:
+    // https://cocoacasts.com/ud-6-how-to-store-an-enum-in-user-defaults-in-swift
+    var selectedAppTab: String = AppTab.notebook.rawValue
 }


### PR DESCRIPTION
Tested on simulator and confirmed it works. 

I think the app should actually default to the `.notebook` view on first run, because the feed is always empty.