### PR TITLE
Do not refresh viewer if content is indentical

### DIFF
--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -473,7 +473,7 @@ struct MemoViewerDetailModel: ModelProtocol {
         description: MemoViewerDetailDescription
     ) -> Update<Self> {
         guard state.address != description.address else {
-            logger.warning("Attempted to appear with same address, doing nothing")
+            logger.log("Attempted to appear with same address, doing nothing")
             return Update(state: state)
         }
         
@@ -496,7 +496,7 @@ struct MemoViewerDetailModel: ModelProtocol {
         environment: Environment
     ) -> Update<Self> {
         guard let address = state.address else {
-            logger.warning("Attempted to refresh with nil address")
+            logger.log("Attempted to refresh with nil address")
             return Update(state: state)
         }
         

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -291,6 +291,7 @@ enum MemoViewerDetailAction: Hashable {
 
     case metaSheet(MemoViewerDetailMetaSheetAction)
     case appear(_ description: MemoViewerDetailDescription)
+    case refreshAll
     case setDetail(_ entry: MemoEntry?)
     case setDom(Subtext)
     case failLoadDetail(_ message: String)
@@ -328,6 +329,8 @@ extension MemoViewerDetailAction {
         switch (action) {
         case .succeedIndexOurSphere, .completeIndexPeers:
             return .succeedIndexBackgroundSphere
+        case .succeedSyncSphereWithGateway:
+            return .refreshAll
         case _:
             return nil
         }
@@ -376,6 +379,11 @@ struct MemoViewerDetailModel: ModelProtocol {
                 state: state,
                 environment: environment,
                 description: description
+            )
+        case .refreshAll:
+            return refreshAll(
+                state: state,
+                environment: environment
             )
         case .setDetail(let entry):
             return setDetail(
@@ -464,20 +472,45 @@ struct MemoViewerDetailModel: ModelProtocol {
         environment: Environment,
         description: MemoViewerDetailDescription
     ) -> Update<Self> {
+        guard state.address != description.address else {
+            logger.warning("Attempted to appear with same address, doing nothing")
+            return Update(state: state)
+        }
+        
         var model = state
-        model.loadingState = .loading
         model.address = description.address
         
-        let fx: Fx<Action> = environment.data.readMemoDetailPublisher(
-            address: description.address
-        ).map({ response in
-            Action.setDetail(response)
-        }).eraseToAnyPublisher()
         return update(
             state: model,
             // Set meta sheet address as well
             actions: [
                 .setMetaSheetAddress(description.address),
+                .refreshAll
+            ],
+            environment: environment
+        )
+    }
+    
+    static func refreshAll(
+        state: Self,
+        environment: Environment
+    ) -> Update<Self> {
+        guard let address = state.address else {
+            logger.warning("Attempted to refresh with nil address")
+            return Update(state: state)
+        }
+        
+        var model = state
+        model.loadingState = .loading
+        
+        let fx: Fx<Action> = environment.data.readMemoDetailPublisher(
+            address: address
+        ).map({ response in
+            Action.setDetail(response)
+        }).eraseToAnyPublisher()
+        return update(
+            state: model,
+            actions: [
                 .fetchOwnerProfile,
                 .refreshBacklinks
             ],


### PR DESCRIPTION
Fixes #940 

Introduce new `MemoViewer` action `.refreshAll` that actually does the loading. `.appear` will only trigger loading if the address changes and the `MemoViewerDetailView` listens for `AppAction.succeedSyncSphereWithGateway` to trigger `.refreshAll`.

My thinking is that 3P content can only change after a sync, so that's the only explicit trigger we need.