### PR TITLE
Update StoryUser description to remove newlines

### DIFF
--- a/xcode/Subconscious/Shared/Models/StoryUser.swift
+++ b/xcode/Subconscious/Shared/Models/StoryUser.swift
@@ -21,11 +21,7 @@ struct StoryUser:
     var statistics: UserProfileStatistics?
 
     var description: String {
-        """
-        \(String(describing: user.did))
-        \(String(describing: user.address))
-        \(String(describing: user.nickname))
-        \(String(describing: user.ourFollowStatus))
-        """
+        let nickname = String(describing: user.nickname)
+        return "StoryUser(\(user.did), \(user.address), \(nickname), \(user.ourFollowStatus))"
     }
 }

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -451,6 +451,7 @@
 		B8EC568A26F4204F00AC64E5 /* SQLite3Database.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8EC568826F4204F00AC64E5 /* SQLite3Database.swift */; };
 		B8EF986E29034ADF0029363D /* Pathlike.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8EF986D29034ADF0029363D /* Pathlike.swift */; };
 		B8EF986F29034ADF0029363D /* Pathlike.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8EF986D29034ADF0029363D /* Pathlike.swift */; };
+		B8F164252AE1B4A300A05CE7 /* Tests_StoryUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F164242AE1B4A300A05CE7 /* Tests_StoryUser.swift */; };
 		B8F27EE42970CD8F00A33E78 /* Tests_Sphere.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F27EE32970CD8F00A33E78 /* Tests_Sphere.swift */; };
 		B8F832E329B9292C00DFDFA8 /* Tests_SubtextAttributedStringRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F832E229B9292C00DFDFA8 /* Tests_SubtextAttributedStringRenderer.swift */; };
 /* End PBXBuildFile section */
@@ -796,6 +797,7 @@
 		B8EC20932AC4A9A000D435F6 /* Tests_Redacted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_Redacted.swift; sourceTree = "<group>"; };
 		B8EC568826F4204F00AC64E5 /* SQLite3Database.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLite3Database.swift; sourceTree = "<group>"; };
 		B8EF986D29034ADF0029363D /* Pathlike.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pathlike.swift; sourceTree = "<group>"; };
+		B8F164242AE1B4A300A05CE7 /* Tests_StoryUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_StoryUser.swift; sourceTree = "<group>"; };
 		B8F27EE32970CD8F00A33E78 /* Tests_Sphere.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_Sphere.swift; sourceTree = "<group>"; };
 		B8F832E229B9292C00DFDFA8 /* Tests_SubtextAttributedStringRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_SubtextAttributedStringRenderer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -972,6 +974,7 @@
 				B8F27EE32970CD8F00A33E78 /* Tests_Sphere.swift */,
 				B81D063C29F1C1E400593BBA /* Tests_SphereFile.swift */,
 				B80CC806299D4DF000C4D7C0 /* Tests_SQLite3Database.swift */,
+				B8F164242AE1B4A300A05CE7 /* Tests_StoryUser.swift */,
 				B84AD8E0280F7A19006B3153 /* Tests_StringUtilities.swift */,
 				B8682DCA2804BF04001CD8DD /* Tests_Subtext.swift */,
 				B8F832E229B9292C00DFDFA8 /* Tests_SubtextAttributedStringRenderer.swift */,
@@ -1765,6 +1768,7 @@
 				B8682DCB2804BF04001CD8DD /* Tests_Subtext.swift in Sources */,
 				B88CC956284FCF8C00994928 /* Tests_DatabaseService.swift in Sources */,
 				B8D328BA29A69D2D00850A37 /* Tests_URLUtilities.swift in Sources */,
+				B8F164252AE1B4A300A05CE7 /* Tests_StoryUser.swift in Sources */,
 				B831BDB72824DA9700C4CE92 /* Tests_Tape.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/xcode/Subconscious/SubconsciousTests/Tests_StoryUser.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_StoryUser.swift
@@ -1,0 +1,41 @@
+//
+//  Tests_StoryUser.swift
+//  SubconsciousTests
+//
+//  Created by Gordon Brander on 10/19/23.
+//
+
+import XCTest
+@testable import Subconscious
+
+final class Tests_StoryUser: XCTestCase {
+    func testDescription() throws {
+        let story = StoryUser(
+            entry: AddressBookEntry(
+                petname: Petname(name: Petname.Name(formatting: "bob")!),
+                did: Did("did:key:abc123")!,
+                status: .unresolved,
+                version: "bafyfakefakefake"
+            ),
+            user: UserProfile(
+                did: Did("did:key:abc123")!,
+                nickname: Petname.Name(formatting: "bob")!,
+                address: Slashlink("@bob/foo")!,
+                pfp: .generated(Did("did:key:abc123")!),
+                bio: nil,
+                category: .human,
+                ourFollowStatus: .following(Petname.Name(formatting: "bob")!),
+                aliases: []
+            )
+        )
+        XCTAssertEqual(story.description, "StoryUser(did:key:abc123, @bob/foo, Optional(bob), following(bob))")
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/xcode/Subconscious/SubconsciousTests/Tests_StoryUser.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_StoryUser.swift
@@ -30,12 +30,4 @@ final class Tests_StoryUser: XCTestCase {
         )
         XCTAssertEqual(story.description, "StoryUser(did:key:abc123, @bob/foo, Optional(bob), following(bob))")
     }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-
 }


### PR DESCRIPTION
We should not be including newlines in the text description of this type since these get logged and break up logging.

Fixes #948 