### PR TITLE
Index peers serially (and other performance enhancements)

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -1975,10 +1975,11 @@ struct AppModel: ModelProtocol {
         peers: [PeerRecord]
     ) -> Update<Self> {
         // Transform list of peers into fx publisher of actions.
-        let fx: Fx<Action> = Future.detached {
-            AppAction.indexPeers(peers
-                .map({ peer in peer.petname }))
-        }
+        let fx: Fx<Action> = Just(
+            AppAction.indexPeers(
+                peers.map({ peer in peer.petname })
+            )
+        )
         .eraseToAnyPublisher()
         
         return Update(state: state, fx: fx)

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -2051,6 +2051,7 @@ struct AppModel: ModelProtocol {
                         petname: petname
                     )
                     success.append(peer)
+                    await Task.yield()
                 } catch {
                     fail.append(petname)
                 }

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -2014,37 +2014,11 @@ struct AppModel: ModelProtocol {
     ) -> Update<Self> {
         
         let fx: Fx<Action> = Future.detached(priority: .background) {
-            var results: [PeerIndexResult] = []
-            
-            for petname in petnames {
-                logger.log(
-                    "Indexing peer",
-                    metadata: [
-                        "petname": petname.description
-                    ]
-                )
-                
-                do {
-                    let peer = try await environment.data.indexPeer(
-                        petname: petname
-                    )
-                    
-                    results.append(.success(peer))
-                    await Task.yield()
-                } catch {
-                    results.append(
-                        PeerIndexResult.failure(
-                            PeerIndexError(
-                                error: error,
-                                petname: petname
-                            )
-                        )
-                    )
-                }
-            }
-            
+            let results = await environment.data.indexPeers(petnames: petnames)
             return AppAction.completeIndexPeers(results: results)
-        }.eraseToAnyPublisher()
+        }
+        .eraseToAnyPublisher()
+        
         return Update(state: state, fx: fx)
     }
     

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -98,8 +98,6 @@ enum AppAction {
         category: "AppAction"
     )
 
-    case writeTestData
-    
     /// Sent immediately upon store creation
     case start
 
@@ -595,11 +593,6 @@ struct AppModel: ModelProtocol {
         environment: AppEnvironment
     ) -> Update<AppModel> {
         switch action {
-        case .writeTestData:
-            return writeTestData(
-                state: state,
-                environment: environment
-            )
         case .start:
             return start(
                 state: state,
@@ -1089,24 +1082,6 @@ struct AppModel: ModelProtocol {
     ) -> Update<AppModel> {
         logger.log("\(message)")
         return Update(state: state)
-    }
-    
-    static func writeTestData(
-        state: AppModel,
-        environment: AppEnvironment
-    ) -> Update<Self> {
-        
-        let fx: Fx<AppAction> = Future.detached {
-            for _ in 0..<100 {
-                try? await environment.noosphere.write(slug: Slug.dummyData(), contentType: "text/subtext", additionalHeaders: [], body: String.dummyDataMedium().data(using: .utf8)!)
-            }
-            
-            try? await environment.noosphere.save()
-            return AppAction.start
-        }
-        .eraseToAnyPublisher()
-        
-        return Update(state: state, fx: fx)
     }
     
     static func start(

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -1277,12 +1277,12 @@ struct AppModel: ModelProtocol {
     }
     
     static func fetchNicknameFromProfileMemo(
-        state: AppModel,
+        state: AppModel, 
         environment: AppEnvironment
     ) -> Update<AppModel> {
         let fx: Fx<AppAction> = Future.detached {
-            let response = try await environment.userProfile.requestOurProfile()
-            if let nickname = response.profile.nickname {
+            let response = try await environment.userProfile.readOurProfile(alias: nil)
+            if let nickname = response.nickname {
                 return AppAction.succeedFetchNicknameFromProfile(nickname)
             }
             

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -97,7 +97,6 @@ enum AppAction {
         subsystem: Config.default.rdns,
         category: "AppAction"
     )
-
     /// Sent immediately upon store creation
     case start
 
@@ -213,8 +212,6 @@ enum AppAction {
     /// Index the contents of a sphere in the database
     case indexPeers(_ petnames: [Petname])
     case completeIndexPeers(succeeded: [PeerRecord], failed: [Petname])
-//    case succeedIndexPeer(_ peer: PeerRecord)
-//    case failIndexPeer(petname: Petname, error: Error)
 
     /// Purge the contents of a sphere from the database
     case purgePeer(_ did: Did)

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileSheets.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileSheets.swift
@@ -196,15 +196,19 @@ struct EditProfileSheetModifier: ViewModifier {
                 store.actions.compactMap(AppAction.from),
                 perform: app.send
             )
-//            .onReceive(app.actions, perform: { action in
-//                switch (action) {
-//                case .succeedIndexPeer(let peer) where peer.identity == store.state.user?.did:
-//                    store.send(.refresh(forceSync: false))
-//                    break
-//                case _:
-//                    break
-//                }
-//            })
+            .onReceive(app.actions, perform: { action in
+                switch (action) {
+                case .completeIndexPeers(let succeeded, _)
+                    where succeeded.contains(where: {
+                        peer in peer.identity == store.state.user?.did
+                    }):
+                    
+                    store.send(.refresh(forceSync: false))
+                    break
+                case _:
+                    break
+                }
+            })
     }
 }
 

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileSheets.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileSheets.swift
@@ -198,9 +198,15 @@ struct EditProfileSheetModifier: ViewModifier {
             )
             .onReceive(app.actions, perform: { action in
                 switch (action) {
-                case .completeIndexPeers(let succeeded, _)
-                    where succeeded.contains(where: {
-                        peer in peer.identity == store.state.user?.did
+                case .completeIndexPeers(let results)
+                    // Only refresh the view if the presented user was indexed
+                    where results.contains(where: { result in
+                        switch (result) {
+                        case .success(let peer) where peer.identity == state.user?.did:
+                            return true
+                        default:
+                            return false
+                        }
                     }):
                     
                     store.send(.refresh(forceSync: false))

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileSheets.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileSheets.swift
@@ -196,15 +196,15 @@ struct EditProfileSheetModifier: ViewModifier {
                 store.actions.compactMap(AppAction.from),
                 perform: app.send
             )
-            .onReceive(app.actions, perform: { action in
-                switch (action) {
-                case .succeedIndexPeer(let peer) where peer.identity == store.state.user?.did:
-                    store.send(.refresh(forceSync: false))
-                    break
-                case _:
-                    break
-                }
-            })
+//            .onReceive(app.actions, perform: { action in
+//                switch (action) {
+//                case .succeedIndexPeer(let peer) where peer.identity == store.state.user?.did:
+//                    store.send(.refresh(forceSync: false))
+//                    break
+//                case _:
+//                    break
+//                }
+//            })
     }
 }
 

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -80,9 +80,9 @@ struct FollowTabView: View {
         ForEach(store.state.following) { follow in
             StoryUserView(
                 story: follow,
-                action: { _ in
+                action: { address in
                     notify(
-                        .requestNavigateToProfile(follow.user.address)
+                        .requestNavigateToProfile(address)
                     )
                 },
                 profileAction: { user, action in

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -475,7 +475,7 @@ extension MemoEditorDetailAction {
     ) -> MemoEditorDetailAction? {
         switch (action) {
         case .succeedIndexOurSphere(_),
-             .succeedIndexPeer(_):
+             .completeIndexPeers:
             return .refreshBacklinks
         case _:
             return nil

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -295,8 +295,7 @@ extension MemoViewerDetailAction {
         _ action: AppAction
     ) -> MemoViewerDetailAction? {
         switch (action) {
-        case .succeedIndexOurSphere(_),
-             .succeedIndexPeer(_):
+        case .succeedIndexOurSphere, .completeIndexPeers:
             return .succeedIndexBackgroundSphere
         case _:
             return nil

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -556,7 +556,7 @@ struct MemoViewerDetailModel: ModelProtocol {
                 guard let petname = state.address?.toPetname() else {
                      return try await environment
                         .userProfile
-                        .requestOurProfile()
+                        .loadOurFullProfileData()
                         .profile
                 }
                 

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -285,9 +285,13 @@ extension UserProfileDetailModel {
     ) async throws -> UserProfileContentResponse {
         return try await Func.run {
             if let petname = address.toPetname() {
-                return try await environment.userProfile.requestUserProfile(petname: petname)
+                return try await environment
+                    .userProfile
+                    .loadFullProfileData(address: Slashlink(petname: petname))
             } else {
-                return try await environment.userProfile.requestOurProfile()
+                return try await environment
+                    .userProfile
+                    .loadOurFullProfileData()
             }
         }
     }

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -89,7 +89,7 @@ extension UserProfileDetailAction {
         switch action {
         case .succeedIndexOurSphere:
             return .refresh(forceSync: false)
-        case .succeedIndexPeer:
+        case .completeIndexPeers:
             return .refresh(forceSync: false)
         case .succeedRecoverOurSphere:
             return .refresh(forceSync: false)
@@ -183,8 +183,9 @@ extension UserProfileDetailAction {
         action: AppAction
     ) -> UserProfileDetailAction? {
         switch (action) {
-        case let .succeedIndexPeer(peer):
-            return .succeedIndexPeer(peer)
+            // TODO: put this back
+//        case let .succeedIndexPeer(peer):
+//            return .succeedIndexPeer(peer)
         case _:
             return nil
         }

--- a/xcode/Subconscious/Shared/Components/Feed/Feed.swift
+++ b/xcode/Subconscious/Shared/Components/Feed/Feed.swift
@@ -120,7 +120,7 @@ extension FeedAction {
         switch action {
         case .succeedIndexOurSphere:
             return .refreshAll
-        case .succeedIndexPeer:
+        case .completeIndexPeers:
             return .refreshAll
         case .succeedRecoverOurSphere:
             return .refreshAll

--- a/xcode/Subconscious/Shared/Components/Settings/DeveloperSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/DeveloperSettingsView.swift
@@ -21,6 +21,15 @@ struct DeveloperSettingsView: View {
                     Text("Reset First Run Experience")
                 }
             )
+            
+            Button(
+                action: {
+                    app.send(.writeTestData)
+                },
+                label: {
+                    Text("Write Test Data")
+                }
+            )
         }
         .navigationTitle("Developer")
     }

--- a/xcode/Subconscious/Shared/Components/Settings/DeveloperSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/DeveloperSettingsView.swift
@@ -21,15 +21,6 @@ struct DeveloperSettingsView: View {
                     Text("Reset First Run Experience")
                 }
             )
-            
-            Button(
-                action: {
-                    app.send(.writeTestData)
-                },
-                label: {
-                    Text("Write Test Data")
-                }
-            )
         }
         .navigationTitle("Developer")
     }

--- a/xcode/Subconscious/Shared/Services/AddressBookService.swift
+++ b/xcode/Subconscious/Shared/Services/AddressBookService.swift
@@ -96,6 +96,7 @@ actor AddressBook<Sphere: SphereProtocol> {
         
         var entries: [AddressBookEntry] = []
         
+        logger.log("Listing adress book")
         let petnames = try await sphere.listPetnames()
         for petname in petnames {
             let did = try await sphere.getPetname(petname: petname)
@@ -122,6 +123,7 @@ actor AddressBook<Sphere: SphereProtocol> {
             a.name < b.name
         }
         
+        logger.log("Finished listing address book")
         self.cache = entries
         self.cacheVersion = version
         return entries

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -218,6 +218,41 @@ actor DataService {
             since: version
         )
     }
+    
+    func indexPeers(petnames: [Petname]) async -> [PeerIndexResult] {
+        var results: [PeerIndexResult] = []
+        
+        for petname in petnames {
+            logger.log(
+                "Indexing peer",
+                metadata: [
+                    "petname": petname.description
+                ]
+            )
+            
+            do {
+                let peer = try await self.indexPeer(
+                    petname: petname
+                )
+                
+                results.append(.success(peer))
+                // Give other tasks a chance to use noosphere, indexing many peers
+                // can take a long time and potentially block user actions
+                await Task.yield()
+            } catch {
+                results.append(
+                    PeerIndexResult.failure(
+                        PeerIndexError(
+                            error: error,
+                            petname: petname
+                        )
+                    )
+                )
+            }
+        }
+        
+        return results
+    }
 
     /// Index our sphere's content in our database.
     ///

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -570,32 +570,15 @@ actor UserProfileService {
     }
     
     /// Retrieve all the content for the App User's profile view, fetching their profile, notes and address book.
-    func requestOurProfile() async throws -> UserProfileContentResponse {
+    func loadOurFullProfileData() async throws -> UserProfileContentResponse {
         try await loadFullProfileData(address: Slashlink.ourProfile)
     }
     
-    nonisolated func requestOurProfilePublisher(
+    nonisolated func loadOurFullProfileDataPublisher(
     ) -> AnyPublisher<UserProfileContentResponse, Error> {
         Future.detached {
-            try await self.requestOurProfile()
+            try await self.loadOurFullProfileData()
         }
         .eraseToAnyPublisher()
     }
-    
-    /// Retrieve all the content for the passed user's profile view, fetching their profile, notes and address book.
-    func requestUserProfile(
-        petname: Petname
-    ) async throws -> UserProfileContentResponse {
-        try await loadFullProfileData(address: Slashlink(petname: petname))
-    }
-    
-    nonisolated func requestUserProfilePublisher(
-        petname: Petname
-    ) -> AnyPublisher<UserProfileContentResponse, Error> {
-        Future.detached {
-            try await self.requestUserProfile(petname: petname)
-        }
-        .eraseToAnyPublisher()
-    }
-   
 }

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -492,7 +492,7 @@ actor UserProfileService {
     func loadFullProfileData(
         address: Slashlink
     ) async throws -> UserProfileContentResponse {
-        logger.log("Open sphere")
+        logger.log("Opening sphere...")
         let sphere = try await self.noosphere.sphere(address: address)
         let did = try await sphere.identity()
         logger.log("Opened sphere \(did)")
@@ -527,7 +527,7 @@ actor UserProfileService {
                     break
                 }
                 
-                logger.log("Read from local index")
+                logger.log("List from local index")
                 return try
                     self.database.listRecentMemos(owner: did, includeDrafts: false)
                     .map { memo in
@@ -543,7 +543,7 @@ actor UserProfileService {
                 break
             }
             
-            logger.log("Read from sphere itself")
+            logger.log("List from sphere itself")
             let notes = try await sphere.list()
             return try await self.loadEntries(
                 sphere: sphere,
@@ -552,7 +552,6 @@ actor UserProfileService {
             )
         }
         
-        logger.log("Sort entries")
         let recentEntries = sortEntriesByModified(entries: entries)
         
         logger.log("Assemble response")

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -171,7 +171,7 @@ actor UserProfileService {
     ) async -> UserProfileEntry? {
         let identity = try? await sphere.identity()
         do {
-            let data = try? await sphere.read(slashlink: Slashlink.ourProfile)
+            let data = try? await sphere.read(slashlink: Slashlink(slug: Slug.profile))
             guard let data = data else {
                 return nil
             }

--- a/xcode/Subconscious/SubconsciousTests/Tests_UserProfileService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_UserProfileService.swift
@@ -23,7 +23,7 @@ final class Tests_UserProfileService: XCTestCase {
         try await data.addressBook.followUser(did: didB, petname: Petname("sphere-b")!)
         try await data.addressBook.followUser(did: didB, petname: Petname("sphere-b-again")!)
         
-        let profile = try await data.userProfile.requestOurProfile()
+        let profile = try await data.userProfile.loadOurFullProfileData()
         
         XCTAssertEqual(profile.following.count, 2)
         for entry in profile.following {
@@ -217,7 +217,7 @@ final class Tests_UserProfileService: XCTestCase {
             petname: Petname("ronald")!
         )
         
-        let profile = try await data.userProfile.requestOurProfile()
+        let profile = try await data.userProfile.loadOurFullProfileData()
         
         XCTAssertEqual(profile.profile.nickname, Petname.Name("alice")!)
         XCTAssertEqual(profile.profile.bio, UserProfileBio("my bio"))

--- a/xcode/Subconscious/SubconsciousTests/Tests_UserProfileService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_UserProfileService.swift
@@ -172,7 +172,7 @@ final class Tests_UserProfileService: XCTestCase {
         let _ = try await environment.data.indexOurSphere()
         
         let profileA = try await environment.userProfile.readProfileFromDb(did: did)
-        let profileB = await environment.userProfile.readProfileMemo(address: Slashlink.ourProfile)
+        let profileB = await environment.userProfile.readProfileMemo(sphere: environment.noosphere)
         
         XCTAssertEqual(profileA, profileB)
     }


### PR DESCRIPTION
# Changes

1. Index peers in serial, never concurrently (introduce `Task.yield()` between each peer)
2. Pass `sphere` reference around in `UserProfileService` to minimise excessive init/deinit
3. Prevent excessive profile refreshing
4. Prevent refreshing profile if it's already loading
5. Log each step of producing the profile view
6. Fix bug: we were loading the data for the entire profile view just to get our nickname on startup

None of these dramatically changed anything for me in testing but they do all incrementally improve performance.

Fixes #943  