### PR TITLE
Fetch basic user metadata from SQLite if available

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -100,7 +100,6 @@ enum AppAction {
     
     /// Sent immediately upon store creation
     case start
-    case writeTestData
 
     case recoveryPhrase(RecoveryPhraseAction)
     case appUpgrade(AppUpgradeAction)
@@ -591,8 +590,6 @@ struct AppModel: ModelProtocol {
         environment: AppEnvironment
     ) -> Update<AppModel> {
         switch action {
-        case .writeTestData:
-            return writeTestData(state: state, environment: environment)
         case .start:
             return start(
                 state: state,
@@ -1083,39 +1080,6 @@ struct AppModel: ModelProtocol {
     ) -> Update<AppModel> {
         logger.log("\(message)")
         return Update(state: state)
-    }
-    
-    static func writeTestData(
-        state: AppModel,
-        environment: AppEnvironment
-    ) -> Update<Self> {
-        let now = Date.now
-        
-        let fx: Fx<AppAction> = Future.detached {
-            // do this 100 times
-            for _ in 0..<100 {
-                // generate a random string
-                let randomString = UUID().uuidString
-                // create a memo
-                let memo = Memo(
-                    contentType: "text/subtext",
-                    created: now,
-                    modified: now,
-                    fileExtension: "subtext",
-                    additionalHeaders: [],
-                    body: String.dummyDataMedium()
-                )
-                try await environment.data.writeMemo(address: Slashlink(slug: Slug.dummyData()), memo: memo)
-            }
-            
-            return AppAction.ready
-        }
-        .recover { error in
-            return AppAction.ready
-        }
-        .eraseToAnyPublisher()
-        
-        return Update(state: state, fx: fx)
     }
     
     static func start(

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -100,6 +100,7 @@ enum AppAction {
     
     /// Sent immediately upon store creation
     case start
+    case writeTestData
 
     case recoveryPhrase(RecoveryPhraseAction)
     case appUpgrade(AppUpgradeAction)
@@ -590,6 +591,8 @@ struct AppModel: ModelProtocol {
         environment: AppEnvironment
     ) -> Update<AppModel> {
         switch action {
+        case .writeTestData:
+            return writeTestData(state: state, environment: environment)
         case .start:
             return start(
                 state: state,
@@ -1080,6 +1083,39 @@ struct AppModel: ModelProtocol {
     ) -> Update<AppModel> {
         logger.log("\(message)")
         return Update(state: state)
+    }
+    
+    static func writeTestData(
+        state: AppModel,
+        environment: AppEnvironment
+    ) -> Update<Self> {
+        let now = Date.now
+        
+        let fx: Fx<AppAction> = Future.detached {
+            // do this 100 times
+            for _ in 0..<100 {
+                // generate a random string
+                let randomString = UUID().uuidString
+                // create a memo
+                let memo = Memo(
+                    contentType: "text/subtext",
+                    created: now,
+                    modified: now,
+                    fileExtension: "subtext",
+                    additionalHeaders: [],
+                    body: String.dummyDataMedium()
+                )
+                try await environment.data.writeMemo(address: Slashlink(slug: Slug.dummyData()), memo: memo)
+            }
+            
+            return AppAction.ready
+        }
+        .recover { error in
+            return AppAction.ready
+        }
+        .eraseToAnyPublisher()
+        
+        return Update(state: state, fx: fx)
     }
     
     static func start(

--- a/xcode/Subconscious/Shared/Components/BacklinksView.swift
+++ b/xcode/Subconscious/Shared/Components/BacklinksView.swift
@@ -21,9 +21,7 @@ struct BacklinksView: View {
             if backlinks.count > 0 {
                 ForEach(backlinks) { entry in
                     TranscludeView(
-                        author: entry.author,
-                        address: entry.address,
-                        excerpt: entry.excerpt,
+                        entry: entry,
                         action: {
                             onSelect(EntryLink(entry))
                         }
@@ -55,22 +53,19 @@ struct BacklinksView_Previews: PreviewProvider {
                         did: Did.dummyData(),
                         address: Slashlink("@handle/short")!,
                         excerpt: "Short",
-                        modified: Date.now,
-                        author: UserProfile.dummyData()
+                        modified: Date.now
                     ),
                     EntryStub(
                         did: Did.dummyData(),
                         address: Slashlink("/loomings")!,
                         excerpt: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.",
-                        modified: Date.now,
-                        author: UserProfile.dummyData()
+                        modified: Date.now
                     ),
                     EntryStub(
                         did: Did.dummyData(),
                         address: Slashlink(slug: Slug(formatting: "The Lee Shore")!),
                         excerpt: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.",
-                        modified: Date.now,
-                        author: UserProfile.dummyData()
+                        modified: Date.now
                     )
                 ],
                 onSelect: { title in }

--- a/xcode/Subconscious/Shared/Components/BacklinksView.swift
+++ b/xcode/Subconscious/Shared/Components/BacklinksView.swift
@@ -52,18 +52,21 @@ struct BacklinksView_Previews: PreviewProvider {
             BacklinksView(
                 backlinks: [
                     EntryStub(
+                        did: Did.dummyData(),
                         address: Slashlink("@handle/short")!,
                         excerpt: "Short",
                         modified: Date.now,
                         author: UserProfile.dummyData()
                     ),
                     EntryStub(
+                        did: Did.dummyData(),
                         address: Slashlink("/loomings")!,
                         excerpt: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.",
                         modified: Date.now,
                         author: UserProfile.dummyData()
                     ),
                     EntryStub(
+                        did: Did.dummyData(),
                         address: Slashlink(slug: Slug(formatting: "The Lee Shore")!),
                         excerpt: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi.",
                         modified: Date.now,

--- a/xcode/Subconscious/Shared/Components/Common/Byline/PetnameView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Byline/PetnameView.swift
@@ -8,9 +8,8 @@
 import SwiftUI
 
 public enum NameVariant {
-    case petname(Slashlink, Petname.Name)
-    case proposedName(Slashlink, Petname.Name)
-    case selfNickname(Slashlink, Petname.Name)
+    case known(Slashlink, Petname.Name)
+    case unknown(Slashlink, Petname.Name)
 }
 
 extension UserProfile {
@@ -22,13 +21,13 @@ extension UserProfile {
             self.address.petname?.leaf
         ) {
         case (.ourself, _, .some(let selfNickname), _):
-            return NameVariant.petname(Slashlink.ourProfile, selfNickname)
+            return NameVariant.known(Slashlink.ourProfile, selfNickname)
         case (_, .following(let petname), _, _):
-            return NameVariant.petname(self.address, petname)
+            return NameVariant.known(self.address, petname)
         case (_, .notFollowing, .some(let selfNickname), _):
-            return NameVariant.selfNickname(self.address, selfNickname)
+            return NameVariant.unknown(self.address, selfNickname)
         case (_, .notFollowing, _, .some(let proposedName)):
-            return NameVariant.proposedName(self.address, proposedName)
+            return NameVariant.unknown(self.address, proposedName)
         case _:
             return nil
         }
@@ -68,7 +67,7 @@ struct PetnameView: View {
     
     var uniqueAliases: [Petname] {
         switch name {
-        case .petname(_, let name):
+        case .known(_, let name):
             return aliases.filter { alias in
                 name != alias.leaf
             }
@@ -80,7 +79,7 @@ struct PetnameView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.unit) {
             switch name {
-            case .petname(_, let name):
+            case .known(_, let name):
                 Text(name.toPetname().markup)
                     .fontWeight(.medium)
                     .foregroundColor(.accentColor)
@@ -88,8 +87,7 @@ struct PetnameView: View {
                 if !uniqueAliases.isEmpty {
                     AliasView(aliases: uniqueAliases)
                 }
-            case .selfNickname(let address, let name),
-                 .proposedName(let address, let name):
+            case .unknown(let address, let name):
                 Text(showMaybePrefix
                      ? "Maybe: \(name.description)"
                      : name.description
@@ -104,32 +102,24 @@ struct PetnameView: View {
         }
     }
     
-    
-    
     struct PetnameView_Previews: PreviewProvider {
         static var previews: some View {
             VStack {
                 PetnameView(
-                    name: .selfNickname(
-                        Slashlink(petname: Petname("melville.bobby.tables")!),
-                        Petname.Name("melville")!
-                    )
-                )
-                PetnameView(
-                    name: .proposedName(
+                    name: .unknown(
                         Slashlink(petname: Petname("melville.bobby.tables")!),
                         Petname.Name("melville")!
                     ),
                     showMaybePrefix: true
                 )
                 PetnameView(
-                    name: .petname(
+                    name: .known(
                         Slashlink(petname: Petname("robert")!),
                         Petname.Name("robert")!
                     )
                 )
                 PetnameView(
-                    name: .petname(
+                    name: .known(
                         Slashlink(petname: Petname("robert")!),
                         Petname.Name("robert")!
                     ),

--- a/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
@@ -58,8 +58,7 @@ struct EntryRow_Previews: PreviewProvider {
                              Anything that can be derived should be derived.
                              Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply.
                              """,
-                    modified: Date.now,
-                    author: nil
+                    modified: Date.now
                 )
             )
             EntryRow(
@@ -69,8 +68,7 @@ struct EntryRow_Previews: PreviewProvider {
                         "@here/anything-that-can-be-derived-should-be-derived"
                     )!,
                     excerpt: "Anything that can be derived should be derived. Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply.",
-                    modified: Date.now,
-                    author: nil
+                    modified: Date.now
                 )
             )
             EntryRow(
@@ -80,8 +78,7 @@ struct EntryRow_Previews: PreviewProvider {
                         "did:key:abc123/anything-that-can-be-derived-should-be-derived"
                     )!,
                     excerpt: "Anything that can be derived should be derived. Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply.",
-                    modified: Date.now,
-                    author: nil
+                    modified: Date.now
                 )
             )
             EntryRow(
@@ -91,8 +88,7 @@ struct EntryRow_Previews: PreviewProvider {
                         "did:subconscious:local/anything-that-can-be-derived-should-be-derived"
                     )!,
                     excerpt: "Anything that can be derived should be derived. Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply.",
-                    modified: Date.now,
-                    author: nil
+                    modified: Date.now
                 )
             )
         }

--- a/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
@@ -49,6 +49,7 @@ struct EntryRow_Previews: PreviewProvider {
         VStack {
             EntryRow(
                 entry: EntryStub(
+                    did: Did.dummyData(),
                     address: Slashlink(
                         peer: Peer.did(Did.local),
                         slug: Slug(formatting: "Anything that can be derived should be derived")!
@@ -63,6 +64,7 @@ struct EntryRow_Previews: PreviewProvider {
             )
             EntryRow(
                 entry: EntryStub(
+                    did: Did.dummyData(),
                     address: Slashlink(
                         "@here/anything-that-can-be-derived-should-be-derived"
                     )!,
@@ -73,6 +75,7 @@ struct EntryRow_Previews: PreviewProvider {
             )
             EntryRow(
                 entry: EntryStub(
+                    did: Did.dummyData(),
                     address: Slashlink(
                         "did:key:abc123/anything-that-can-be-derived-should-be-derived"
                     )!,
@@ -83,6 +86,7 @@ struct EntryRow_Previews: PreviewProvider {
             )
             EntryRow(
                 entry: EntryStub(
+                    did: Did.dummyData(),
                     address: Slashlink(
                         "did:subconscious:local/anything-that-can-be-derived-should-be-derived"
                     )!,

--- a/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/EditProfileSheet.swift
@@ -139,7 +139,6 @@ struct EditProfileSheet: View {
             pfp: pfp,
             bio: UserProfileBio(state.bioField.validated?.text ?? ""),
             category: .ourself,
-            resolutionStatus: .resolved(Cid("fake-for-preview")),
             ourFollowStatus: .notFollowing,
             aliases: []
         )

--- a/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/FollowUserSheet.swift
@@ -207,7 +207,7 @@ struct FollowUserSheet: View {
                    let name = state.followUserForm.petname.validated {
                     HStack(spacing: AppTheme.padding) {
                         ProfilePic(pfp: user.pfp, size: .large)
-                        PetnameView(name: .proposedName(user.address, name))
+                        PetnameView(name: .unknown(user.address, name))
                     }
                     
                     Spacer()

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileHeaderView.swift
@@ -115,7 +115,6 @@ struct BylineLgView_Previews: PreviewProvider {
                     pfp: .image("pfp-dog"),
                     bio: UserProfileBio("Ploofy snooflewhumps burbled, outflonking the zibber-zabber in a traddlewaddle."),
                     category: .human,
-                    resolutionStatus: .resolved("abc"),
                     ourFollowStatus: .notFollowing,
                     aliases: [Petname("alt")!]
                 )
@@ -128,7 +127,6 @@ struct BylineLgView_Previews: PreviewProvider {
                     pfp: .image("pfp-dog"),
                     bio: UserProfileBio("Ploofy snooflewhumps burbled, outflonking the zibber-zabber in a traddlewaddle."),
                     category: .geist,
-                    resolutionStatus: .resolved(Cid("ok")),
                     ourFollowStatus: .following(Petname.Name("ben")!),
                     aliases: []
                 ),
@@ -142,7 +140,6 @@ struct BylineLgView_Previews: PreviewProvider {
                     pfp: .image("pfp-dog"),
                     bio: UserProfileBio("Ploofy snooflewhumps burbled, outflonking the zibber-zabber in a traddlewaddle."),
                     category: .ourself,
-                    resolutionStatus: .resolved(Cid("ok")),
                     ourFollowStatus: .notFollowing,
                     aliases: []
                 )

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -61,11 +61,12 @@ struct FollowTabView: View {
         ForEach(state.following) { follow in
             StoryUserView(
                 story: follow,
-                action: { _ in
-                    onNavigateToUser(Slashlink(petname: follow.entry.petname)) },
+                onNavigate: {
+                    onNavigateToUser(follow.user.address)
+                },
                 profileAction: onProfileAction,
                 onRefreshUser: {
-                    send(.requestWaitForFollowedUserResolution(follow.entry.petname))
+                    send(.requestWaitForFollowedUserResolution(follow.user.entry.petname))
                 }
             )
         }

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -54,21 +54,18 @@ struct RecentTabView: View {
 struct FollowTabView: View {
     var state: UserProfileDetailModel
     var send: (UserProfileDetailAction) -> Void
-    var onNavigateToUser: (UserProfile) -> Void
+    var onNavigateToUser: (Slashlink) -> Void
     var onProfileAction: (UserProfile, UserProfileAction) -> Void
     
     var body: some View {
         ForEach(state.following) { follow in
             StoryUserView(
                 story: follow,
-                action: { _ in onNavigateToUser(follow.user) },
+                action: { _ in
+                    onNavigateToUser(Slashlink(petname: follow.entry.petname)) },
                 profileAction: onProfileAction,
                 onRefreshUser: {
-                    guard let petname = follow.user.address.toPetname() else {
-                        return
-                    }
-                    
-                    send(.requestWaitForFollowedUserResolution(petname))
+                    send(.requestWaitForFollowedUserResolution(follow.entry.petname))
                 }
             )
         }
@@ -93,7 +90,7 @@ struct UserProfileView: View {
     }
     
     var onNavigateToNote: (Slashlink) -> Void
-    var onNavigateToUser: (UserProfile) -> Void
+    var onNavigateToUser: (Slashlink) -> Void
     
     var onProfileAction: (UserProfile, UserProfileAction) -> Void
     var onRefresh: () async -> Void

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -66,7 +66,7 @@ struct FollowTabView: View {
                 },
                 profileAction: onProfileAction,
                 onRefreshUser: {
-                    send(.requestWaitForFollowedUserResolution(follow.user.entry.petname))
+                    send(.requestWaitForFollowedUserResolution(follow.entry.petname))
                 }
             )
         }

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -31,16 +31,13 @@ struct RecentTabView: View {
     var onNavigateToNote: (Slashlink) -> Void
     
     var body: some View {
-        if let user = state.user {
-            ForEach(state.recentEntries) { entry in
-                StoryEntryView(
-                    story: StoryEntry(
-                        author: user,
-                        entry: entry
-                    ),
-                    action: { address, _ in onNavigateToNote(address) }
-                )
-            }
+        ForEach(state.recentEntries) { entry in
+            StoryEntryView(
+                story: StoryEntry(
+                    entry: entry
+                ),
+                action: { address, _ in onNavigateToNote(address) }
+            )
         }
         
         if state.recentEntries.count == 0 {

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryComboView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryComboView.swift
@@ -30,9 +30,7 @@ struct StoryComboView: View {
                 Text(story.prompt)
                 
                 TranscludeView(
-                    author: UserProfile.dummyData(),
-                    address: story.entryA.address,
-                    excerpt: story.entryA.excerpt,
+                    entry: story.entryA,
                     action: {
                         action(
                             story.entryA.address,
@@ -42,9 +40,7 @@ struct StoryComboView: View {
                 )
                 
                 TranscludeView(
-                    author: UserProfile.dummyData(),
-                    address: story.entryB.address,
-                    excerpt: story.entryB.excerpt,
+                    entry: story.entryB,
                     action: {
                         action(
                             story.entryB.address,

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryComboView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryComboView.swift
@@ -97,7 +97,8 @@ struct StoryComboView_Previews: PreviewProvider {
                             But do we have to go to distant worlds to find other kinds of replicator and other, consequent, kinds of evolution? I think that a new kind of replicator has recently emerged on this very planet. It is staring us in the face.
                             """
                         )
-                    )
+                    ),
+                    did: Did.dummyData()
                 ),
                 entryB: EntryStub(
                     MemoEntry(
@@ -117,7 +118,8 @@ struct StoryComboView_Previews: PreviewProvider {
                             But do we have to go to distant worlds to find other kinds of replicator and other, consequent, kinds of evolution? I think that a new kind of replicator has recently emerged on this very planet. It is staring us in the face.
                             """
                         )
-                    )
+                    ),
+                    did: Did.dummyData()
                 )
             ),
             action: { link, fallback in }

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
@@ -84,7 +84,8 @@ struct StoryPlainView_Previews: PreviewProvider {
                             But do we have to go to distant worlds to find other kinds of replicator and other, consequent, kinds of evolution? I think that a new kind of replicator has recently emerged on this very planet. It is staring us in the face.
                             """
                         )
-                    )
+                    ),
+                    did: Did.dummyData()
                 )
             ),
             action: { _, _ in }

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
@@ -27,11 +27,8 @@ struct StoryEntryView: View {
                     
                     HStack(alignment: .center, spacing: AppTheme.unit) {
                         BylineSmView(
-                            pfp: story.author.pfp,
-                            slashlink: Slashlink(
-                                peer: story.author.address.peer,
-                                slug: story.entry.address.slug
-                            )
+                            pfp: .generated(story.entry.did),
+                            slashlink: story.entry.address
                         )
                         
                         Spacer()
@@ -68,7 +65,6 @@ struct StoryPlainView_Previews: PreviewProvider {
     static var previews: some View {
         StoryEntryView(
             story: StoryEntry(
-                author: UserProfile.dummyData(),
                 entry: EntryStub(
                     MemoEntry(
                         address: Slashlink("@here/meme")!,

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryPromptView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryPromptView.swift
@@ -82,7 +82,8 @@ struct StoryPromptView_Previews: PreviewProvider {
                             But do we have to go to distant worlds to find other kinds of replicator and other, consequent, kinds of evolution? I think that a new kind of replicator has recently emerged on this very planet. It is staring us in the face.
                             """
                         )
-                    )
+                    ),
+                    did: Did.dummyData()
                 ),
                 prompt: "Can I invert this?"
             ),

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryPromptView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryPromptView.swift
@@ -29,9 +29,7 @@ struct StoryPromptView: View {
             VStack(alignment: .leading, spacing: AppTheme.unit4) {
                 Text(story.prompt)
                 TranscludeView(
-                    author: UserProfile.dummyData(),
-                    address: story.entry.address,
-                    excerpt: story.entry.excerpt,
+                    entry: story.entry,
                     action: {
                         action(
                             story.entry.address,

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
@@ -57,7 +57,7 @@ struct StoryUserView: View {
                     
                     Spacer()
                     
-                    switch story.user.resolutionStatus {
+                    switch story.addressBookEntry.status {
                     case .unresolved:
                         Image(systemName: "person.fill.questionmark")
                             .foregroundColor(.secondary)
@@ -77,7 +77,7 @@ struct StoryUserView: View {
                         }
                     }
                 }
-                .disabled(!story.user.resolutionStatus.isReady)
+                .disabled(!story.addressBookEntry.status.isReady)
                 
                 Menu(
                     content: {
@@ -134,7 +134,7 @@ struct StoryUserView: View {
         }
         .contentShape(.interaction, RectangleCroppedTopRightCorner())
         .onTapGesture {
-            switch (story.user.ourFollowStatus, story.user.resolutionStatus) {
+            switch (story.user.ourFollowStatus, story.addressBookEntry.status) {
             case (.following(_), .unresolved):
                 onRefreshUser()
             case (.following(let name), _):
@@ -160,9 +160,14 @@ struct StoryUserView_Previews: PreviewProvider {
                         pfp: .image("pfp-dog"),
                         bio: UserProfileBio("Ploofy snooflewhumps burbled, outflonking the zibber-zabber."),
                         category: .human,
-                        resolutionStatus: .unresolved,
                         ourFollowStatus: .notFollowing,
                         aliases: []
+                    ),
+                    addressBookEntry: AddressBookEntry(
+                        petname: Petname("ben")!,
+                        did: Did("did:key:123")!,
+                        status: .resolved("ok"),
+                        version: "ok"
                     )
                 ),
                 action: { _ in }
@@ -176,9 +181,14 @@ struct StoryUserView_Previews: PreviewProvider {
                         pfp: .image("pfp-dog"),
                         bio: UserProfileBio("Ploofy snooflewhumps burbled, outflonking the zibber-zabber."),
                         category: .human,
-                        resolutionStatus: .pending,
                         ourFollowStatus: .following(Petname.Name("lol")!),
                         aliases: []
+                    ),
+                    addressBookEntry: AddressBookEntry(
+                        petname: Petname("ben")!,
+                        did: Did("did:key:123")!,
+                        status: .resolved("ok"),
+                        version: "ok"
                     )
                 ),
                 action: { _ in }
@@ -192,9 +202,14 @@ struct StoryUserView_Previews: PreviewProvider {
                         pfp: .image("pfp-dog"),
                         bio: UserProfileBio("Ploofy snooflewhumps burbled, outflonking the zibber-zabber."),
                         category: .ourself,
-                        resolutionStatus: .resolved(Cid("ok")),
                         ourFollowStatus: .notFollowing,
                         aliases: []
+                    ),
+                    addressBookEntry: AddressBookEntry(
+                        petname: Petname("ben")!,
+                        did: Did("did:key:123")!,
+                        status: .resolved("ok"),
+                        version: "ok"
                     )
                 ),
                 action: { _ in }
@@ -208,9 +223,14 @@ struct StoryUserView_Previews: PreviewProvider {
                         pfp: .image("pfp-dog"),
                         bio: UserProfileBio.empty,
                         category: .ourself,
-                        resolutionStatus: .pending,
                         ourFollowStatus: .notFollowing,
                         aliases: []
+                    ),
+                    addressBookEntry: AddressBookEntry(
+                        petname: Petname("ben")!,
+                        did: Did("did:key:123")!,
+                        status: .resolved("ok"),
+                        version: "ok"
                     )
                 ),
                 action: { _ in }

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
@@ -56,7 +56,7 @@ struct StoryUserView: View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(alignment: .center, spacing: AppTheme.unit2) {
                 Group {
-                    ProfilePic(pfp: .generated(user.did), size: .medium)
+                    ProfilePic(pfp: user.pfp, size: .medium)
                     
                     if let name = user.toNameVariant() {
                         PetnameView(name: name, aliases: user.aliases)

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
@@ -40,14 +40,14 @@ struct StoryUserView: View {
     @Environment(\.colorScheme) var colorScheme
     
     var story: StoryUser
-    var action: (Slashlink) -> Void
+    var onNavigate: () -> Void
     
     var profileAction: (UserProfile, UserProfileAction) -> Void = { _, _ in }
     var onRefreshUser: () -> Void = {}
     
     var body: some View {
         switch (story.user) {
-        case let .unknown(entry):
+        case let .unknown(address, entry):
             VStack(alignment: .leading, spacing: 0) {
                 HStack(alignment: .center, spacing: AppTheme.unit2) {
                     Group {
@@ -97,7 +97,7 @@ struct StoryUserView: View {
                 case (.unresolved):
                     onRefreshUser()
                 case _:
-                    action(Slashlink(petname: entry.petname))
+                    onNavigate()
                 }
             }
             .background(.background)
@@ -193,10 +193,8 @@ struct StoryUserView: View {
                 switch (user.ourFollowStatus, entry.status) {
                 case (.following(_), .unresolved):
                     onRefreshUser()
-                case (.following(let name), _):
-                    action(Slashlink(petname: name.toPetname()))
-                case _:
-                    action(user.address)
+                default:
+                    onNavigate()
                 }
             }
             .background(.background)
@@ -229,7 +227,7 @@ struct StoryUserView_Previews: PreviewProvider {
                         )
                     )
                 ),
-                action: { _ in }
+                onNavigate: { }
             )
             StoryUserView(
                 story: StoryUser(
@@ -252,7 +250,7 @@ struct StoryUserView_Previews: PreviewProvider {
                         )
                     )
                 ),
-                action: { _ in }
+                onNavigate: { }
             )
             StoryUserView(
                 story: StoryUser(
@@ -275,7 +273,7 @@ struct StoryUserView_Previews: PreviewProvider {
                         )
                     )
                 ),
-                action: { _ in }
+                onNavigate: { }
             )
             StoryUserView(
                 story: StoryUser(
@@ -298,7 +296,7 @@ struct StoryUserView_Previews: PreviewProvider {
                         )
                     )
                 ),
-                action: { _ in }
+                onNavigate: { }
             )
             Spacer()
         }

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryUserView.swift
@@ -46,68 +46,34 @@ struct StoryUserView: View {
     var onRefreshUser: () -> Void = {}
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            HStack(alignment: .center, spacing: AppTheme.unit2) {
-                Group {
-                    ProfilePic(pfp: story.user.pfp, size: .medium)
-                    
-                    if let name = story.user.toNameVariant() {
-                        PetnameView(name: name, aliases: story.user.aliases)
-                    }
-                    
-                    Spacer()
-                    
-                    switch story.addressBookEntry.status {
-                    case .unresolved:
-                        Image(systemName: "person.fill.questionmark")
-                            .foregroundColor(.secondary)
-                    case .pending:
-                        PendingSyncBadge()
-                            .foregroundColor(.secondary)
-                    case .resolved:
-                        switch (story.user.ourFollowStatus, story.user.category) {
-                        case (.following(_), _):
-                            Image.from(appIcon: .following)
+        switch (story.user) {
+        case let .unknown(entry):
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(alignment: .center, spacing: AppTheme.unit2) {
+                    Group {
+                        ProfilePic(pfp: .generated(entry.did), size: .medium)
+                        PetnameView(name: .petname(Slashlink(petname: entry.petname), entry.name), aliases: [])
+                        
+                        Spacer()
+                        
+                        switch entry.status {
+                        case .unresolved:
+                            Image(systemName: "person.fill.questionmark")
                                 .foregroundColor(.secondary)
-                        case (_, .ourself):
-                            Image.from(appIcon: .you(colorScheme))
+                        case .pending:
+                            PendingSyncBadge()
                                 .foregroundColor(.secondary)
-                        case (_, _):
+                        case .resolved:
                             EmptyView()
                         }
                     }
-                }
-                .disabled(!story.addressBookEntry.status.isReady)
-                
-                Menu(
-                    content: {
-                        if story.user.isFollowedByUs {
+                    .disabled(!entry.status.isReady)
+                    
+                    Menu(
+                        content: {
                             Button(
                                 action: {
-                                    profileAction(story.user, .requestUnfollow)
-                                },
-                                label: {
-                                    Label(
-                                        title: { Text("Unfollow") },
-                                        icon: { Image(systemName: "person.fill.xmark") }
-                                    )
-                                }
-                            )
-                            Button(
-                                action: {
-                                    profileAction(story.user, .requestRename)
-                                },
-                                label: {
-                                    Label(
-                                        title: { Text("Rename") },
-                                        icon: { Image(systemName: "pencil") }
-                                    )
-                                }
-                            )
-                        } else {
-                            Button(
-                                action: {
-                                    profileAction(story.user, .requestFollow)
+//                                    profileAction(user, .requestFollow)
                                 },
                                 label: {
                                     Label(
@@ -116,34 +82,125 @@ struct StoryUserView: View {
                                     )
                                 }
                             )
+                        },
+                        label: {
+                            EllipsisLabelView()
                         }
-                    },
-                    label: {
-                        EllipsisLabelView()
+                    )
+                }
+                .padding(AppTheme.tightPadding)
+                .frame(height: AppTheme.unit * 13)
+            }
+            .contentShape(.interaction, RectangleCroppedTopRightCorner())
+            .onTapGesture {
+                switch (entry.status) {
+                case (.unresolved):
+                    onRefreshUser()
+                case _:
+                    action(Slashlink(petname: entry.petname))
+                }
+            }
+            .background(.background)
+        case let .known(user, entry):
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(alignment: .center, spacing: AppTheme.unit2) {
+                    Group {
+                        ProfilePic(pfp: .generated(entry.did), size: .medium)
+                        
+                        if let name = user.toNameVariant() {
+                            PetnameView(name: name, aliases: user.aliases)
+                        }
+                        
+                        Spacer()
+                        
+                        switch entry.status {
+                        case .unresolved:
+                            Image(systemName: "person.fill.questionmark")
+                                .foregroundColor(.secondary)
+                        case .pending:
+                            PendingSyncBadge()
+                                .foregroundColor(.secondary)
+                        case .resolved:
+                            switch (user.ourFollowStatus, user.category) {
+                            case (.following(_), _):
+                                Image.from(appIcon: .following)
+                                    .foregroundColor(.secondary)
+                            case (_, .ourself):
+                                Image.from(appIcon: .you(colorScheme))
+                                    .foregroundColor(.secondary)
+                            case (_, _):
+                                EmptyView()
+                            }
+                        }
                     }
-                ).disabled(story.user.category == .ourself)
+                    .disabled(!entry.status.isReady)
+                    
+                    Menu(
+                        content: {
+                            if user.isFollowedByUs {
+                                Button(
+                                    action: {
+                                        profileAction(user, .requestUnfollow)
+                                    },
+                                    label: {
+                                        Label(
+                                            title: { Text("Unfollow") },
+                                            icon: { Image(systemName: "person.fill.xmark") }
+                                        )
+                                    }
+                                )
+                                Button(
+                                    action: {
+                                        profileAction(user, .requestRename)
+                                    },
+                                    label: {
+                                        Label(
+                                            title: { Text("Rename") },
+                                            icon: { Image(systemName: "pencil") }
+                                        )
+                                    }
+                                )
+                            } else {
+                                Button(
+                                    action: {
+                                        profileAction(user, .requestFollow)
+                                    },
+                                    label: {
+                                        Label(
+                                            title: { Text("Follow") },
+                                            icon: { Image(systemName: "person.badge.plus") }
+                                        )
+                                    }
+                                )
+                            }
+                        },
+                        label: {
+                            EllipsisLabelView()
+                        }
+                    ).disabled(user.category == .ourself)
+                }
+                .padding(AppTheme.tightPadding)
+                .frame(height: AppTheme.unit * 13)
+                
+                if let bio = user.bio,
+                   bio.hasVisibleContent {
+                    Text(verbatim: bio.text)
+                        .padding(AppTheme.tightPadding)
+                }
             }
-            .padding(AppTheme.tightPadding)
-            .frame(height: AppTheme.unit * 13)
-            
-            if let bio = story.user.bio,
-               bio.hasVisibleContent {
-                Text(verbatim: bio.text)
-                    .padding(AppTheme.tightPadding)
+            .contentShape(.interaction, RectangleCroppedTopRightCorner())
+            .onTapGesture {
+                switch (user.ourFollowStatus, entry.status) {
+                case (.following(_), .unresolved):
+                    onRefreshUser()
+                case (.following(let name), _):
+                    action(Slashlink(petname: name.toPetname()))
+                case _:
+                    action(user.address)
+                }
             }
+            .background(.background)
         }
-        .contentShape(.interaction, RectangleCroppedTopRightCorner())
-        .onTapGesture {
-            switch (story.user.ourFollowStatus, story.addressBookEntry.status) {
-            case (.following(_), .unresolved):
-                onRefreshUser()
-            case (.following(let name), _):
-                action(Slashlink(petname: name.toPetname()))
-            case _:
-                action(story.user.address)
-            }
-        }
-        .background(.background)
     }
 }
 
@@ -153,84 +210,92 @@ struct StoryUserView_Previews: PreviewProvider {
             Spacer()
             StoryUserView(
                 story: StoryUser(
-                    user: UserProfile(
-                        did: Did("did:key:123")!,
-                        nickname: Petname.Name("ben")!,
-                        address: Slashlink(petname: Petname("ben.gordon.chris.bob")!),
-                        pfp: .image("pfp-dog"),
-                        bio: UserProfileBio("Ploofy snooflewhumps burbled, outflonking the zibber-zabber."),
-                        category: .human,
-                        ourFollowStatus: .notFollowing,
-                        aliases: []
-                    ),
-                    addressBookEntry: AddressBookEntry(
-                        petname: Petname("ben")!,
-                        did: Did("did:key:123")!,
-                        status: .resolved("ok"),
-                        version: "ok"
+                    user: .known(
+                        UserProfile(
+                            did: Did("did:key:123")!,
+                            nickname: Petname.Name("ben")!,
+                            address: Slashlink(petname: Petname("ben.gordon.chris.bob")!),
+                            pfp: .image("pfp-dog"),
+                            bio: UserProfileBio("Ploofy snooflewhumps burbled, outflonking the zibber-zabber."),
+                            category: .human,
+                            ourFollowStatus: .notFollowing,
+                            aliases: []
+                        ),
+                        AddressBookEntry(
+                            petname: Petname("ben")!,
+                            did: Did("did:key:123")!,
+                            status: .resolved("ok"),
+                            version: "ok"
+                        )
                     )
                 ),
                 action: { _ in }
             )
             StoryUserView(
                 story: StoryUser(
-                    user: UserProfile(
-                        did: Did("did:key:123")!,
-                        nickname: Petname.Name("ben")!,
-                        address: Slashlink(petname: Petname("ben.gordon.chris.bob")!),
-                        pfp: .image("pfp-dog"),
-                        bio: UserProfileBio("Ploofy snooflewhumps burbled, outflonking the zibber-zabber."),
-                        category: .human,
-                        ourFollowStatus: .following(Petname.Name("lol")!),
-                        aliases: []
-                    ),
-                    addressBookEntry: AddressBookEntry(
-                        petname: Petname("ben")!,
-                        did: Did("did:key:123")!,
-                        status: .resolved("ok"),
-                        version: "ok"
+                    user: .known(
+                        UserProfile(
+                            did: Did("did:key:123")!,
+                            nickname: Petname.Name("ben")!,
+                            address: Slashlink(petname: Petname("ben.gordon.chris.bob")!),
+                            pfp: .image("pfp-dog"),
+                            bio: UserProfileBio("Ploofy snooflewhumps burbled, outflonking the zibber-zabber."),
+                            category: .human,
+                            ourFollowStatus: .following(Petname.Name("lol")!),
+                            aliases: []
+                        ),
+                        AddressBookEntry(
+                            petname: Petname("ben")!,
+                            did: Did("did:key:123")!,
+                            status: .resolved("ok"),
+                            version: "ok"
+                        )
                     )
                 ),
                 action: { _ in }
             )
             StoryUserView(
                 story: StoryUser(
-                    user: UserProfile(
-                        did: Did("did:key:123")!,
-                        nickname: Petname.Name("ben")!,
-                        address: Slashlink(petname: Petname("ben.gordon.chris.bob")!),
-                        pfp: .image("pfp-dog"),
-                        bio: UserProfileBio("Ploofy snooflewhumps burbled, outflonking the zibber-zabber."),
-                        category: .ourself,
-                        ourFollowStatus: .notFollowing,
-                        aliases: []
-                    ),
-                    addressBookEntry: AddressBookEntry(
-                        petname: Petname("ben")!,
-                        did: Did("did:key:123")!,
-                        status: .resolved("ok"),
-                        version: "ok"
+                    user: .known(
+                        UserProfile(
+                            did: Did("did:key:123")!,
+                            nickname: Petname.Name("ben")!,
+                            address: Slashlink(petname: Petname("ben.gordon.chris.bob")!),
+                            pfp: .image("pfp-dog"),
+                            bio: UserProfileBio("Ploofy snooflewhumps burbled, outflonking the zibber-zabber."),
+                            category: .ourself,
+                            ourFollowStatus: .notFollowing,
+                            aliases: []
+                        ),
+                        AddressBookEntry(
+                            petname: Petname("ben")!,
+                            did: Did("did:key:123")!,
+                            status: .resolved("ok"),
+                            version: "ok"
+                        )
                     )
                 ),
                 action: { _ in }
             )
             StoryUserView(
                 story: StoryUser(
-                    user: UserProfile(
-                        did: Did("did:key:123")!,
-                        nickname: Petname.Name("ben")!,
-                        address: Slashlink(petname: Petname("ben.gordon.chris.bob")!),
-                        pfp: .image("pfp-dog"),
-                        bio: UserProfileBio.empty,
-                        category: .ourself,
-                        ourFollowStatus: .notFollowing,
-                        aliases: []
-                    ),
-                    addressBookEntry: AddressBookEntry(
-                        petname: Petname("ben")!,
-                        did: Did("did:key:123")!,
-                        status: .resolved("ok"),
-                        version: "ok"
+                    user: .known(
+                        UserProfile(
+                            did: Did("did:key:123")!,
+                            nickname: Petname.Name("ben")!,
+                            address: Slashlink(petname: Petname("ben.gordon.chris.bob")!),
+                            pfp: .image("pfp-dog"),
+                            bio: UserProfileBio.empty,
+                            category: .ourself,
+                            ourFollowStatus: .notFollowing,
+                            aliases: []
+                        ),
+                        AddressBookEntry(
+                            petname: Petname("ben")!,
+                            did: Did("did:key:123")!,
+                            status: .resolved("ok"),
+                            version: "ok"
+                        )
                     )
                 ),
                 action: { _ in }

--- a/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
@@ -71,9 +71,7 @@ struct SubtextView: View {
                 
                 ForEach(renderable.entries, id: \.self) { entry in
                     TranscludeView(
-                        author: entry.author,
-                        address: entry.address,
-                        excerpt: entry.excerpt,
+                        entry: entry,
                         action: {
                             onViewTransclude(entry.address)
                         }
@@ -124,8 +122,7 @@ struct SubtextView_Previews: PreviewProvider {
                             "/wanderer-your-footsteps-are-the-road"
                         )!,
                         excerpt: "hello mother",
-                        modified: Date.now,
-                        author: UserProfile.dummyData()
+                        modified: Date.now
                     ),
                     Slashlink("/voice")!: EntryStub(
                         did: Did.dummyData(),
@@ -133,8 +130,7 @@ struct SubtextView_Previews: PreviewProvider {
                             "/voice"
                         )!,
                         excerpt: "hello father",
-                        modified: Date.now,
-                        author: UserProfile.dummyData()
+                        modified: Date.now
                     ),
                     Slashlink("/memory")!: EntryStub(
                         did: Did.dummyData(),
@@ -142,8 +138,7 @@ struct SubtextView_Previews: PreviewProvider {
                             "/memory"
                         )!,
                         excerpt: "hello world",
-                        modified: Date.now,
-                        author: UserProfile.dummyData()
+                        modified: Date.now
                     )
                 ],
                 onViewTransclude: {

--- a/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
@@ -119,6 +119,7 @@ struct SubtextView_Previews: PreviewProvider {
                 ),
                 transcludePreviews: [
                     Slashlink("/wanderer-your-footsteps-are-the-road")!: EntryStub(
+                        did: Did.dummyData(),
                         address: Slashlink(
                             "/wanderer-your-footsteps-are-the-road"
                         )!,
@@ -127,6 +128,7 @@ struct SubtextView_Previews: PreviewProvider {
                         author: UserProfile.dummyData()
                     ),
                     Slashlink("/voice")!: EntryStub(
+                        did: Did.dummyData(),
                         address: Slashlink(
                             "/voice"
                         )!,
@@ -135,6 +137,7 @@ struct SubtextView_Previews: PreviewProvider {
                         author: UserProfile.dummyData()
                     ),
                     Slashlink("/memory")!: EntryStub(
+                        did: Did.dummyData(),
                         address: Slashlink(
                             "/memory"
                         )!,

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeView.swift
@@ -29,13 +29,11 @@ struct ExcerptView: View {
 }
 
 struct TranscludeView: View {
-    var author: UserProfile?
-    var address: Slashlink
-    var excerpt: String
+    var entry: EntryStub
     var action: () -> Void
     
     var excerptLines: [EnumeratedSequence<[String.SubSequence]>.Element] {
-        Array(excerpt.split(separator: "\n").enumerated())
+        Array(entry.excerpt.split(separator: "\n").enumerated())
     }
 
     var body: some View {
@@ -44,10 +42,10 @@ struct TranscludeView: View {
             label: {
                 VStack(alignment: .leading, spacing: AppTheme.unit2) {
                     BylineSmView(
-                        pfp: author?.pfp,
-                        slashlink: address
+                        pfp: .generated(entry.did),
+                        slashlink: entry.address
                     )
-                    ExcerptView(excerpt: excerpt)
+                    ExcerptView(excerpt: entry.excerpt)
                 }
             }
         )
@@ -59,38 +57,54 @@ struct TranscludeView_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
             TranscludeView(
-                author: UserProfile.dummyData(),
-                address: Slashlink("/short")!,
-                excerpt: "Short.",
+                entry: EntryStub(
+                    did: Did.dummyData(),
+                    address: Slashlink("/short")!,
+                    excerpt: "Short.",
+                    modified: Date.now
+                ),
                 action: { }
             )
             TranscludeView(
-                author: UserProfile.dummyData(),
-                address: Slashlink("@gordon/loomings")!,
-                excerpt: "Call me Ishmael. Some years ago- never mind how long precisely- having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little and see the watery part of the world. It is a way I have of driving off the spleen and regulating the circulation.",
+                entry: EntryStub(
+                    did: Did.dummyData(),
+                    address: Slashlink("@gordon/loomings")!,
+                    excerpt: "Call me Ishmael. Some years ago- never mind how long precisely- having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little and see the watery part of the world. It is a way I have of driving off the spleen and regulating the circulation.",
+                    modified: Date.now
+                ),
                 action: { }
             )
             TranscludeView(
-                author: UserProfile.dummyData(),
-                address: Slashlink("/loomings")!,
-                excerpt: "Call me Ishmael. Some years ago- never mind how long precisely",
+                entry: EntryStub(
+                    did: Did.dummyData(),
+                    address: Slashlink("/loomings")!,
+                    excerpt: "Call me Ishmael. Some years ago- never mind how long precisely",
+                    modified: Date.now
+                ),
                 action: { }
             )
             TranscludeView(
-                author: UserProfile.dummyData(),
-                address: Slashlink("did:subconscious:local/loomings")!,
-                excerpt: """
-                        Call me Ishmael.
-                        Some years ago- never mind how long precisely
-                        """,
+                entry: EntryStub(
+                    did: Did.dummyData(),
+                    address: Slashlink("did:subconscious:local/loomings")!,
+                    excerpt: """
+                            Call me Ishmael.
+                            Some years ago- never mind how long precisely
+                            """,
+                    modified: Date.now
+                ),
                 action: { }
             )
             TranscludeView(
-                author: UserProfile.dummyData(),
-                address: Slashlink("did:key:abc123/loomings")!,
-                excerpt: "Call me Ishmael. Some years ago- never mind how long precisely",
+                entry: EntryStub(
+                    did: Did.dummyData(),
+                    address: Slashlink("did:key:abc123/loomings")!,
+                    excerpt: "Call me Ishmael. Some years ago- never mind how long precisely",
+                    modified: Date.now
+                ),
                 action: { }
             )
+
         }
     }
 }

--- a/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
@@ -427,8 +427,10 @@ struct DetailStackModel: Hashable, ModelProtocol {
         environment: Environment
     ) -> Update<Self> {
         let fx: Fx<Action> = Future.detached {
+                let did = try await environment.noosphere.identity()
                 let user = try await environment.userProfile.buildUserProfile(
-                    address: Slashlink.ourProfile
+                    address: Slashlink.ourProfile,
+                    did: did
                 )
                 return Action.pushOurProfileDetail(user)
             }

--- a/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
@@ -119,7 +119,6 @@ enum DetailStackAction: Hashable {
     case pushDetail(MemoDetailDescription)
 
     case requestOurProfileDetail
-    case pushOurProfileDetail
     case failPushDetail(_ message: String)
 
     case pushRandomDetail(autofocus: Bool)
@@ -217,11 +216,6 @@ struct DetailStackModel: Hashable, ModelProtocol {
             )
         case .requestOurProfileDetail:
             return requestOurProfileDetail(
-                state: state,
-                environment: environment
-            )
-        case .pushOurProfileDetail:
-            return pushOurProfileDetail(
                 state: state,
                 environment: environment
             )
@@ -422,22 +416,6 @@ struct DetailStackModel: Hashable, ModelProtocol {
     }
 
     static func requestOurProfileDetail(
-        state: Self,
-        environment: Environment
-    ) -> Update<Self> {
-        // TODO: does nothing now
-        let fx: Fx<Action> = Future.detached {
-                return Action.pushOurProfileDetail
-            }
-            .recover { error in
-                Action.failPushDetail(error.localizedDescription)
-            }
-            .eraseToAnyPublisher()
-
-        return Update(state: state, fx: fx)
-    }
-
-    static func pushOurProfileDetail(
         state: Self,
         environment: Environment
     ) -> Update<Self> {

--- a/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
@@ -646,24 +646,10 @@ extension DetailStackAction {
         switch action {
         case let .requestDetail(detail):
             return .pushDetail(detail)
-        case let .requestNavigateToProfile(user):
-            let user = Func.run {
-                switch (user.category, user.ourFollowStatus) {
-                case (.ourself, _):
-                    // Loop back to our profile
-                    return user.overrideAddress(Slashlink.ourProfile)
-                case (_, .following(let name)):
-                    // Rewrite address using our name
-                    return user.overrideAddress(Slashlink(petname: name.toPetname()))
-                case _:
-                    return user
-                }
-            }
-
+        case let .requestNavigateToProfile(address):
             return .pushDetail(.profile(
                 UserProfileDetailDescription(
-                    address: user.address,
-                    user: user
+                    address: address
                 )
             ))
         }

--- a/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
@@ -443,6 +443,9 @@ struct DetailStackModel: Hashable, ModelProtocol {
     ) -> Update<Self> {
         let detail = UserProfileDetailDescription(
             address: Slashlink.ourProfile,
+            // Focus following list by default
+            // We can already see our recent notes in our notebook so no
+            // point showing it again
             initialTabIndex: UserProfileDetailModel.followingTabIndex
         )
         return update(

--- a/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
@@ -660,10 +660,6 @@ extension DetailStackAction {
                 }
             }
 
-
-            guard user.resolutionStatus.isReady else {
-                return .failPushDetail("Attempted to navigate to unresolved user")
-            }
             return .pushDetail(.profile(
                 UserProfileDetailDescription(
                     address: user.address,

--- a/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
@@ -426,10 +426,11 @@ struct DetailStackModel: Hashable, ModelProtocol {
         state: Self,
         environment: Environment
     ) -> Update<Self> {
-        let fx: Fx<Action> = environment.userProfile
-            .loadOurProfileFromMemoPublisher()
-            .map { user in
-                Action.pushOurProfileDetail(user)
+        let fx: Fx<Action> = Future.detached {
+                let user = try await environment.userProfile.buildUserProfile(
+                    address: Slashlink.ourProfile
+                )
+                return Action.pushOurProfileDetail(user)
             }
             .recover { error in
                 Action.failPushDetail(error.localizedDescription)

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -231,14 +231,14 @@ enum MemoViewerDetailNotification: Hashable {
         address: Slashlink,
         link: SubSlashlinkLink
     )
-    case requestUserProfileDetail(_ user: UserProfile)
+    case requestUserProfileDetail(_ address: Slashlink)
 }
 
 extension MemoViewerDetailNotification {
     static func from(_ action: MemoViewerDetailAction) -> Self? {
         switch action {
         case let .requestAuthorDetail(user):
-            return .requestUserProfileDetail(user)
+            return .requestUserProfileDetail(user.address)
         default:
             return nil
         }
@@ -561,10 +561,11 @@ struct MemoViewerDetailModel: ModelProtocol {
                         .profile
                 }
                 
+                let did = try await environment.noosphere.resolve(peer: state.address?.peer)
+                
                 return try await environment
                     .userProfile
-                    .requestUserProfile(petname: petname)
-                    .profile
+                    .identifyUser(did: did, petname: petname, context: nil)
             }
             .map { profile in
                 .succeedFetchOwnerProfile(profile)
@@ -651,6 +652,7 @@ struct MemoViewerDetailView_Previews: PreviewProvider {
             ),
             transcludePreviews: [
                 Slashlink("/infinity-paths")!: EntryStub(
+                    did: Did.dummyData(),
                     address: Slashlink(
                         "/infinity-paths"
                     )!,
@@ -670,12 +672,14 @@ struct MemoViewerDetailView_Previews: PreviewProvider {
         MemoViewerDetailNotFoundView(
             backlinks: [
                 EntryStub(
+                    did: Did.dummyData(),
                     address: Slashlink("@bob/bar")!,
                     excerpt: "The hidden well-spring of your soul must needs rise and run murmuring to the sea; And the treasure of your infinite depths would be revealed to your eyes. But let there be no scales to weigh your unknown treasure; And seek not the depths of your knowledge with staff or sounding line. For self is a sea boundless and measureless.",
                     modified: Date.now,
                     author: UserProfile.dummyData()
                 ),
                 EntryStub(
+                    did: Did.dummyData(),
                     address: Slashlink("@bob/baz")!,
                     excerpt: "Think you the spirit is a still pool which you can trouble with a staff? Oftentimes in denying yourself pleasure you do but store the desire in the recesses of your being. Who knows but that which seems omitted today, waits for tomorrow?",
                     modified: Date.now,

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -657,8 +657,7 @@ struct MemoViewerDetailView_Previews: PreviewProvider {
                         "/infinity-paths"
                     )!,
                     excerpt: "Say not, \"I have discovered the soul's destination,\" but rather, \"I have glimpsed the soul's journey, ever unfolding along the way.\"",
-                    modified: Date.now,
-                    author: UserProfile.dummyData()
+                    modified: Date.now
                 )
             ],
             address: Slashlink(slug: Slug("truth-the-prophet")!),
@@ -675,15 +674,13 @@ struct MemoViewerDetailView_Previews: PreviewProvider {
                     did: Did.dummyData(),
                     address: Slashlink("@bob/bar")!,
                     excerpt: "The hidden well-spring of your soul must needs rise and run murmuring to the sea; And the treasure of your infinite depths would be revealed to your eyes. But let there be no scales to weigh your unknown treasure; And seek not the depths of your knowledge with staff or sounding line. For self is a sea boundless and measureless.",
-                    modified: Date.now,
-                    author: UserProfile.dummyData()
+                    modified: Date.now
                 ),
                 EntryStub(
                     did: Did.dummyData(),
                     address: Slashlink("@bob/baz")!,
                     excerpt: "Think you the spirit is a still pool which you can trouble with a staff? Oftentimes in denying yourself pleasure you do but store the desire in the recesses of your being. Who knows but that which seems omitted today, waits for tomorrow?",
-                    modified: Date.now,
-                    author: UserProfile.dummyData()
+                    modified: Date.now
                 )
             ],
             notify: {

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -67,8 +67,7 @@ struct UserProfileDetailView: View {
             store.send(
                 UserProfileDetailAction.appear(
                     description.address,
-                    description.initialTabIndex,
-                    description.user
+                    description.initialTabIndex
                 )
             )
         }
@@ -127,7 +126,6 @@ extension UserProfileDetailAction {
 /// profile's internal state.
 struct UserProfileDetailDescription: Hashable {
     var address: Slashlink
-    var user: UserProfile?
     var initialTabIndex: Int = UserProfileDetailModel.recentEntriesTabIndex
 }
 
@@ -137,7 +135,7 @@ enum UserProfileDetailAction {
         category: "UserProfileDetailAction"
     )
 
-    case appear(Slashlink, Int, UserProfile?)
+    case appear(Slashlink, Int)
     case refresh(forceSync: Bool)
     case populate(UserProfileContentResponse)
     case failedToPopulate(String)
@@ -409,13 +407,12 @@ struct UserProfileDetailModel: ModelProtocol {
                 state: state,
                 environment: environment
             )
-        case .appear(let address, let initialTabIndex, let user):
+        case .appear(let address, let initialTabIndex):
             return appear(
                 state: state,
                 environment: environment,
                 address: address,
-                initialTabIndex: initialTabIndex,
-                user: user
+                initialTabIndex: initialTabIndex
             )
         case .populate(let content):
             return populate(
@@ -627,7 +624,7 @@ struct UserProfileDetailModel: ModelProtocol {
         
         return update(
             state: state,
-            action: .appear(user.address, state.initialTabIndex, state.user),
+            action: .appear(user.address, state.initialTabIndex),
             environment: environment
         )
     }
@@ -636,15 +633,13 @@ struct UserProfileDetailModel: ModelProtocol {
         state: Self,
         environment: Environment,
         address: Slashlink,
-        initialTabIndex: Int,
-        user: UserProfile?
+        initialTabIndex: Int
     ) -> Update<Self> {
         var model = state
         model.initialTabIndex = initialTabIndex
         // We might be passed some basic profile data
         // we can use this in the loading state for a preview
         model.address = address
-        model.user = user
         
         let fx: Fx<UserProfileDetailAction> = Future.detached {
             try await Self.refresh(address: address, environment: environment)

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -31,8 +31,8 @@ struct UserProfileDetailView: View {
         notify(.requestDetail(.from(address: address, fallback: "")))
     }
     
-    func onNavigateToUser(user: UserProfile) {
-        notify(.requestNavigateToProfile(user))
+    func onNavigateToUser(address: Slashlink) {
+        notify(.requestNavigateToProfile(address))
     }
     
     func onProfileAction(user: UserProfile, action: UserProfileAction) {
@@ -91,7 +91,7 @@ struct UserProfileDetailView: View {
 /// Actions forwarded up to the parent context to notify it of specific
 /// lifecycle events that happened within our component.
 enum UserProfileDetailNotification: Hashable {
-    case requestNavigateToProfile(_ user: UserProfile)
+    case requestNavigateToProfile(_ address: Slashlink)
     case requestDetail(MemoDetailDescription)
 }
 

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -220,7 +220,7 @@ struct UserProfile: Equatable, Codable, Hashable {
     let pfp: ProfilePicVariant
     let bio: UserProfileBio?
     let category: UserCategory
-    let resolutionStatus: ResolutionStatus
+//    let resolutionStatus: ResolutionStatus
     let ourFollowStatus: UserProfileFollowStatus
     let aliases: [Petname]
     
@@ -252,7 +252,7 @@ struct UserProfile: Equatable, Codable, Hashable {
             pfp: pfp,
             bio: bio,
             category: category,
-            resolutionStatus: resolutionStatus,
+//            resolutionStatus: resolutionStatus,
             ourFollowStatus: ourFollowStatus,
             aliases: aliases
         )

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -218,7 +218,6 @@ struct UserProfile: Equatable, Codable, Hashable {
     let pfp: ProfilePicVariant
     let bio: UserProfileBio?
     let category: UserCategory
-//    let resolutionStatus: ResolutionStatus
     let ourFollowStatus: UserProfileFollowStatus
     let aliases: [Petname]
     
@@ -250,7 +249,6 @@ struct UserProfile: Equatable, Codable, Hashable {
             pfp: pfp,
             bio: bio,
             category: category,
-//            resolutionStatus: resolutionStatus,
             ourFollowStatus: ourFollowStatus,
             aliases: aliases
         )

--- a/xcode/Subconscious/Shared/Components/Feed.swift
+++ b/xcode/Subconscious/Shared/Components/Feed.swift
@@ -30,22 +30,19 @@ struct FeedNavigationView: View {
                         FeedPlaceholderView()
                     case let (.loaded, .some(feed)):
                         ForEach(feed) { entry in
-                            if let author = entry.author {
-                                StoryEntryView(
-                                    story: StoryEntry(
-                                        author: author,
-                                        entry: entry
-                                    ),
-                                    action: { address, _ in
-                                        store.send(.detailStack(.pushDetail(
-                                            MemoDetailDescription.from(
-                                                address: address,
-                                                fallback: ""
-                                            )
-                                        )))
-                                    }
-                                )
-                            }
+                            StoryEntryView(
+                                story: StoryEntry(
+                                    entry: entry
+                                ),
+                                action: { address, _ in
+                                    store.send(.detailStack(.pushDetail(
+                                        MemoDetailDescription.from(
+                                            address: address,
+                                            fallback: ""
+                                        )
+                                    )))
+                                }
+                            )
                         }
                         
                         if feed.isEmpty {

--- a/xcode/Subconscious/Shared/Components/Settings/DeveloperSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/DeveloperSettingsView.swift
@@ -21,6 +21,15 @@ struct DeveloperSettingsView: View {
                     Text("Reset First Run Experience")
                 }
             )
+            
+            Button(
+                action: {
+                    app.send(.writeTestData)
+                },
+                label: {
+                    Text("Write Test Data")
+                }
+            )
         }
         .navigationTitle("Developer")
     }

--- a/xcode/Subconscious/Shared/Components/Settings/DeveloperSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/DeveloperSettingsView.swift
@@ -21,15 +21,6 @@ struct DeveloperSettingsView: View {
                     Text("Reset First Run Experience")
                 }
             )
-            
-            Button(
-                action: {
-                    app.send(.writeTestData)
-                },
-                label: {
-                    Text("Write Test Data")
-                }
-            )
         }
         .navigationTitle("Developer")
     }

--- a/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
@@ -99,27 +99,28 @@ extension StoryUser: DummyData {
     static func dummyData() -> StoryUser {
         let nickname = Petname.Name.dummyData()
         return StoryUser(
-            user: UserProfile.dummyData(),
-            addressBookEntry: AddressBookEntry.dummyData()
+            user: .known(UserProfile.dummyData(), AddressBookEntry.dummyData())
         )
     }
     
     static func dummyData(petname: Petname) -> StoryUser {
         StoryUser(
-            user: UserProfile(
-                did: Did.dummyData(),
-                nickname: petname.leaf,
-                address: Slashlink(petname: petname),
-                pfp: .image(String.dummyProfilePicture()),
-                bio: UserProfileBio.dummyData(),
-                category: [UserCategory.human, UserCategory.geist].randomElement()!,
-                ourFollowStatus: [
-                    .following(Petname.Name.dummyData()),
-                    .notFollowing
-                ].randomElement()!,
-                aliases: []
-            ),
-            addressBookEntry: AddressBookEntry.dummyData()
+            user: .known(
+                UserProfile(
+                    did: Did.dummyData(),
+                    nickname: petname.leaf,
+                    address: Slashlink(petname: petname),
+                    pfp: .image(String.dummyProfilePicture()),
+                    bio: UserProfileBio.dummyData(),
+                    category: [UserCategory.human, UserCategory.geist].randomElement()!,
+                    ourFollowStatus: [
+                        .following(Petname.Name.dummyData()),
+                        .notFollowing
+                    ].randomElement()!,
+                    aliases: []
+                ),
+                AddressBookEntry.dummyData()
+            )
         )
     }
 }

--- a/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
@@ -84,24 +84,23 @@ extension Petname: DummyData {
     }
 }
 
+extension AddressBookEntry: DummyData {
+    static func dummyData() -> AddressBookEntry {
+        AddressBookEntry(
+            petname: Petname.dummyData(),
+            did: Did.dummyData(),
+            status: .pending,
+            version: Cid.dummyDataMedium()
+        )
+    }
+}
+
 extension StoryUser: DummyData {
     static func dummyData() -> StoryUser {
         let nickname = Petname.Name.dummyData()
         return StoryUser(
-            user: UserProfile(
-                did: Did.dummyData(),
-                nickname: nickname,
-                address: Slashlink(petname: nickname.toPetname()),
-                pfp: .image(String.dummyProfilePicture()),
-                bio: UserProfileBio.dummyData(),
-                category: [UserCategory.human, UserCategory.geist].randomElement()!,
-                resolutionStatus: .unresolved,
-                ourFollowStatus: [
-                    .following(Petname.Name.dummyData()),
-                    .notFollowing
-                ].randomElement()!,
-                aliases: []
-            )
+            user: UserProfile.dummyData(),
+            addressBookEntry: AddressBookEntry.dummyData()
         )
     }
     
@@ -114,13 +113,13 @@ extension StoryUser: DummyData {
                 pfp: .image(String.dummyProfilePicture()),
                 bio: UserProfileBio.dummyData(),
                 category: [UserCategory.human, UserCategory.geist].randomElement()!,
-                resolutionStatus: .unresolved,
                 ourFollowStatus: [
                     .following(Petname.Name.dummyData()),
                     .notFollowing
                 ].randomElement()!,
                 aliases: []
-            )
+            ),
+            addressBookEntry: AddressBookEntry.dummyData()
         )
     }
 }
@@ -184,7 +183,6 @@ extension UserProfile: DummyData {
             pfp: .image(String.dummyProfilePicture()),
             bio: UserProfileBio.dummyData(),
             category: .human,
-            resolutionStatus: .unresolved,
             ourFollowStatus: .notFollowing,
             aliases: []
         )
@@ -201,7 +199,6 @@ extension UserProfile: DummyData {
             pfp: .image(String.dummyProfilePicture()),
             bio: UserProfileBio.dummyData(),
             category: category,
-            resolutionStatus: .unresolved,
             ourFollowStatus: .notFollowing,
             aliases: []
         )

--- a/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
@@ -161,7 +161,7 @@ extension EntryStub: DummyData {
         let excerpt = String.dummyDataMedium()
         let modified = Date().addingTimeInterval(TimeInterval(-86400 * Int.random(in: 0..<5)))
         
-        return EntryStub(address: address, excerpt: excerpt, modified: modified, author: UserProfile.dummyData())
+        return EntryStub(did: Did.dummyData(), address: address, excerpt: excerpt, modified: modified, author: UserProfile.dummyData())
     }
     
     static func dummyData(petname: Petname, slug: Slug) -> EntryStub {
@@ -170,7 +170,7 @@ extension EntryStub: DummyData {
         let excerpt = String.dummyDataMedium()
         let modified = Date().addingTimeInterval(TimeInterval(-86400 * Int.random(in: 0..<5)))
         
-        return EntryStub(address: address, excerpt: excerpt, modified: modified, author: UserProfile.dummyData())
+        return EntryStub(did: Did.dummyData(), address: address, excerpt: excerpt, modified: modified, author: UserProfile.dummyData())
     }
 }
 

--- a/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
@@ -97,29 +97,27 @@ extension AddressBookEntry: DummyData {
 
 extension StoryUser: DummyData {
     static func dummyData() -> StoryUser {
-        let nickname = Petname.Name.dummyData()
         return StoryUser(
-            user: .known(UserProfile.dummyData(), AddressBookEntry.dummyData())
+            entry: AddressBookEntry.dummyData(),
+            user: UserProfile.dummyData()
         )
     }
     
     static func dummyData(petname: Petname) -> StoryUser {
         StoryUser(
-            user: .known(
-                UserProfile(
-                    did: Did.dummyData(),
-                    nickname: petname.leaf,
-                    address: Slashlink(petname: petname),
-                    pfp: .image(String.dummyProfilePicture()),
-                    bio: UserProfileBio.dummyData(),
-                    category: [UserCategory.human, UserCategory.geist].randomElement()!,
-                    ourFollowStatus: [
-                        .following(Petname.Name.dummyData()),
-                        .notFollowing
-                    ].randomElement()!,
-                    aliases: []
-                ),
-                AddressBookEntry.dummyData()
+            entry: AddressBookEntry.dummyData(),
+            user: UserProfile(
+                did: Did.dummyData(),
+                nickname: petname.leaf,
+                address: Slashlink(petname: petname),
+                pfp: .image(String.dummyProfilePicture()),
+                bio: UserProfileBio.dummyData(),
+                category: [UserCategory.human, UserCategory.geist].randomElement()!,
+                ourFollowStatus: [
+                    .following(Petname.Name.dummyData()),
+                    .notFollowing
+                ].randomElement()!,
+                aliases: []
             )
         )
     }

--- a/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
@@ -159,7 +159,12 @@ extension EntryStub: DummyData {
         let excerpt = String.dummyDataMedium()
         let modified = Date().addingTimeInterval(TimeInterval(-86400 * Int.random(in: 0..<5)))
         
-        return EntryStub(did: Did.dummyData(), address: address, excerpt: excerpt, modified: modified, author: UserProfile.dummyData())
+        return EntryStub(
+            did: Did.dummyData(),
+            address: address,
+            excerpt: excerpt,
+            modified: modified
+        )
     }
     
     static func dummyData(petname: Petname, slug: Slug) -> EntryStub {
@@ -168,7 +173,12 @@ extension EntryStub: DummyData {
         let excerpt = String.dummyDataMedium()
         let modified = Date().addingTimeInterval(TimeInterval(-86400 * Int.random(in: 0..<5)))
         
-        return EntryStub(did: Did.dummyData(), address: address, excerpt: excerpt, modified: modified, author: UserProfile.dummyData())
+        return EntryStub(
+            did: Did.dummyData(),
+            address: address,
+            excerpt: excerpt,
+            modified: modified
+        )
     }
 }
 

--- a/xcode/Subconscious/Shared/Models/Entry.swift
+++ b/xcode/Subconscious/Shared/Models/Entry.swift
@@ -33,15 +33,6 @@ extension EntryStub {
         self.address = entry.address
         self.excerpt = entry.contents.excerpt()
         self.modified = entry.contents.modified
-        self.author = nil
         self.did = did
-    }
-    
-    init(_ entry: MemoEntry, author: UserProfile) {
-        self.address = entry.address
-        self.excerpt = entry.contents.excerpt()
-        self.modified = entry.contents.modified
-        self.author = author
-        self.did = author.did
     }
 }

--- a/xcode/Subconscious/Shared/Models/Entry.swift
+++ b/xcode/Subconscious/Shared/Models/Entry.swift
@@ -29,11 +29,12 @@ extension EntryLink {
 }
 
 extension EntryStub {
-    init(_ entry: MemoEntry) {
+    init(_ entry: MemoEntry, did: Did) {
         self.address = entry.address
         self.excerpt = entry.contents.excerpt()
         self.modified = entry.contents.modified
         self.author = nil
+        self.did = did
     }
     
     init(_ entry: MemoEntry, author: UserProfile) {
@@ -41,5 +42,6 @@ extension EntryStub {
         self.excerpt = entry.contents.excerpt()
         self.modified = entry.contents.modified
         self.author = author
+        self.did = author.did
     }
 }

--- a/xcode/Subconscious/Shared/Models/EntryStub.swift
+++ b/xcode/Subconscious/Shared/Models/EntryStub.swift
@@ -20,21 +20,10 @@ struct EntryStub:
     let address: Slashlink
     let excerpt: String
     let modified: Date
-    let author: UserProfile?
 
     var id: Slashlink { address }
     var debugDescription: String {
         "Subconscious.EntryStub(\(address))"
-    }
-    
-    func withAuthor(_ author: UserProfile) -> Self {
-        return Self(
-            did: did,
-            address: address,
-            excerpt: excerpt,
-            modified: modified,
-            author: author
-        )
     }
     
     func withAddress(_ address: Slashlink) -> Self {
@@ -42,8 +31,7 @@ struct EntryStub:
             did: did,
             address: address,
             excerpt: excerpt,
-            modified: modified,
-            author: author
+            modified: modified
         )
     }
 }

--- a/xcode/Subconscious/Shared/Models/EntryStub.swift
+++ b/xcode/Subconscious/Shared/Models/EntryStub.swift
@@ -16,6 +16,7 @@ struct EntryStub:
     CustomDebugStringConvertible,
     Codable
 {
+    let did: Did
     let address: Slashlink
     let excerpt: String
     let modified: Date
@@ -28,6 +29,7 @@ struct EntryStub:
     
     func withAuthor(_ author: UserProfile) -> Self {
         return Self(
+            did: did,
             address: address,
             excerpt: excerpt,
             modified: modified,
@@ -37,6 +39,7 @@ struct EntryStub:
     
     func withAddress(_ address: Slashlink) -> Self {
         return Self(
+            did: did,
             address: address,
             excerpt: excerpt,
             modified: modified,

--- a/xcode/Subconscious/Shared/Models/Slashlink.swift
+++ b/xcode/Subconscious/Shared/Models/Slashlink.swift
@@ -211,7 +211,11 @@ extension Slashlink {
     /// Given an address, re-base relative to the passed peer.
     /// If `@alice.bob/test` appears in a note owned by `@donna.charlie`
     /// then we want `@alice.bob.donna.charlie/test`
-    func rebaseIfNeeded(peer: Peer) -> Slashlink {
+    func rebaseIfNeeded(peer: Peer?) -> Slashlink {
+        guard let peer = peer else {
+            return self
+        }
+        
         switch (peer) {
         case .petname(let petname):
             return self.rebaseIfNeeded(petname: petname)

--- a/xcode/Subconscious/Shared/Models/StoryEntry.swift
+++ b/xcode/Subconscious/Shared/Models/StoryEntry.swift
@@ -15,12 +15,11 @@ struct StoryEntry:
     Codable
 {
     var id = UUID()
-    var author: UserProfile
+//    var author: UserProfile
     var entry: EntryStub
 
     var description: String {
         """
-        \(author.displayName)
         \(String(describing: entry))
         """
     }

--- a/xcode/Subconscious/Shared/Models/StoryEntry.swift
+++ b/xcode/Subconscious/Shared/Models/StoryEntry.swift
@@ -15,7 +15,6 @@ struct StoryEntry:
     Codable
 {
     var id = UUID()
-//    var author: UserProfile
     var entry: EntryStub
 
     var description: String {

--- a/xcode/Subconscious/Shared/Models/StoryUser.swift
+++ b/xcode/Subconscious/Shared/Models/StoryUser.swift
@@ -17,6 +17,7 @@ struct StoryUser:
     
     var id = UUID()
     var user: UserProfile
+    var addressBookEntry: AddressBookEntry
     var statistics: UserProfileStatistics?
 
     var description: String {

--- a/xcode/Subconscious/Shared/Models/StoryUser.swift
+++ b/xcode/Subconscious/Shared/Models/StoryUser.swift
@@ -8,31 +8,6 @@
 import Foundation
 import SwiftUI
 
-enum StoryUserVariant: Codable, Equatable, Hashable {
-    case unknown(Slashlink, AddressBookEntry)
-    case known(UserProfile, AddressBookEntry)
-}
-
-extension StoryUserVariant {
-    var entry: AddressBookEntry {
-        switch self {
-        case .unknown(_, let entry):
-            return entry
-        case .known(_, let entry):
-            return entry
-        }
-    }
-    
-    var address: Slashlink {
-        switch self {
-        case .unknown(let address, _):
-            return address
-        case .known(let user, _):
-            return user.address
-        }
-    }
-}
-
 /// Story prompt model
 struct StoryUser:
     Hashable,
@@ -41,15 +16,16 @@ struct StoryUser:
     Codable {
     
     var id = UUID()
-    var user: StoryUserVariant
+    var entry: AddressBookEntry
+    var user: UserProfile
     var statistics: UserProfileStatistics?
 
     var description: String {
         """
+        \(String(describing: user.did))
         \(String(describing: user.address))
-        \(String(describing: user.entry.did))
-        \(String(describing: user.entry.petname))
-        \(String(describing: user.entry.status))
+        \(String(describing: user.nickname))
+        \(String(describing: user.ourFollowStatus))
         """
     }
 }

--- a/xcode/Subconscious/Shared/Models/StoryUser.swift
+++ b/xcode/Subconscious/Shared/Models/StoryUser.swift
@@ -8,6 +8,22 @@
 import Foundation
 import SwiftUI
 
+enum StoryUserVariant: Codable, Equatable, Hashable {
+    case unknown(AddressBookEntry)
+    case known(UserProfile, AddressBookEntry)
+}
+
+extension StoryUserVariant {
+    var entry: AddressBookEntry {
+        switch self {
+        case .unknown(let entry):
+            return entry
+        case .known(_, let entry):
+            return entry
+        }
+    }
+}
+
 /// Story prompt model
 struct StoryUser:
     Hashable,
@@ -16,16 +32,23 @@ struct StoryUser:
     Codable {
     
     var id = UUID()
-    var user: UserProfile
-    var addressBookEntry: AddressBookEntry
+    var user: StoryUserVariant
     var statistics: UserProfileStatistics?
+    
+    var entry: AddressBookEntry {
+        switch user {
+        case .unknown(let entry):
+            return entry
+        case .known(_, let entry):
+            return entry
+        }
+    }
 
     var description: String {
         """
-        \(String(describing: user.nickname))
-        Following? \(user.isFollowedByUs)
-        
-        \(user.bio?.text ?? "")
+        \(String(describing: entry.did))
+        \(String(describing: entry.petname))
+        \(String(describing: entry.status))
         """
     }
 }

--- a/xcode/Subconscious/Shared/Models/StoryUser.swift
+++ b/xcode/Subconscious/Shared/Models/StoryUser.swift
@@ -9,17 +9,26 @@ import Foundation
 import SwiftUI
 
 enum StoryUserVariant: Codable, Equatable, Hashable {
-    case unknown(AddressBookEntry)
+    case unknown(Slashlink, AddressBookEntry)
     case known(UserProfile, AddressBookEntry)
 }
 
 extension StoryUserVariant {
     var entry: AddressBookEntry {
         switch self {
-        case .unknown(let entry):
+        case .unknown(_, let entry):
             return entry
         case .known(_, let entry):
             return entry
+        }
+    }
+    
+    var address: Slashlink {
+        switch self {
+        case .unknown(let address, _):
+            return address
+        case .known(let user, _):
+            return user.address
         }
     }
 }
@@ -34,21 +43,13 @@ struct StoryUser:
     var id = UUID()
     var user: StoryUserVariant
     var statistics: UserProfileStatistics?
-    
-    var entry: AddressBookEntry {
-        switch user {
-        case .unknown(let entry):
-            return entry
-        case .known(_, let entry):
-            return entry
-        }
-    }
 
     var description: String {
         """
-        \(String(describing: entry.did))
-        \(String(describing: entry.petname))
-        \(String(describing: entry.status))
+        \(String(describing: user.address))
+        \(String(describing: user.entry.did))
+        \(String(describing: user.entry.petname))
+        \(String(describing: user.entry.status))
         """
     }
 }

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -663,13 +663,7 @@ actor DataService {
         let identity = try await noosphere.identity()
         var feed: [EntryStub] = []
         for entry in try self.database.listFeed(owner: identity) {
-            let author = try await Func.run {
-                if entry.address.isOurs {
-                    return try await self.userProfile.loadOurProfileFromMemo()
-                } else {
-                    return try await self.userProfile.buildUserProfile(address: entry.address)
-                }
-            }
+            let author = try await self.userProfile.buildUserProfile(address: entry.address)
             feed.append(entry.withAuthor(author))
         }
         return feed

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -663,7 +663,11 @@ actor DataService {
         let identity = try await noosphere.identity()
         var feed: [EntryStub] = []
         for entry in try self.database.listFeed(owner: identity) {
-            let author = try await self.userProfile.identifyUser(did: entry.did, address: entry.address, context: nil)
+            let author = try await self.userProfile.identifyUser(
+                did: entry.did,
+                address: entry.address,
+                context: nil
+            )
             feed.append(entry.withAuthor(author))
         }
         return feed
@@ -848,7 +852,11 @@ actor DataService {
         
         var backlinks: [EntryStub] = []
         for entry in entries {
-            guard let author = try? await userProfile.identifyUser(did: entry.did, address: entry.address, context: address.peer) else {
+            guard let author = try? await userProfile.identifyUser(
+                did: entry.did,
+                address: entry.address,
+                context: address.peer
+            ) else {
                 logger.error("Failed to load author for \(entry.address)")
                 backlinks.append(entry)
                 continue

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -661,16 +661,7 @@ actor DataService {
     
     func listFeed() async throws -> [EntryStub] {
         let identity = try await noosphere.identity()
-        var feed: [EntryStub] = []
-        for entry in try self.database.listFeed(owner: identity) {
-            let author = try await self.userProfile.identifyUser(
-                did: entry.did,
-                address: entry.address,
-                context: nil
-            )
-            feed.append(entry.withAuthor(author))
-        }
-        return feed
+        return try self.database.listFeed(owner: identity)
     }
     
     nonisolated func listFeedPublisher() -> AnyPublisher<[EntryStub], Error> {
@@ -844,28 +835,11 @@ actor DataService {
         let identity = try? await noosphere.identity()
         let did = try await noosphere.resolve(peer: address.peer)
         
-        let entries = try database.readEntryBacklinks(
+        return try database.readEntryBacklinks(
             owner: identity,
             did: did,
             slug: address.slug
         )
-        
-        var backlinks: [EntryStub] = []
-        for entry in entries {
-            guard let author = try? await userProfile.identifyUser(
-                did: entry.did,
-                address: entry.address,
-                context: address.peer
-            ) else {
-                logger.error("Failed to load author for \(entry.address)")
-                backlinks.append(entry)
-                continue
-            }
-            
-            backlinks.append(entry.withAuthor(author))
-        }
-        
-        return backlinks
     }
 
     /// Read editor detail for address.

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -663,7 +663,7 @@ actor DataService {
         let identity = try await noosphere.identity()
         var feed: [EntryStub] = []
         for entry in try self.database.listFeed(owner: identity) {
-            let author = try await self.userProfile.buildUserProfile(address: entry.address, did: nil)
+            let author = try await self.userProfile.identifyUser(did: entry.did, address: entry.address, context: nil)
             feed.append(entry.withAuthor(author))
         }
         return feed
@@ -848,10 +848,7 @@ actor DataService {
         
         var backlinks: [EntryStub] = []
         for entry in entries {
-            guard let author = try? await userProfile.buildUserProfile(
-                address: entry.address,
-                did: nil
-            ) else {
+            guard let author = try? await userProfile.identifyUser(did: entry.did, address: entry.address, context: address.peer) else {
                 logger.error("Failed to load author for \(entry.address)")
                 backlinks.append(entry)
                 continue

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -663,7 +663,7 @@ actor DataService {
         let identity = try await noosphere.identity()
         var feed: [EntryStub] = []
         for entry in try self.database.listFeed(owner: identity) {
-            let author = try await self.userProfile.buildUserProfile(address: entry.address)
+            let author = try await self.userProfile.buildUserProfile(address: entry.address, did: nil)
             feed.append(entry.withAuthor(author))
         }
         return feed
@@ -849,7 +849,8 @@ actor DataService {
         var backlinks: [EntryStub] = []
         for entry in entries {
             guard let author = try? await userProfile.buildUserProfile(
-                address: entry.address
+                address: entry.address,
+                did: nil
             ) else {
                 logger.error("Failed to load author for \(entry.address)")
                 backlinks.append(entry)

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -494,11 +494,12 @@ final class DatabaseService {
             sql: """
             SELECT body
             FROM memo
-            WHERE did = ? AND slug = "_profile_"
+            WHERE did = ? AND slug = ?
             LIMIT 1
             """,
             parameters: [
-                .text(did.description)
+                .text(did.description),
+                .text(Slug.profile.description)
             ]
         )
         

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -534,7 +534,7 @@ final class DatabaseService {
         return results.compactMap({ row in
             guard
                 let did = row.col(0)?.toString()?.toDid(),
-                let address = row.col(1)?
+                let slashlink = row.col(1)?
                     .toString()?
                     .toSlashlink()?
                     .relativizeIfNeeded(did: owner),
@@ -545,7 +545,7 @@ final class DatabaseService {
             }
             return EntryStub(
                 did: did,
-                address: address,
+                address: slashlink,
                 excerpt: excerpt,
                 modified: modified
             )
@@ -584,6 +584,7 @@ final class DatabaseService {
                 let did = row.col(0)?.toString()?.toDid(),
                 let address = row.col(1)?
                     .toString()?
+                    .toLink()?
                     .toSlashlink()?
                     .relativizeIfNeeded(did: owner),
                 let modified = row.col(2)?.toDate(),
@@ -869,6 +870,7 @@ final class DatabaseService {
             .compactMap({ row in
                 row.col(0)?
                     .toString()?
+                    .toLink()?
                     .toSlashlink()?
                     .relativizeIfNeeded(did: owner)
             })
@@ -1163,8 +1165,8 @@ final class DatabaseService {
             sql: """
             SELECT did, id, modified, excerpt
             FROM memo_search
-            WHERE memo_search.description MATCH ?
-                AND substr(memo.slug, 1, 1) != '_'
+            WHERE description MATCH ?
+                AND substr(slug, 1, 1) != '_'
             ORDER BY RANDOM()
             LIMIT 1
             """,
@@ -1177,6 +1179,7 @@ final class DatabaseService {
                 let did = row.col(0)?.toString()?.toDid(),
                 let address = row.col(1)?
                     .toString()?
+                    .toLink()?
                     .toSlashlink()?
                     .relativizeIfNeeded(did: owner),
                 let modified = row.col(2)?.toDate(),

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -484,6 +484,31 @@ final class DatabaseService {
         .first
     }
     
+    func loadUserProfile(address: Slashlink) throws -> Data? {
+        guard self.state == .ready else {
+            throw DatabaseServiceError.notReady
+        }
+        
+        let results = try database.execute(
+            sql: """
+            SELECT body
+            FROM memo
+            WHERE slashlink = ? AND slug = "_profile_"
+            LIMIT 1
+            """,
+            parameters: [
+                .text(address.description)
+            ]
+        )
+        
+        guard let entry = results.first,
+              let excerpt = entry.col(0)?.toString() else {
+            return nil
+        }
+        
+        return excerpt.data(using: .utf8)
+    }
+    
     func listFeed(owner: Did) throws -> [EntryStub] {
         guard self.state == .ready else {
             throw DatabaseServiceError.notReady

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -484,7 +484,7 @@ final class DatabaseService {
         .first
     }
     
-    func loadUserProfile(did: Did) throws -> Data? {
+    func readUserProfile(did: Did) throws -> Data? {
         guard self.state == .ready else {
             throw DatabaseServiceError.notReady
         }

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -1079,8 +1079,8 @@ final class DatabaseService {
         return try? database.execute(
             sql: """
             SELECT did, id, modified, excerpt
-            FROM modified
-            WHERE modified.modified BETWEEN ? AND ?
+            FROM memo_search
+            WHERE memo_search.modified BETWEEN ? AND ?
                 AND substr(memo_search.slug, 1, 1) != '_'
             ORDER BY RANDOM()
             LIMIT 1

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -478,8 +478,7 @@ final class DatabaseService {
                 did: did,
                 address: address,
                 excerpt: excerpt,
-                modified: modified,
-                author: nil
+                modified: modified
             )
         })
         .first
@@ -548,8 +547,7 @@ final class DatabaseService {
                 did: did,
                 address: address,
                 excerpt: excerpt,
-                modified: modified,
-                author: nil
+                modified: modified
             )
         })
     }
@@ -597,8 +595,7 @@ final class DatabaseService {
                 did: did,
                 address: address,
                 excerpt: excerpt,
-                modified: modified,
-                author: nil
+                modified: modified
             )
         })
     }
@@ -1051,8 +1048,7 @@ final class DatabaseService {
                         slug: slug
                     ),
                     excerpt: excerpt,
-                    modified: modified,
-                    author: nil
+                    modified: modified
                 )
             case let (.none, .some(slug), .some(modified)):
                 let address = Slashlink(
@@ -1063,8 +1059,7 @@ final class DatabaseService {
                     did: did,
                     address: address,
                     excerpt: excerpt,
-                    modified: modified,
-                    author: nil
+                    modified: modified
                 )
             default:
                 return nil
@@ -1111,8 +1106,7 @@ final class DatabaseService {
                 did: did,
                 address: address,
                 excerpt: excerpt,
-                modified: modified,
-                author: nil
+                modified: modified
             )
         })
         .first
@@ -1150,8 +1144,7 @@ final class DatabaseService {
                 did: did,
                 address: address,
                 excerpt: excerpt,
-                modified: modified,
-                author: nil
+                modified: modified
             )
         })
         .first
@@ -1195,8 +1188,7 @@ final class DatabaseService {
                 did: did,
                 address: address,
                 excerpt: excerpt,
-                modified: modified,
-                author: nil
+                modified: modified
             )
         })
         .first

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -485,7 +485,7 @@ final class DatabaseService {
         .first
     }
     
-    func loadUserProfile(address: Slashlink) throws -> Data? {
+    func loadUserProfile(did: Did) throws -> Data? {
         guard self.state == .ready else {
             throw DatabaseServiceError.notReady
         }
@@ -494,11 +494,11 @@ final class DatabaseService {
             sql: """
             SELECT body
             FROM memo
-            WHERE slashlink = ? AND slug = "_profile_"
+            WHERE did = ? AND slug = "_profile_"
             LIMIT 1
             """,
             parameters: [
-                .text(address.description)
+                .text(did.description)
             ]
         )
         

--- a/xcode/Subconscious/Shared/Services/TranscludeService.swift
+++ b/xcode/Subconscious/Shared/Services/TranscludeService.swift
@@ -57,16 +57,8 @@ actor TranscludeService {
             )
             
             let address = Slashlink(peer: .did(transclusion.authorDid), slug: link.slug)
-            guard var entry = try database.readEntry(for: address) else {
+            guard let entry = try database.readEntry(for: address) else {
                 continue
-            }
-            
-            if let author = try? await userProfile.identifyUser(
-                did: transclusion.authorDid,
-                address: transclusion.address,
-                context: owner.address.peer
-            ) {
-                entry = entry.withAuthor(author)
             }
             
             if entry.address.isLocal {

--- a/xcode/Subconscious/Shared/Services/TranscludeService.swift
+++ b/xcode/Subconscious/Shared/Services/TranscludeService.swift
@@ -61,9 +61,10 @@ actor TranscludeService {
                 continue
             }
             
-            if let author = try? await userProfile.buildUserProfile(
+            if let author = try? await userProfile.identifyUser(
+                did: transclusion.authorDid,
                 address: transclusion.address,
-                did: transclusion.authorDid
+                context: owner.address.peer
             ) {
                 entry = entry.withAuthor(author)
             }

--- a/xcode/Subconscious/Shared/Services/TranscludeService.swift
+++ b/xcode/Subconscious/Shared/Services/TranscludeService.swift
@@ -62,7 +62,8 @@ actor TranscludeService {
             }
             
             if let author = try? await userProfile.buildUserProfile(
-                address: transclusion.address
+                address: transclusion.address,
+                did: transclusion.authorDid
             ) {
                 entry = entry.withAuthor(author)
             }

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -479,6 +479,11 @@ actor UserProfileService {
             }
         }
         
+        var aliases = try await self.addressBook.listAliases(did: did)
+        if let petname = petname {
+            aliases.append(petname)
+        }
+        
         let sparseProfile = UserProfile(
             did: did,
             nickname: nil,
@@ -487,7 +492,7 @@ actor UserProfileService {
             bio: nil,
             category: .human,
             ourFollowStatus: following,
-            aliases: [petname].compactMap { $0 }
+            aliases: aliases
         )
         
         let profile = try await Func.run {
@@ -500,11 +505,6 @@ actor UserProfileService {
                 }
                 
                 // Collect all the possible names for this user
-                var aliases = try await self.addressBook.listAliases(did: did)
-                if let petname = petname {
-                    aliases.append(petname)
-                }
-                
                 if let nickname = Petname.Name(dbProfile.nickname ?? "")?.toPetname() {
                     aliases.append(nickname)
                 }

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -276,8 +276,7 @@ actor UserProfileService {
                         slug: slug
                     ),
                     excerpt: memo.excerpt(),
-                    modified: memo.modified,
-                    author: nil
+                    modified: memo.modified
                 )
             )
         }
@@ -370,6 +369,8 @@ actor UserProfileService {
     /// Build a UserProfile suitable for list views, transcludes etc.
     /// This will attempt to read from the database and also maintain an in-memory cache of profiles
     /// we have encountered.
+    ///
+    /// `context` will be used to determine the preferred navigation address for a user.
     func identifyUser(
         entry: AddressBookEntry,
         context: Peer?
@@ -384,6 +385,8 @@ actor UserProfileService {
     /// Build a UserProfile suitable for list views, transcludes etc.
     /// This will attempt to read from the database and also maintain an in-memory cache of profiles
     /// we have encountered.
+    ///
+    /// `context` will be used to determine the preferred navigation address for a user.
     func identifyUser(
         did: Did,
         address: Slashlink,

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -293,7 +293,7 @@ actor UserProfileService {
         let entries = try await localAddressBook.listEntries()
         
         for entry in entries {
-            let user = try await self.identifyUser(entry: entry, context: address.peer)
+            let user = try await self.identifyUser(entry: entry, context: address.petname)
             following.append(
                 StoryUser(entry: entry, user: user)
             )
@@ -361,7 +361,7 @@ actor UserProfileService {
     /// `context` will be used to determine the preferred navigation address for a user.
     func identifyUser(
         entry: AddressBookEntry,
-        context: Peer?
+        context: Petname?
     ) async throws -> UserProfile {
         return try await self.identifyUser(
             did: entry.did,
@@ -378,7 +378,7 @@ actor UserProfileService {
     func identifyUser(
         did: Did,
         address: Slashlink,
-        context: Peer?
+        context: Petname?
     ) async throws -> UserProfile {
         switch address.peer {
         case .petname(let petname):
@@ -396,7 +396,7 @@ actor UserProfileService {
     func identifyUser(
         did: Did,
         petname: Petname?,
-        context: Peer?
+        context: Petname?
     ) async throws -> UserProfile {
         // Special case: our profile
         let identity = try await self.noosphere.identity()
@@ -414,12 +414,12 @@ actor UserProfileService {
         // If this is us, chop off the petname altogether
         let address = Func.run {
             switch (petname, context) {
-            case let (.some(petname), .some(peer)):
-                return Slashlink(petname: petname).rebaseIfNeeded(peer: peer)
+            case let (.some(petname), .some(context)):
+                return Slashlink(petname: petname).rebaseIfNeeded(peer: .petname(context))
             case let (.some(petname), .none):
                 return Slashlink(petname: petname)
-            case (.none, .some(let peer)):
-                return Slashlink.ourProfile.rebaseIfNeeded(peer: peer)
+            case (.none, .some(let context)):
+                return Slashlink.ourProfile.rebaseIfNeeded(peer: .petname(context))
             case (.none, .none):
                 return Slashlink.ourProfile
             }

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -160,7 +160,7 @@ actor UserProfileService {
     /// Attempt to read & deserialize a user `_profile_.json` at the given address.
     /// Because profile data is optional and we expect it will not always be present
     /// any errors are logged & handled and nil will be returned if reading fails.
-    private func readProfileMemo(
+    func readProfileMemo(
         address: Slashlink
     ) async -> UserProfileEntry? {
         do {
@@ -181,10 +181,10 @@ actor UserProfileService {
     
     /// Attempt to read & deserialize a user `_profile_.json` from the indexed copy.
     /// This can only work for user's we follow & have indexed, otherwise it returns nil
-    private func readProfileFromDb(
+    func readProfileFromDb(
         did: Did
     ) async throws -> UserProfileEntry? {
-        guard let data = try database.loadUserProfile(did: did) else {
+        guard let data = try database.readUserProfile(did: did) else {
             return nil
         }
         

--- a/xcode/Subconscious/SubconsciousTests/TestUtilities.swift
+++ b/xcode/Subconscious/SubconsciousTests/TestUtilities.swift
@@ -56,6 +56,7 @@ struct TestUtilities {
             path: "database.sqlite",
             directoryHint: .notDirectory
         )
+        print("Test SQLite Path: \(databaseURL.path(percentEncoded: false))")
         let db = SQLite3Database(
             path: databaseURL.path(percentEncoded: false),
             mode: .readwrite

--- a/xcode/Subconscious/SubconsciousTests/Tests_DataService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DataService.swift
@@ -417,7 +417,7 @@ final class Tests_DataService: XCTestCase {
         let list = try await environment.data.listFeed()
         
         XCTAssertEqual(list.count, 3)
-        XCTAssertEqual(list.filter({ entry in entry.author!.address.isOurProfile }).count, 2)
+        XCTAssertEqual(list.filter({ entry in entry.address.isOurs }).count, 2)
         XCTAssertFalse(list.contains(where: { entry in entry.address.slug.isHidden }))
     }
     

--- a/xcode/Subconscious/SubconsciousTests/Tests_DatabaseService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DatabaseService.swift
@@ -258,6 +258,80 @@ class Tests_DatabaseService: XCTestCase {
         )
     }
     
+    func testReadRandomEntryInDateRange() throws {
+        let service = try createDatabaseService()
+        _ = try service.migrate()
+        
+        // Add some entries to DB
+        let now = Date.now
+        
+        let foo = Memo(
+            contentType: "text/subtext",
+            created: Date.distantPast,
+            modified: Date.distantPast,
+            fileExtension: "subtext",
+            additionalHeaders: [],
+            body: "Foo"
+        )
+        try service.writeMemo(
+            MemoRecord(
+                did: Did.local,
+                petname: nil,
+                slug: Slug("foo")!,
+                memo: foo,
+                size: foo.toHeaderSubtext().size()!
+            )
+        )
+        
+        let bar = Memo(
+            contentType: "text/subtext",
+            created: Date.distantFuture,
+            modified: Date.distantFuture,
+            fileExtension: "subtext",
+            additionalHeaders: [],
+            body: "Bar"
+        )
+        try service.writeMemo(
+            MemoRecord(
+                did: Did.local,
+                petname: nil,
+                slug: Slug("bar")!,
+                memo: bar,
+                size: bar.toHeaderSubtext().size()!
+            )
+        )
+        
+        let baz = Memo(
+            contentType: "text/subtext",
+            created: now,
+            modified: now,
+            fileExtension: "subtext",
+            additionalHeaders: [],
+            body: "Baz"
+        )
+        let did = Did("did:key:abc123")!
+        try service.writeMemo(
+            MemoRecord(
+                did: did,
+                petname: Petname("abc")!,
+                slug: Slug("baz")!,
+                memo: baz
+            )
+        )
+        
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date.now)!
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: Date.now)!
+        
+        guard let recent = service.readRandomEntryInDateRange(startDate: yesterday, endDate: tomorrow, owner: did) else {
+            XCTFail("No entry found")
+            return
+        }
+        
+        XCTAssertEqual(recent.did, did)
+        XCTAssertEqual(recent.address.slug, Slug("baz")!)
+        XCTAssertEqual(recent.address, Slashlink(slug: Slug("baz")!))
+    }
+    
     func testListRecentMemosWithoutOwner() throws {
         let service = try createDatabaseService()
         _ = try service.migrate()

--- a/xcode/Subconscious/SubconsciousTests/Tests_DatabaseService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DatabaseService.swift
@@ -209,18 +209,23 @@ class Tests_DatabaseService: XCTestCase {
             additionalHeaders: [],
             body: "Baz"
         )
+        let did = Did("did:key:abc123")!
         try service.writeMemo(
             MemoRecord(
-                did: Did("did:key:abc123")!,
+                did: did,
                 petname: Petname("abc")!,
                 slug: Slug("baz")!,
                 memo: baz
             )
         )
         
-        let recent = try service.listRecentMemos(owner: Did("did:key:abc123")!, includeDrafts: true)
+        let recent = try service.listRecentMemos(owner: did, includeDrafts: true)
         
         XCTAssertEqual(recent.count, 3)
+        
+        XCTAssertEqual(recent[0].did, Did.local)
+        XCTAssertEqual(recent[1].did, Did.local)
+        XCTAssertEqual(recent[2].did, did)
         
         let slashlinks = Set(
             recent.compactMap({ stub in
@@ -313,9 +318,13 @@ class Tests_DatabaseService: XCTestCase {
             )
         )
         
+        
         let recent = try service.listRecentMemos(owner: nil, includeDrafts: true)
         
         XCTAssertEqual(recent.count, 2)
+        
+        XCTAssertEqual(recent[0].did, Did.local)
+        XCTAssertEqual(recent[1].did, Did.local)
         
         let slashlinks = Set(
             recent.compactMap({ stub in

--- a/xcode/Subconscious/SubconsciousTests/Tests_NotebookUpdate.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_NotebookUpdate.swift
@@ -37,22 +37,19 @@ class Tests_NotebookUpdate: XCTestCase {
                     did: Did.dummyData(),
                     address: a,
                     excerpt: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris fermentum orci quis lorem semper porta. Integer sem eros, ultricies et risus id, congue tristique libero.",
-                    modified: Date.now,
-                    author: nil
+                    modified: Date.now
                 ),
                 EntryStub(
                     did: Did.dummyData(),
                     address: b,
                     excerpt: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris fermentum orci quis lorem semper porta. Integer sem eros, ultricies et risus id, congue tristique libero.",
-                    modified: Date.now,
-                    author: nil
+                    modified: Date.now
                 ),
                 EntryStub(
                     did: Did.dummyData(),
                     address: c,
                     excerpt: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris fermentum orci quis lorem semper porta. Integer sem eros, ultricies et risus id, congue tristique libero.",
-                    modified: Date.now,
-                    author: nil
+                    modified: Date.now
                 )
             ]
         )

--- a/xcode/Subconscious/SubconsciousTests/Tests_NotebookUpdate.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_NotebookUpdate.swift
@@ -34,18 +34,21 @@ class Tests_NotebookUpdate: XCTestCase {
         let state = NotebookModel(
             recent: [
                 EntryStub(
+                    did: Did.dummyData(),
                     address: a,
                     excerpt: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris fermentum orci quis lorem semper porta. Integer sem eros, ultricies et risus id, congue tristique libero.",
                     modified: Date.now,
                     author: nil
                 ),
                 EntryStub(
+                    did: Did.dummyData(),
                     address: b,
                     excerpt: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris fermentum orci quis lorem semper porta. Integer sem eros, ultricies et risus id, congue tristique libero.",
                     modified: Date.now,
                     author: nil
                 ),
                 EntryStub(
+                    did: Did.dummyData(),
                     address: c,
                     excerpt: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris fermentum orci quis lorem semper porta. Integer sem eros, ultricies et risus id, congue tristique libero.",
                     modified: Date.now,

--- a/xcode/Subconscious/SubconsciousTests/Tests_UserProfileService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_UserProfileService.swift
@@ -36,7 +36,7 @@ final class Tests_UserProfileService: XCTestCase {
         XCTAssertTrue(profile.following[1].user.aliases.contains(where: { name in name == Petname("sphere-b")! }))
     }
     
-    func testIdentifyUserContext() async throws {
+    func testIdentifyUserRebaseOnContext() async throws {
         let tmp = try TestUtilities.createTmpDir()
         let environment = try await TestUtilities.createDataServiceEnvironment(tmp: tmp)
         
@@ -99,7 +99,7 @@ final class Tests_UserProfileService: XCTestCase {
         XCTAssertTrue(profile.aliases.contains(where: { petname in petname == Petname("more.path") }))
     }
     
-    func testIdentifyUserSignatures() async throws {
+    func testIdentifyUserCallSignatures() async throws {
         let tmp = try TestUtilities.createTmpDir()
         let environment = try await TestUtilities.createDataServiceEnvironment(tmp: tmp)
         

--- a/xcode/Subconscious/SubconsciousTests/Tests_UserProfileService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_UserProfileService.swift
@@ -36,6 +36,30 @@ final class Tests_UserProfileService: XCTestCase {
         XCTAssertTrue(profile.following[1].user.aliases.contains(where: { name in name == Petname("sphere-b")! }))
     }
     
+    func testReadUserProfile() async throws {
+        let tmp = try TestUtilities.createTmpDir()
+        let environment = try await TestUtilities.createDataServiceEnvironment(tmp: tmp)
+        
+        let receipt = try await environment.noosphere.createSphere(ownerKeyName: "test")
+        let did = Did(receipt.identity)!
+        
+        await environment.noosphere.resetSphere(receipt.identity)
+        
+        try await environment.userProfile.writeOurProfile(
+            profile: UserProfileEntry(
+                nickname: "Finn",
+                bio: "Mathematical!"
+            )
+        )
+        
+        let _ = try await environment.data.indexOurSphere()
+        
+        let profileA = try await environment.userProfile.readProfileFromDb(did: did)
+        let profileB = await environment.userProfile.readProfileMemo(address: Slashlink.ourProfile)
+        
+        XCTAssertEqual(profileA, profileB)
+    }
+    
     func testCanRequestOwnProfile() async throws {
         let tmp = try TestUtilities.createTmpDir()
         let data = try await TestUtilities.createDataServiceEnvironment(tmp: tmp)


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/924

This turned into quite a meaty refactor. The goal is to avoid hitting the network to produce the feed or our local profile view. To accomplish this we had to revisit our entire approach to loading and caching user profiles. While a lot of code changed, the new approach is much simpler: we have two code paths, one for loading user data for list views and another for the profile detail view.

I've tested loading the feed with several hundred posts in it from various peers and it loads instantly for me without reading any of the peer's `_profile_` memos.

# Changes
- Introduce `UserProfileService.identifyUser` which consults the DB to produce a `UserProfile` and never traverses (intended for list views which need user metadata)
    - If we don't follow this user or their profile is missing from the DB we fall back to a "shallow" profile display
- Remove `UserProfileService.buildUserProfile`
- Roll `buildUserProfile` into `UserProfileService.loadFullProfileData` which _always_ fetches the latest profile from noosphere (intended for the profile detail view)
    - We do not fetch profiles for any users in the following list _unless_ we follow them and have their profile indexed in the DB
- Consolidate and fix `UserProfile.aliases` logic
- `EntryStub` now comes with a `did` field

# TODO
- [x] explicitly read from memo for the actual users profile, fall back to DB
- [x] when listing users if _we_ follow them, check the DB for their profile, fallback to nothing
- [x] stop passing user profiles around everywhere
- [x] do a join to list the feed?
- [x] show AKA blocks on followed users