### PR TITLE
Attempt to include the DID if `indexPeer` fails

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -213,7 +213,7 @@ enum AppAction {
     /// Index the contents of a sphere in the database
     case indexPeer(_ petname: Petname)
     case succeedIndexPeer(_ peer: PeerRecord)
-    case failIndexPeer(petname: Petname, identity: Did?, error: Error)
+    case failIndexPeer(petname: Petname, error: Error)
 
     /// Purge the contents of a sphere from the database
     case purgePeer(_ did: Did)
@@ -922,11 +922,10 @@ struct AppModel: ModelProtocol {
                 environment: environment,
                 peer: peer
             )
-        case let .failIndexPeer(petname, identity, error):
+        case let .failIndexPeer(petname, error):
             return failIndexPeer(
                 state: state,
                 environment: environment,
-                identity: identity,
                 petname: petname,
                 error: error
             )
@@ -2004,12 +2003,8 @@ struct AppModel: ModelProtocol {
                 )
                 return Action.succeedIndexPeer(peer)
             } catch {
-                // We may be unable to resolve a peer, but attempt to grab the DID
-                let sphere = try? await environment.noosphere.traverse(petname: petname)
-                let identity = try? await sphere?.identity()
                 return Action.failIndexPeer(
                     petname: petname,
-                    identity: identity,
                     error: error
                 )
             }
@@ -2037,7 +2032,6 @@ struct AppModel: ModelProtocol {
     static func failIndexPeer(
         state: Self,
         environment: Environment,
-        identity: Did?,
         petname: Petname,
         error: Error
     ) -> Update<Self> {
@@ -2045,7 +2039,6 @@ struct AppModel: ModelProtocol {
             "Failed to index peer",
             metadata: [
                 "petname": petname.description,
-                "identity": identity?.description,
                 "error": error.localizedDescription
             ]
         )

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -120,20 +120,21 @@ actor DataService {
         petname: Petname
     ) async throws -> PeerRecord {
         let sphere = try await noosphere.traverse(petname: petname)
-        logger.debug(
+        let identity = try await sphere.identity()
+        logger.log(
             "Traversed to peer",
             metadata: [
-                "petname": petname.description
+                "petname": petname.description,
+                "identity": identity.description,
             ]
         )
-        let identity = try await sphere.identity()
         let version = try await sphere.version()
         // Get peer info from last sync
         let peer = try? database.readPeer(identity: identity)
         // Get changes since the last time we indexed this peer,
         // or get all changes if this is the first time we've tried to index.
         let changes = try await sphere.changes(since: peer?.since)
-        logger.debug(
+        logger.log(
             "Indexing peer",
             metadata: [
                 "petname": petname.description,
@@ -162,14 +163,14 @@ actor DataService {
                             memo: memo
                         )
                     )
-                    logger.debug(
+                    logger.log(
                         "Indexed memo \(slashlink)",
                         metadata: [
                             "slashlink": slashlink.description
                         ]
                     )
                 } else {
-                    logger.debug(
+                    logger.log(
                         "Removed indexed memo \(slashlink)",
                         metadata: [
                             "slashlink": slashlink.description


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/927

We cannot always guarantee that the identity is available (or even exists) but we can make a best-effort to include the identity for debugging purposes.