### PR TITLE
Fix (possible) delay on tapping links

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -545,8 +545,7 @@ struct AppModel: ModelProtocol {
     ///
     /// This property is updated at `.start` with the corresponding value
     /// stored in `AppDefaults`.
-    var sphereIdentity: String?
-    var sphereDid: Did?
+    var sphereIdentity: Did?
     
     /// Default sphere version, if any.
     var sphereVersion: String?
@@ -1174,7 +1173,7 @@ struct AppModel: ModelProtocol {
         state: AppModel,
         environment: AppEnvironment
     ) -> Update<AppModel> {
-        let sphereIdentity = state.sphereIdentity ?? "nil"
+        let sphereIdentity = state.sphereIdentity?.description ?? "nil"
         logger.debug(
             "appear",
             metadata: [
@@ -1427,8 +1426,7 @@ struct AppModel: ModelProtocol {
         sphereIdentity: String?
     ) -> Update<AppModel> {
         var model = state
-        model.sphereIdentity = sphereIdentity
-        model.sphereDid = Did(sphereIdentity ?? "")
+        model.sphereIdentity = Did(sphereIdentity ?? "")
         if let sphereIdentity = sphereIdentity {
             logger.debug("Set sphere ID: \(sphereIdentity)")
         }
@@ -2249,8 +2247,7 @@ struct AppModel: ModelProtocol {
         environment: AppEnvironment,
         inviteCode: InviteCode
     ) -> Update<AppModel> {
-        guard let did = state.sphereIdentity,
-              let did = Did(did) else {
+        guard let did = state.sphereIdentity else {
             // Attempt to create the sphere if it's missing.
             // We could retry redeeming the code automatically but
             // if .createSphere fails we'll end up in an infinite loop
@@ -2520,7 +2517,7 @@ struct AppModel: ModelProtocol {
                 .presentRecoveryMode(true),
                 .recoveryMode(
                     .populate(
-                        state.sphereDid,
+                        state.sphereIdentity,
                         GatewayURL(state.gatewayURL),
                         context
                     )

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -546,6 +546,9 @@ struct AppModel: ModelProtocol {
     /// This property is updated at `.start` with the corresponding value
     /// stored in `AppDefaults`.
     var sphereIdentity: String?
+    var sphereDid: Did? {
+        Did(sphereIdentity ?? "")
+    }
     /// Default sphere version, if any.
     var sphereVersion: String?
     /// State for rendering mnemonic/recovery phrase UI.
@@ -2517,7 +2520,7 @@ struct AppModel: ModelProtocol {
                 .presentRecoveryMode(true),
                 .recoveryMode(
                     .populate(
-                        Did(state.sphereIdentity ?? ""),
+                        state.sphereDid,
                         GatewayURL(state.gatewayURL),
                         context
                     )

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -546,9 +546,8 @@ struct AppModel: ModelProtocol {
     /// This property is updated at `.start` with the corresponding value
     /// stored in `AppDefaults`.
     var sphereIdentity: String?
-    var sphereDid: Did? {
-        Did(sphereIdentity ?? "")
-    }
+    var sphereDid: Did?
+    
     /// Default sphere version, if any.
     var sphereVersion: String?
     /// State for rendering mnemonic/recovery phrase UI.
@@ -1429,6 +1428,7 @@ struct AppModel: ModelProtocol {
     ) -> Update<AppModel> {
         var model = state
         model.sphereIdentity = sphereIdentity
+        model.sphereDid = Did(sphereIdentity ?? "")
         if let sphereIdentity = sphereIdentity {
             logger.debug("Set sphere ID: \(sphereIdentity)")
         }

--- a/xcode/Subconscious/Shared/Components/BacklinksView.swift
+++ b/xcode/Subconscious/Shared/Components/BacklinksView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct BacklinksView: View {
     var backlinks: [EntryStub]
     var onRequestDetail: (EntryLink) -> Void
-    var onLink: (_ context: Slashlink, SubSlashlinkLink) -> Void
+    var onLink: (_ context: EntryStub, SubSlashlinkLink) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.unit2) {
@@ -27,7 +27,7 @@ struct BacklinksView: View {
                             onRequestDetail(EntryLink(entry))
                         },
                         onLink: { link in
-                            onLink(entry.address, link)
+                            onLink(entry, link)
                         }
                     )
                 }

--- a/xcode/Subconscious/Shared/Components/BacklinksView.swift
+++ b/xcode/Subconscious/Shared/Components/BacklinksView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct BacklinksView: View {
     var backlinks: [EntryStub]
     var onRequestDetail: (EntryLink) -> Void
-    var onLink: (_ context: EntryStub, SubSlashlinkLink) -> Void
+    var onLink: (_ context: ResolvedAddress, SubSlashlinkLink) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.unit2) {
@@ -27,7 +27,7 @@ struct BacklinksView: View {
                             onRequestDetail(EntryLink(entry))
                         },
                         onLink: { link in
-                            onLink(entry, link)
+                            onLink(entry.toResolvedAddress(), link)
                         }
                     )
                 }

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -50,7 +50,7 @@ struct RecentTabView: View {
                     onLink: { context, link in
                         notify(
                             .requestFindLinkDetail(
-                                did: context.did,
+                                owner: context.did,
                                 address: context.address,
                                 link: link
                             )

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -47,10 +47,10 @@ struct RecentTabView: View {
                             )
                         )
                     },
-                    onLink: { address, link in
+                    onLink: { context, link in
                         notify(
                             .requestFindLinkDetail(
-                                address: address,
+                                context: context,
                                 link: link
                             )
                         )

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -50,7 +50,8 @@ struct RecentTabView: View {
                     onLink: { context, link in
                         notify(
                             .requestFindLinkDetail(
-                                context: context,
+                                did: context.did,
+                                address: context.address,
                                 link: link
                             )
                         )

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -50,8 +50,7 @@ struct RecentTabView: View {
                     onLink: { context, link in
                         notify(
                             .requestFindLinkDetail(
-                                owner: context.did,
-                                address: context.address,
+                                context: context,
                                 link: link
                             )
                         )

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
@@ -24,7 +24,7 @@ private struct StoryEntryUserDetailsView: View {
 struct StoryEntryView: View {
     var story: StoryEntry
     var onRequestDetail: (Slashlink, String) -> Void
-    var onLink: (_ context: EntryStub, SubSlashlinkLink) -> Void
+    var onLink: (_ context: ResolvedAddress, SubSlashlinkLink) -> Void
     var sharedNote: String {
         """
         \(story.entry.excerpt)
@@ -88,7 +88,7 @@ struct StoryEntryView: View {
                             return .systemAction
                         }
                         
-                        onLink(story.entry, subslashlink)
+                        onLink(story.entry.toResolvedAddress(), subslashlink)
                         return .handled
                     })
                     

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
@@ -76,8 +76,8 @@ struct StoryEntryView: View {
                         onViewTransclude: { slashlink in
                             onRequestDetail(slashlink, story.entry.excerpt.description)
                         },
-                        onTranscludeLink: { entry, link in
-                            onLink(entry, link)
+                        onTranscludeLink: { context, link in
+                            onLink(context, link)
                         }
                     )
                     .padding([.leading, .trailing], AppTheme.padding)

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
@@ -24,7 +24,7 @@ private struct StoryEntryUserDetailsView: View {
 struct StoryEntryView: View {
     var story: StoryEntry
     var onRequestDetail: (Slashlink, String) -> Void
-    var onLink: (_ context: Slashlink, SubSlashlinkLink) -> Void
+    var onLink: (_ context: EntryStub, SubSlashlinkLink) -> Void
     var sharedNote: String {
         """
         \(story.entry.excerpt)
@@ -76,8 +76,8 @@ struct StoryEntryView: View {
                         onViewTransclude: { slashlink in
                             onRequestDetail(slashlink, story.entry.excerpt.description)
                         },
-                        onTranscludeLink: { address, link in
-                            onLink(address, link)
+                        onTranscludeLink: { entry, link in
+                            onLink(entry, link)
                         }
                     )
                     .padding([.leading, .trailing], AppTheme.padding)
@@ -88,7 +88,7 @@ struct StoryEntryView: View {
                             return .systemAction
                         }
                         
-                        onLink(story.entry.address, subslashlink)
+                        onLink(story.entry, subslashlink)
                         return .handled
                     })
                     

--- a/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
@@ -17,7 +17,7 @@ struct SubtextView: View {
     var subtext: Subtext
     var transcludePreviews: [Slashlink: EntryStub] = [:]
     var onViewTransclude: (Slashlink) -> Void  = { _ in }
-    var onTranscludeLink: (_ context: Slashlink, SubSlashlinkLink) -> Void = { _, _ in }
+    var onTranscludeLink: (_ context: EntryStub, SubSlashlinkLink) -> Void = { _, _ in }
     
     private func entries(for block: Subtext.Block) -> [EntryStub] {
         block.slashlinks
@@ -77,7 +77,7 @@ struct SubtextView: View {
                             onViewTransclude(entry.address)
                         },
                         onLink: { link in
-                            onTranscludeLink(entry.address, link)
+                            onTranscludeLink(entry, link)
                         }
                     )
                 }

--- a/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
@@ -17,7 +17,7 @@ struct SubtextView: View {
     var subtext: Subtext
     var transcludePreviews: [Slashlink: EntryStub] = [:]
     var onViewTransclude: (Slashlink) -> Void  = { _ in }
-    var onTranscludeLink: (_ context: EntryStub, SubSlashlinkLink) -> Void = { _, _ in }
+    var onTranscludeLink: (_ context: ResolvedAddress, SubSlashlinkLink) -> Void = { _, _ in }
     
     private func entries(for block: Subtext.Block) -> [EntryStub] {
         block.slashlinks
@@ -77,7 +77,7 @@ struct SubtextView: View {
                             onViewTransclude(entry.address)
                         },
                         onLink: { link in
-                            onTranscludeLink(entry, link)
+                            onTranscludeLink(entry.toResolvedAddress(), link)
                         }
                     )
                 }

--- a/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
@@ -682,10 +682,10 @@ extension DetailStackAction {
         switch action {
         case let .requestDetail(detail):
             return .pushDetail(detail)
-        case let .requestFindLinkDetail(context, link):
+        case let .requestFindLinkDetail(did, address, link):
             return .findAndPushLinkDetail(
-                did: context.did,
-                address: context.address,
+                did: did,
+                address: address,
                 link: link
             )
         case let .requestNavigateToProfile(address):

--- a/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
@@ -109,7 +109,7 @@ enum DetailStackAction: Hashable {
     )
     
     case findAndPushLinkDetail(
-        did: Did,
+        owner: Did,
         address: Slashlink,
         link: SubSlashlinkLink
     )
@@ -182,11 +182,11 @@ struct DetailStackModel: Hashable, ModelProtocol {
                 environment: environment,
                 details: details
             )
-        case let .findAndPushLinkDetail(did, address, link):
+        case let .findAndPushLinkDetail(owner, address, link):
             return findAndPushLinkDetail(
                 state: state,
                 environment: environment,
-                did: did,
+                owner: owner,
                 address: address,
                 link: link
             )
@@ -308,7 +308,7 @@ struct DetailStackModel: Hashable, ModelProtocol {
     static func findAndPushLinkDetail(
         state: Self,
         environment: Environment,
-        did: Did,
+        owner: Did,
         address: Slashlink,
         link: SubSlashlinkLink
     ) -> Update<Self> {
@@ -317,12 +317,12 @@ struct DetailStackModel: Hashable, ModelProtocol {
         let fx: Fx<DetailStackAction> = Future.detached {
             let identity = try await environment.noosphere.identity()
             let following = await environment.addressBook.followingStatus(
-                did: did,
+                did: owner,
                 expectedName: address.petname?.leaf
             )
             
             // Is this us? Trim off the peer
-            guard did != identity else {
+            guard owner != identity else {
                 return .findAndPushDetail(
                     address: Slashlink(slug: slashlink.slug),
                     link: link
@@ -640,9 +640,9 @@ extension DetailStackAction {
             return .requestDeleteMemo(address)
         case let .requestDetail(detail):
             return .pushDetail(detail)
-        case let .requestFindLinkDetail(did, address, link):
+        case let .requestFindLinkDetail(owner, address, link):
             return .findAndPushLinkDetail(
-                did: did,
+                owner: owner,
                 address: address,
                 link: link
             )
@@ -661,9 +661,9 @@ extension DetailStackAction {
         switch action {
         case let .requestDetail(detail):
             return .pushDetail(detail)
-        case let .requestFindLinkDetail(did, address, link):
+        case let .requestFindLinkDetail(owner, address, link):
             return .findAndPushLinkDetail(
-                did: did,
+                owner: owner,
                 address: address,
                 link: link
             )
@@ -682,9 +682,9 @@ extension DetailStackAction {
         switch action {
         case let .requestDetail(detail):
             return .pushDetail(detail)
-        case let .requestFindLinkDetail(did, address, link):
+        case let .requestFindLinkDetail(owner, address, link):
             return .findAndPushLinkDetail(
-                did: did,
+                owner: owner,
                 address: address,
                 link: link
             )

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -46,7 +46,7 @@ struct MemoEditorDetailView: View {
         url: URL
     ) -> Bool {
         guard let sub = url.toSubSlashlinkURL(),
-              let did = app.state.sphereDid else {
+              let did = app.state.sphereIdentity else {
             return true
         }
         

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -49,7 +49,7 @@ struct MemoEditorDetailView: View {
             return true
         }
         
-        guard let did = Did(app.state.sphereIdentity ?? "") else {
+        guard let did = app.state.sphereDid else {
             return true
         }
         

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -45,19 +45,15 @@ struct MemoEditorDetailView: View {
     private func onLink(
         url: URL
     ) -> Bool {
-        guard let sub = url.toSubSlashlinkURL() else {
-            return true
-        }
-        
-        guard let did = app.state.sphereDid else {
+        guard let sub = url.toSubSlashlinkURL(),
+              let did = app.state.sphereDid else {
             return true
         }
         
         notify(
             // Links in the editor are based from our sphere
             .requestFindLinkDetail(
-                did: did,
-                address: Slashlink.ourProfile,
+                context: ResolvedAddress(owner: did, slashlink: Slashlink.ourProfile),
                 link: sub
             )
         )
@@ -281,8 +277,7 @@ enum MemoEditorDetailNotification: Hashable {
     case requestDetail(MemoDetailDescription)
     /// Request detail from any audience scope
     case requestFindLinkDetail(
-        did: Did,
-        address: Slashlink,
+        context: ResolvedAddress,
         link: SubSlashlinkLink
     )
     case requestDelete(Slashlink?)

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -183,9 +183,7 @@ struct MemoEditorDetailView: View {
             VStack(spacing: 0) {
                 ScrollView(.vertical) {
                     VStack(spacing: 0) {
-                        SubtextTextViewRepresentable(
-                            state: store.state.editor,
-                            send: Address.forward(
+                        SubtextTextViewRepresentable( state: store.state.editor, send: Address.forward(
                                 send: store.send,
                                 tag: MemoEditorDetailSubtextTextCursor.tag
                             ),
@@ -217,8 +215,13 @@ struct MemoEditorDetailView: View {
                                     )
                                 )
                             },
-                            onLink: { address, link in
-                                notify(.requestFindLinkDetail(address, link: link))
+                            onLink: { context, link in
+                                notify(
+                                    .requestFindLinkDetail(
+                                        context: context,
+                                        link: link
+                                    )
+                                )
                             }
                         )
                     }

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -49,9 +49,15 @@ struct MemoEditorDetailView: View {
             return true
         }
         
+        guard let did = Did(app.state.sphereIdentity ?? "") else {
+            return true
+        }
+        
         notify(
+            // Links in the editor are based from our sphere
             .requestFindLinkDetail(
-                Slashlink.ourProfile, // Links in the editor are based from our sphere
+                did: did,
+                address: Slashlink.ourProfile,
                 link: sub
             )
         )
@@ -275,7 +281,8 @@ enum MemoEditorDetailNotification: Hashable {
     case requestDetail(MemoDetailDescription)
     /// Request detail from any audience scope
     case requestFindLinkDetail(
-        _ context: Slashlink,
+        did: Did,
+        address: Slashlink,
         link: SubSlashlinkLink
     )
     case requestDelete(Slashlink?)

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -176,7 +176,8 @@ struct MemoViewerDetailLoadedView: View {
         }
         
         guard let did = user?.did else {
-            return .systemAction
+            MemoViewerDetailModel.logger.log("User profile is not loaded, can't handle link")
+            return .handled
         }
         
         notify(

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -128,8 +128,7 @@ struct MemoViewerDetailNotFoundView: View {
                 onLink: { context, link in
                     notify(
                         .requestFindLinkDetail(
-                            owner: context.did,
-                            address: context.address,
+                            context: context,
                             link: link
                         )
                     )
@@ -182,8 +181,7 @@ struct MemoViewerDetailLoadedView: View {
         
         notify(
             .requestFindLinkDetail(
-                owner: did,
-                address: address,
+                context: ResolvedAddress(owner: did, slashlink: address),
                 link: link
             )
         )
@@ -191,7 +189,7 @@ struct MemoViewerDetailLoadedView: View {
     }
     
     private func onLink(
-        context: EntryStub,
+        context: ResolvedAddress,
         url: URL
     ) -> OpenURLAction.Result {
         guard let link = url.toSubSlashlinkURL() else {
@@ -200,8 +198,7 @@ struct MemoViewerDetailLoadedView: View {
         
         notify(
             .requestFindLinkDetail(
-                owner: context.did,
-                address: context.address,
+                context: context,
                 link: link
             )
         )
@@ -234,8 +231,7 @@ struct MemoViewerDetailLoadedView: View {
                             onTranscludeLink: { context, link in
                                 notify(
                                     .requestFindLinkDetail(
-                                        owner: context.did,
-                                        address: context.address,
+                                        context: context,
                                         link: link
                                     )
                                 )
@@ -259,8 +255,7 @@ struct MemoViewerDetailLoadedView: View {
                         onLink: { context, link in
                             notify(
                                 .requestFindLinkDetail(
-                                    owner: context.did,
-                                    address: context.address,
+                                    context: context,
                                     link: link
                                 )
                             )
@@ -279,8 +274,7 @@ enum MemoViewerDetailNotification: Hashable {
     case requestDetail(_ description: MemoDetailDescription)
     /// Request detail from any audience scope
     case requestFindLinkDetail(
-        owner: Did,
-        address: Slashlink,
+        context: ResolvedAddress,
         link: SubSlashlinkLink
     )
     case requestUserProfileDetail(_ address: Slashlink)

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -156,6 +156,11 @@ struct MemoViewerDetailLoadedView: View {
     var send: (MemoViewerDetailAction) -> Void
     var notify: (MemoViewerDetailNotification) -> Void
     
+    static let logger = Logger(
+        subsystem: Config.default.rdns,
+        category: "MemoViewerDetailLoadedView"
+    )
+    
     func onBacklinkSelect(_ link: EntryLink) {
         notify(
             .requestDetail(
@@ -175,7 +180,7 @@ struct MemoViewerDetailLoadedView: View {
         }
         
         guard let did = user?.did else {
-            MemoViewerDetailModel.logger.log("User profile is not loaded, can't handle link")
+            Self.logger.log("User profile is not loaded, can't handle link")
             return .handled
         }
         

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -53,7 +53,7 @@ struct MemoViewerDetailView: View {
                 )
             case .notFound:
                 MemoViewerDetailNotFoundView(
-                    store: store,
+                    backlinks: store.state.backlinks,
                     notify: notify
                 )
             }
@@ -102,12 +102,7 @@ struct MemoViewerDetailView: View {
 
 /// View for the "not found" state of content
 struct MemoViewerDetailNotFoundView: View {
-    @ObservedObject var store: Store<MemoViewerDetailModel>
-    
-    var backlinks: [EntryStub] {
-        store.state.backlinks
-    }
-    
+    var backlinks: [EntryStub]
     var notify: (MemoViewerDetailNotification) -> Void
     var contentFrameHeight = UIFont.appTextMono.lineHeight * 8
     
@@ -133,7 +128,7 @@ struct MemoViewerDetailNotFoundView: View {
                 onLink: { context, link in
                     notify(
                         .requestFindLinkDetail(
-                            did: context.did,
+                            owner: context.did,
                             address: context.address,
                             link: link
                         )
@@ -186,7 +181,7 @@ struct MemoViewerDetailLoadedView: View {
         
         notify(
             .requestFindLinkDetail(
-                did: did,
+                owner: did,
                 address: address,
                 link: link
             )
@@ -204,7 +199,7 @@ struct MemoViewerDetailLoadedView: View {
         
         notify(
             .requestFindLinkDetail(
-                did: context.did,
+                owner: context.did,
                 address: context.address,
                 link: link
             )
@@ -238,7 +233,7 @@ struct MemoViewerDetailLoadedView: View {
                             onTranscludeLink: { context, link in
                                 notify(
                                     .requestFindLinkDetail(
-                                        did: context.did,
+                                        owner: context.did,
                                         address: context.address,
                                         link: link
                                     )
@@ -263,7 +258,7 @@ struct MemoViewerDetailLoadedView: View {
                         onLink: { context, link in
                             notify(
                                 .requestFindLinkDetail(
-                                    did: context.did,
+                                    owner: context.did,
                                     address: context.address,
                                     link: link
                                 )
@@ -283,7 +278,7 @@ enum MemoViewerDetailNotification: Hashable {
     case requestDetail(_ description: MemoDetailDescription)
     /// Request detail from any audience scope
     case requestFindLinkDetail(
-        did: Did,
+        owner: Did,
         address: Slashlink,
         link: SubSlashlinkLink
     )
@@ -760,35 +755,30 @@ struct MemoViewerDetailView_Previews: PreviewProvider {
         )
 
         MemoViewerDetailNotFoundView(
-            store: Store(
-                state: MemoViewerDetailModel(
-                    backlinks: [
-                        EntryStub(
-                            did: Did.dummyData(),
-                            address: Slashlink(
-                                "@bob/bar"
-                            )!,
-                            excerpt: Subtext(
-                                markup: "The hidden well-spring of your soul must needs rise and run murmuring to the sea; And the treasure of your infinite depths would be revealed to your eyes. But let there be no scales to weigh your unknown treasure; And seek not the depths of your knowledge with staff or sounding line. For self is a sea boundless and measureless."
-                            ),
-                            isTruncated: false,
-                            modified: Date.now
-                        ),
-                        EntryStub(
-                            did: Did.dummyData(),
-                            address: Slashlink(
-                                "@bob/baz"
-                            )!,
-                            excerpt: Subtext(
-                                markup: "Think you the spirit is a still pool which you can trouble with a staff? Oftentimes in denying yourself pleasure you do but store the desire in the recesses of your being. Who knows but that which seems omitted today, waits for tomorrow?"
-                            ),
-                            isTruncated: false,
-                            modified: Date.now
-                        )
-                    ]
+            backlinks: [
+                EntryStub(
+                    did: Did.dummyData(),
+                    address: Slashlink(
+                        "@bob/bar"
+                    )!,
+                    excerpt: Subtext(
+                        markup: "The hidden well-spring of your soul must needs rise and run murmuring to the sea; And the treasure of your infinite depths would be revealed to your eyes. But let there be no scales to weigh your unknown treasure; And seek not the depths of your knowledge with staff or sounding line. For self is a sea boundless and measureless."
+                    ),
+                    isTruncated: false,
+                    modified: Date.now
                 ),
-                environment: AppEnvironment()
-            ),
+                EntryStub(
+                    did: Did.dummyData(),
+                    address: Slashlink(
+                        "@bob/baz"
+                    )!,
+                    excerpt: Subtext(
+                        markup: "Think you the spirit is a still pool which you can trouble with a staff? Oftentimes in denying yourself pleasure you do but store the desire in the recesses of your being. Who knows but that which seems omitted today, waits for tomorrow?"
+                    ),
+                    isTruncated: false,
+                    modified: Date.now
+                )
+            ],
             notify: {
                 action in 
             }

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -66,7 +66,7 @@ enum UserProfileDetailNotification: Hashable {
     case requestNavigateToProfile(_ address: Slashlink)
     case requestDetail(MemoDetailDescription)
     case requestFindLinkDetail(
-        address: Slashlink,
+        context: EntryStub,
         link: SubSlashlinkLink
     )
 }

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -66,7 +66,7 @@ enum UserProfileDetailNotification: Hashable {
     case requestNavigateToProfile(_ address: Slashlink)
     case requestDetail(MemoDetailDescription)
     case requestFindLinkDetail(
-        did: Did,
+        owner: Did,
         address: Slashlink,
         link: SubSlashlinkLink
     )

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -66,7 +66,8 @@ enum UserProfileDetailNotification: Hashable {
     case requestNavigateToProfile(_ address: Slashlink)
     case requestDetail(MemoDetailDescription)
     case requestFindLinkDetail(
-        context: EntryStub,
+        did: Did,
+        address: Slashlink,
         link: SubSlashlinkLink
     )
 }

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -66,8 +66,7 @@ enum UserProfileDetailNotification: Hashable {
     case requestNavigateToProfile(_ address: Slashlink)
     case requestDetail(MemoDetailDescription)
     case requestFindLinkDetail(
-        owner: Did,
-        address: Slashlink,
+        context: ResolvedAddress,
         link: SubSlashlinkLink
     )
 }

--- a/xcode/Subconscious/Shared/Components/Feed/FeedListView.swift
+++ b/xcode/Subconscious/Shared/Components/Feed/FeedListView.swift
@@ -33,11 +33,12 @@ struct FeedListView: View {
                                 )
                             )
                         },
-                        onLink: { address, link in
+                        onLink: { entry, link in
                             store.send(
                                 .detailStack(
                                     .findAndPushLinkDetail(
-                                        address: address,
+                                        did: entry.did,
+                                        address: entry.address,
                                         link: link
                                     )
                                 )

--- a/xcode/Subconscious/Shared/Components/Feed/FeedListView.swift
+++ b/xcode/Subconscious/Shared/Components/Feed/FeedListView.swift
@@ -37,8 +37,7 @@ struct FeedListView: View {
                             store.send(
                                 .detailStack(
                                     .findAndPushLinkDetail(
-                                        owner: context.did,
-                                        address: context.address,
+                                        context: context,
                                         link: link
                                     )
                                 )

--- a/xcode/Subconscious/Shared/Components/Feed/FeedListView.swift
+++ b/xcode/Subconscious/Shared/Components/Feed/FeedListView.swift
@@ -33,12 +33,12 @@ struct FeedListView: View {
                                 )
                             )
                         },
-                        onLink: { entry, link in
+                        onLink: { context, link in
                             store.send(
                                 .detailStack(
                                     .findAndPushLinkDetail(
-                                        did: entry.did,
-                                        address: entry.address,
+                                        owner: context.did,
+                                        address: context.address,
                                         link: link
                                     )
                                 )

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunDoneView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunDoneView.swift
@@ -31,7 +31,7 @@ struct FirstRunDoneView: View {
     }
     
     private var did: Did? {
-        Did(app.state.sphereIdentity ?? "")
+        app.state.sphereDid
     }
     
     var statusLabel: String {

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunDoneView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunDoneView.swift
@@ -31,7 +31,7 @@ struct FirstRunDoneView: View {
     }
     
     private var did: Did? {
-        app.state.sphereDid
+        app.state.sphereIdentity
     }
     
     var statusLabel: String {

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
@@ -13,7 +13,7 @@ struct FirstRunProfileView: View {
     @Environment(\.colorScheme) var colorScheme
     
     var did: Did? {
-        Did(app.state.sphereIdentity ?? "")
+        app.state.sphereDid
     }
     
     var body: some View {

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
@@ -13,7 +13,7 @@ struct FirstRunProfileView: View {
     @Environment(\.colorScheme) var colorScheme
     
     var did: Did? {
-        app.state.sphereDid
+        app.state.sphereIdentity
     }
     
     var body: some View {

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunRecoveryView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunRecoveryView.swift
@@ -13,7 +13,7 @@ struct FirstRunRecoveryView: View {
     @Environment(\.colorScheme) var colorScheme
     
     var did: Did? {
-        Did(app.state.sphereIdentity ?? "")
+        app.state.sphereDid
     }
     
     var body: some View {

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunRecoveryView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunRecoveryView.swift
@@ -13,7 +13,7 @@ struct FirstRunRecoveryView: View {
     @Environment(\.colorScheme) var colorScheme
     
     var did: Did? {
-        app.state.sphereDid
+        app.state.sphereIdentity
     }
     
     var body: some View {

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunSphereView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunSphereView.swift
@@ -12,7 +12,7 @@ struct FirstRunSphereView: View {
     @Environment(\.colorScheme) var colorScheme
     
     var did: Did? {
-        app.state.sphereDid
+        app.state.sphereIdentity
     }
     
     var body: some View {

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunSphereView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunSphereView.swift
@@ -12,7 +12,7 @@ struct FirstRunSphereView: View {
     @Environment(\.colorScheme) var colorScheme
     
     var did: Did? {
-        Did(app.state.sphereIdentity ?? "")
+        app.state.sphereDid
     }
     
     var body: some View {

--- a/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
@@ -75,7 +75,7 @@ struct SettingsView: View {
                             label: {
                                 LabeledContent(
                                     "Sphere",
-                                    value: app.state.sphereIdentity ?? unknown
+                                    value: app.state.sphereIdentity?.description ?? unknown
                                 )
                                 .lineLimit(1)
                             }

--- a/xcode/Subconscious/Shared/Components/Settings/SphereSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/SphereSettingsView.swift
@@ -23,7 +23,7 @@ struct SphereSettingsView: View {
                 }
             )
             
-            if let did = app.state.sphereDid {
+            if let did = app.state.sphereIdentity {
                 Section(header: Text("Your DID")) {
                     DidView(did: did)
                 }

--- a/xcode/Subconscious/Shared/Components/Settings/SphereSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/SphereSettingsView.swift
@@ -23,7 +23,7 @@ struct SphereSettingsView: View {
                 }
             )
             
-            if let did = Did(app.state.sphereIdentity ?? "") {
+            if let did = app.state.sphereDid {
                 Section(header: Text("Your DID")) {
                     DidView(did: did)
                 }

--- a/xcode/Subconscious/Shared/Models/EntryStub.swift
+++ b/xcode/Subconscious/Shared/Models/EntryStub.swift
@@ -36,6 +36,10 @@ struct EntryStub:
             modified: modified
         )
     }
+    
+    func toResolvedAddress() -> ResolvedAddress {
+        ResolvedAddress(owner: did, slashlink: address)
+    }
 }
 
 extension EntryLink {

--- a/xcode/Subconscious/Shared/Models/ResolvedAddress.swift
+++ b/xcode/Subconscious/Shared/Models/ResolvedAddress.swift
@@ -1,0 +1,13 @@
+//
+//  Address.swift
+//  Subconscious (iOS)
+//
+//  Created by Ben Follington on 3/11/2023.
+//
+
+import Foundation
+
+struct ResolvedAddress: Equatable, Hashable {
+    var owner: Did
+    var slashlink: Slashlink
+}

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		B532F8C329B1752E00CE9256 /* TranscludeBlockLayoutFragment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532F8C229B1752E00CE9256 /* TranscludeBlockLayoutFragment.swift */; };
 		B540F8BA2A0C748C00876256 /* Line.swift in Sources */ = {isa = PBXBuildFile; fileRef = B540F8B92A0C748C00876256 /* Line.swift */; };
 		B54187B829EF5CA00056E4A9 /* FollowUserFormSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54187B729EF5CA00056E4A9 /* FollowUserFormSheet.swift */; };
+		B542EF802AF4B88500BE29F1 /* ResolvedAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = B542EF7F2AF4B88500BE29F1 /* ResolvedAddress.swift */; };
 		B5432B8329F8BAED003BBB23 /* Tests_UserProfileService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5432B8229F8BAED003BBB23 /* Tests_UserProfileService.swift */; };
 		B54930B12A2F0FE300958F12 /* StoryPlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54930B02A2F0FE300958F12 /* StoryPlaceholderView.swift */; };
 		B549B16B2A0CDAC10070C6AD /* FirstRunRecoveryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B549B16A2A0CDAC10070C6AD /* FirstRunRecoveryView.swift */; };
@@ -539,6 +540,7 @@
 		B532F8C229B1752E00CE9256 /* TranscludeBlockLayoutFragment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscludeBlockLayoutFragment.swift; sourceTree = "<group>"; };
 		B540F8B92A0C748C00876256 /* Line.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Line.swift; sourceTree = "<group>"; };
 		B54187B729EF5CA00056E4A9 /* FollowUserFormSheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FollowUserFormSheet.swift; sourceTree = "<group>"; };
+		B542EF7F2AF4B88500BE29F1 /* ResolvedAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolvedAddress.swift; sourceTree = "<group>"; };
 		B5432B8229F8BAED003BBB23 /* Tests_UserProfileService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_UserProfileService.swift; sourceTree = "<group>"; };
 		B54930B02A2F0FE300958F12 /* StoryPlaceholderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryPlaceholderView.swift; sourceTree = "<group>"; };
 		B549B16A2A0CDAC10070C6AD /* FirstRunRecoveryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstRunRecoveryView.swift; sourceTree = "<group>"; };
@@ -1324,6 +1326,7 @@
 				B5E60C8A2A145F04007065A1 /* UserProfileBio.swift */,
 				B81A1A6C29DF267200B4CD1C /* LoadingState.swift */,
 				B5E816B82AB0458E00C61500 /* RecoveryPhrase.swift */,
+				B542EF7F2AF4B88500BE29F1 /* ResolvedAddress.swift */,
 				B51359292AC2723E004385A7 /* GatewayURL.swift */,
 			);
 			path = Models;
@@ -2170,6 +2173,7 @@
 				B88B1CE1298EAE730062CB7F /* PillButtonStyle.swift in Sources */,
 				B8AE34A7276A885300777FF0 /* TextViewRepresentable.swift in Sources */,
 				B8CAF20F2A9E7C8C0057D5DE /* SubtextTextView.swift in Sources */,
+				B542EF802AF4B88500BE29F1 /* ResolvedAddress.swift in Sources */,
 				B8C0A1B4297C938000D59532 /* Error.swift in Sources */,
 				B8CBAFA229930C660079107E /* ValidatedTextField.swift in Sources */,
 				B86DD5702AA0D28600E1DEA5 /* BlockEditorRelatedView.swift in Sources */,

--- a/xcode/Subconscious/SubconsciousTests/Tests_DetailStack.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DetailStack.swift
@@ -7,10 +7,12 @@
 
 import XCTest
 import ObservableStore
+import Combine
 @testable import Subconscious
 
 class Tests_DetailStack: XCTestCase {
     let environment = AppEnvironment()
+    var cancellable: AnyCancellable?
     
     func testSubSlashlinkRebase() throws {
         let slashlink = Slashlink(petname: Petname("bob.alice")!, slug: Slug("hello")!)
@@ -43,21 +45,21 @@ class Tests_DetailStack: XCTestCase {
             let expectation = XCTestExpectation(
                 description: "findAndPushDetail is sent"
             )
-            _ = update.fx.sink(
-                receiveCompletion: { completion in
-                    expectation.fulfill()
-                },
-                receiveValue: { action in
-                    switch action {
-                    case let .findAndPushDetail(address: newAddress, link: newLink):
-                        XCTAssertEqual(newLink, link)
-                        XCTAssertEqual(Slashlink("@bob.alice.origin/hello"), newAddress)
+        self.cancellable = update.fx.sink(
+            receiveCompletion: { completion in
+                expectation.fulfill()
+            },
+            receiveValue: { action in
+                switch action {
+                case let .findAndPushDetail(address: newAddress, link: newLink):
+                    XCTAssertEqual(newLink, link)
+                    XCTAssertEqual(Slashlink("@bob.alice.origin/hello"), newAddress)
                     default:
                         XCTFail("Incorrect action")
                     }
                 }
             )
-            wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 2.0)
     }
 
 

--- a/xcode/Subconscious/SubconsciousTests/Tests_DetailStack.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DetailStack.swift
@@ -40,15 +40,18 @@ class Tests_DetailStack: XCTestCase {
         let slashlink = Slashlink(petname: Petname("bob.alice")!, slug: Slug("hello")!)
         let address = Slashlink(petname: Petname("origin")!)
         let link = SubSlashlinkLink(slashlink: slashlink)
+        let did = Did.dummyData()
         
         let action = MemoViewerDetailNotification.requestFindLinkDetail(
+            owner: did,
             address: address,
             link: link
         )
         
         let newAction = DetailStackAction.tag(action)
         switch newAction {
-        case let .findAndPushLinkDetail(newAddress, newLink):
+        case let .findAndPushLinkDetail(newDid, newAddress, newLink):
+            XCTAssertEqual(did, newDid)
             XCTAssertEqual(address, newAddress)
             XCTAssertEqual(link, newLink)
         default:
@@ -59,16 +62,19 @@ class Tests_DetailStack: XCTestCase {
     func testEditorSlashlinkConstruction() throws {
         let slashlink = Slashlink(petname: Petname("bob.alice")!, slug: Slug("hello")!)
         let link = SubSlashlinkLink(slashlink: slashlink)
+        let did = Did.dummyData()
         
         let action = MemoEditorDetailNotification.requestFindLinkDetail(
-            Slashlink.ourProfile,
+            owner: did,
+            address: Slashlink.ourProfile,
             link: link
         )
         
         let newAction = DetailStackAction.tag(action)
         
         switch newAction {
-        case let .findAndPushLinkDetail(newAddress, newLink):
+        case let .findAndPushLinkDetail(newDid, newAddress, newLink):
+            XCTAssertEqual(newDid, did)
             XCTAssertEqual(newAddress, Slashlink.ourProfile)
             XCTAssertEqual(newLink, link)
         default:

--- a/xcode/Subconscious/SubconsciousTests/Tests_DetailStack.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DetailStack.swift
@@ -41,10 +41,14 @@ class Tests_DetailStack: XCTestCase {
         let link = SubSlashlinkLink(slashlink: slashlink)
         let did = Did.dummyData()
         
-        let update = DetailStackModel.update(state: model, action: .findAndPushLinkDetail(owner: did, address: address, link: link), environment: environment)
-            let expectation = XCTestExpectation(
-                description: "findAndPushDetail is sent"
-            )
+        let update = DetailStackModel.update(
+            state: model,
+            action: .findAndPushLinkDetail(owner: did, address: address, link: link),
+            environment: environment
+        )
+        let expectation = XCTestExpectation(
+            description: "findAndPushDetail is sent"
+        )
         self.cancellable = update.fx.sink(
             receiveCompletion: { completion in
                 expectation.fulfill()

--- a/xcode/Subconscious/SubconsciousTests/Tests_DetailStack.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DetailStack.swift
@@ -75,16 +75,15 @@ class Tests_DetailStack: XCTestCase {
         let did = Did.dummyData()
         
         let action = MemoViewerDetailNotification.requestFindLinkDetail(
-            owner: did,
-            address: address,
+            context: ResolvedAddress(owner: did, slashlink: address),
             link: link
         )
         
         let newAction = DetailStackAction.tag(action)
         switch newAction {
-        case let .findAndPushLinkDetail(newDid, newAddress, newLink):
-            XCTAssertEqual(did, newDid)
-            XCTAssertEqual(address, newAddress)
+        case let .findAndPushLinkDetail(context, newLink):
+            XCTAssertEqual(did, context.owner)
+            XCTAssertEqual(address, context.slashlink)
             XCTAssertEqual(link, newLink)
         default:
             XCTFail("Incorrect action")
@@ -97,17 +96,16 @@ class Tests_DetailStack: XCTestCase {
         let did = Did.dummyData()
         
         let action = MemoEditorDetailNotification.requestFindLinkDetail(
-            owner: did,
-            address: Slashlink.ourProfile,
+            context: ResolvedAddress(owner: did, slashlink: Slashlink.ourProfile),
             link: link
         )
         
         let newAction = DetailStackAction.tag(action)
         
         switch newAction {
-        case let .findAndPushLinkDetail(newDid, newAddress, newLink):
-            XCTAssertEqual(newDid, did)
-            XCTAssertEqual(newAddress, Slashlink.ourProfile)
+        case let .findAndPushLinkDetail(context, newLink):
+            XCTAssertEqual(did, context.owner)
+            XCTAssertEqual(Slashlink.ourProfile, context.slashlink)
             XCTAssertEqual(newLink, link)
         default:
             XCTFail("Incorrect action")

--- a/xcode/Subconscious/SubconsciousTests/Tests_DetailStack.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DetailStack.swift
@@ -40,10 +40,11 @@ class Tests_DetailStack: XCTestCase {
         let address = Slashlink(petname: Petname("origin")!)
         let link = SubSlashlinkLink(slashlink: slashlink)
         let did = Did.dummyData()
+        let context = ResolvedAddress(owner: did, slashlink: address)
         
         let update = DetailStackModel.update(
             state: model,
-            action: .findAndPushLinkDetail(owner: did, address: address, link: link),
+            action: .findAndPushLinkDetail(context: context, link: link),
             environment: environment
         )
         let expectation = XCTestExpectation(

--- a/xcode/Subconscious/SubconsciousTests/Tests_DetailStack.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DetailStack.swift
@@ -13,8 +13,6 @@ class Tests_DetailStack: XCTestCase {
     let environment = AppEnvironment()
     
     func testSubSlashlinkRebase() throws {
-        let model = DetailStackModel()
-        
         let slashlink = Slashlink(petname: Petname("bob.alice")!, slug: Slug("hello")!)
         let baseAddress = Slashlink(petname: Petname("origin")!)
         let link = SubSlashlinkLink(slashlink: slashlink)
@@ -32,11 +30,38 @@ class Tests_DetailStack: XCTestCase {
             return
         }
     }
+    
+    func testFindAndPushLinkDetail() throws {
+        let model = DetailStackModel()
+        
+        let slashlink = Slashlink(petname: Petname("bob.alice")!, slug: Slug("hello")!)
+        let address = Slashlink(petname: Petname("origin")!)
+        let link = SubSlashlinkLink(slashlink: slashlink)
+        let did = Did.dummyData()
+        
+        let update = DetailStackModel.update(state: model, action: .findAndPushLinkDetail(owner: did, address: address, link: link), environment: environment)
+            let expectation = XCTestExpectation(
+                description: "findAndPushDetail is sent"
+            )
+            _ = update.fx.sink(
+                receiveCompletion: { completion in
+                    expectation.fulfill()
+                },
+                receiveValue: { action in
+                    switch action {
+                    case let .findAndPushDetail(address: newAddress, link: newLink):
+                        XCTAssertEqual(newLink, link)
+                        XCTAssertEqual(Slashlink("@bob.alice.origin/hello"), newAddress)
+                    default:
+                        XCTFail("Incorrect action")
+                    }
+                }
+            )
+            wait(for: [expectation], timeout: 2.0)
+    }
 
 
     func testViewerSlashlinkConstruction() throws {
-        let model = DetailStackModel()
-        
         let slashlink = Slashlink(petname: Petname("bob.alice")!, slug: Slug("hello")!)
         let address = Slashlink(petname: Petname("origin")!)
         let link = SubSlashlinkLink(slashlink: slashlink)


### PR DESCRIPTION
Fixes #957 

- Ensure DID is known at link traversal time
    - Thread the DID through from whatever context the link is being tapped in, lets us skip `noosphere.resolve`
- Don't let `context` make its way to the `DetailStackModel`
