### PR TITLE
Fix delete animation in notes list

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListView.swift
@@ -33,13 +33,13 @@ struct EntryListView: View {
                             allowsFullSwipe: false
                         ) {
                             Button(
-                                role: .destructive,
                                 action: {
                                     onEntryDelete(entry.address)
                                 }
                             ) {
                                 Text("Delete")
                             }
+                            .tint(.red)
                         }
                     }
                     .background(Color.background)


### PR DESCRIPTION
Fixes #955 

Using `role: .destructive` causes the list to preemptively remove the row. However, at this stage we have not removed it, only staged the removal, resulting in an animation jank as the item jumps back.

Instead, we do not assign a role, but give the action a tint. This causes it to show up as a destructive action (visually), but stages the deletion, avoiding the animation until the item is actually removed.


https://github.com/subconsciousnetwork/subconscious/assets/58421/e70c0afd-bbff-4ceb-8977-b3c163ae51f2