### PR TITLE
Update search to use ViewStore

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/Forms/Search.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Forms/Search.swift
@@ -42,6 +42,41 @@ enum SearchAction: Hashable {
     case entryDeleted(Slug)
 }
 
+extension SearchAction: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .requestPresent(let bool):
+            return "requestPresent(\(bool))"
+        case .hideAndClearQuery:
+            return "hideAndClearQuery"
+        case .cancel:
+            return "cancel"
+        case .setQuery(let string):
+            return "setQuery(\(string)"
+        case .submitQuery(let string):
+            return "submitQuery(\(string))"
+        case .setSuggestions(let array):
+            return "setSuggestions(...\(array.count))"
+        case .failSuggestions(let string):
+            return "failSuggestions(\(string))"
+        case .refreshSuggestions:
+            return "refreshSuggestions"
+        case .activateSuggestion(let suggestion):
+            return "activateSuggestion(\(suggestion)"
+        case .activatedSuggestion(let suggestion):
+            return "activatedSuggestion(\(suggestion))"
+        case .createSearchHistoryItem(let string):
+            return "createSearchHistoryItem(\(string ?? ""))"
+        case .succeedCreateSearchHistoryItem(let string):
+            return "succeedCreateSearchHistoryItem(\(string))"
+        case .failCreateSearchHistoryItem(let string):
+            return "failCreateSearchHistoryItem(\(string))"
+        case .entryDeleted(let slug):
+            return "entryDeleted(\(slug))"
+        }
+    }
+}
+
 //  MARK: Model
 struct SearchModel: ModelProtocol {
     var clearSearchTimeout = Duration.keyboard + 0.1
@@ -271,29 +306,28 @@ struct SearchModel: ModelProtocol {
 
 //  MARK: View
 struct SearchView: View {
-    var state: SearchModel
-    var send: (SearchAction) -> Void
+    var store: ViewStore<SearchModel>
     var suggestionHeight: CGFloat = 56
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
                 SearchTextField(
-                    placeholder: state.placeholder,
+                    placeholder: store.state.placeholder,
                     text: Binding(
-                        get: { state.query },
-                        send: send,
+                        get: { store.state.query },
+                        send: store.send,
                         tag: SearchAction.setQuery
                     ),
                     autofocus: true
                 )
                 .submitLabel(.go)
                 .onSubmit {
-                    send(.submitQuery(state.query))
+                    store.send(.submitQuery(store.state.query))
                 }
                 Button(
                     action: {
-                        send(.cancel)
+                        store.send(.cancel)
                     },
                     label: {
                         Text("Cancel")
@@ -302,10 +336,10 @@ struct SearchView: View {
             }
             .frame(height: AppTheme.unit * 10)
             .padding(AppTheme.tightPadding)
-            List(state.suggestions) { item in
+            List(store.state.suggestions) { item in
                 Button(
                     action: {
-                        send(.activateSuggestion(item.value))
+                        store.send(.activateSuggestion(item.value))
                     },
                     label: {
                         SuggestionLabelView(suggestion: item.value)
@@ -341,12 +375,24 @@ struct SearchView: View {
 }
 
 struct SearchView_Previews: PreviewProvider {
-    static var previews: some View {
-        SearchView(
+    struct TestView: View {
+        @StateObject var store = Store(
             state: SearchModel(
                 placeholder: "Search or create..."
             ),
-            send: { action in }
+            environment: AppEnvironment()
         )
+        var body: some View {
+            SearchView(
+                store: store.viewStore(
+                    get: { state in state },
+                    tag: { action in action }
+                )
+            )
+        }
+    }
+
+    static var previews: some View {
+        TestView()
     }
 }

--- a/xcode/Subconscious/Shared/Components/Feed.swift
+++ b/xcode/Subconscious/Shared/Components/Feed.swift
@@ -101,9 +101,8 @@ struct FeedView: View {
             
             if store.state.isSearchPresented {
                 SearchView(
-                    state: store.state.search,
-                    send: Address.forward(
-                        send: store.send,
+                    store: store.viewStore(
+                        get: \.search,
                         tag: FeedSearchCursor.tag
                     )
                 )

--- a/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
@@ -41,9 +41,8 @@ struct NotebookView: View {
             
             if store.state.isSearchPresented {
                 SearchView(
-                    state: store.state.search,
-                    send: Address.forward(
-                        send: store.send,
+                    store: store.viewStore(
+                        get: \.search,
                         tag: NotebookSearchCursor.tag
                     )
                 )


### PR DESCRIPTION
PR updates search view to use a ViewStore. In my playtesting, this significantly improves the perceived perf of type-ahead suggestions.

Why? I suspect this may have something to do with the way inputs work in SwiftUI. Perhaps the binding-style closer access that goes all the way up to store allows the input field to render text BEFORE the search view is invalidated by the parent.

Background:

- I've been bothered by the perceived performance of type-ahead search in the app.
- At first, I suspected this was due to SQLite full text search running up against large amounts of indexed peer content. So I tried searching only post titles instead of full text search.
    - However, upon investigating the app container, it turned out I was searching across relatively low amounts of content
    - SQLite was not the bottleneck.
- I also tried limiting the amount of serializing needed for logging by implementing a `CustomStringConvertible` for `SearchAction`. This wasn't the bottleneck, but I kept it anyway, because IMO its probably a good idea not to serialize and log all suggestions at every keystroke.
- The improvement came with using ViewStore. Surprising, but then again, perhaps not, given the issues we have had with input fields in the past that were fixed by ViewStore.