### PR TITLE
Index and purge peers by petname + rework follow / unfollow lifecycle

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -270,10 +270,22 @@ enum AppAction: Hashable {
     /// Control the visibility of the recovery mode overlay
     case presentRecoveryMode(_ isPresented: Bool)
     
+    // TODO: refactor this as part of https://github.com/subconsciousnetwork/subconscious/pull/996
     /// Notification that a follow happened, and the sphere was resolved
     case notifySucceedResolveFollowedUser(petname: Petname, cid: Cid?)
-    /// Notification that an unfollow happened somewhere else
-    case notifySucceedUnfollow(identity: Did, petname: Petname)
+    
+    // Addressbook Management Actions
+    case followPeer(identity: Did, petname: Petname)
+    case failFollowPeer(error: String)
+    case succeedFollowPeer(_ petname: Petname)
+    
+    case renamePeer(from: Petname, to: Petname)
+    case failRenamePeer(error: String)
+    case succeedRenamePeer(identity: Did, from: Petname, to: Petname)
+    
+    case unfollowPeer(identity: Did, petname: Petname)
+    case failUnfollowPeer(error: String)
+    case succeedUnfollowPeer(identity: Did, petname: Petname)
     
     case authorization(_ action: AuthorizationSettingsAction)
     
@@ -1083,13 +1095,68 @@ struct AppModel: ModelProtocol {
                 petname: petname,
                 cid: cid
             )
-        case let .notifySucceedUnfollow(did, petname):
-            return notifySucceedUnfollow(
+        // MARK: Address book actions
+        case .followPeer(let identity, let petname):
+            return followPeer(
                 state: state,
                 environment: environment,
-                identity: did,
+                identity: identity,
                 petname: petname
             )
+        case .failFollowPeer(let error):
+            return failFollowPeer(
+                state: state,
+                environment: environment,
+                error: error
+            )
+        case .succeedFollowPeer(let petname):
+            return succeedFollowPeer(
+                state: state,
+                environment: environment,
+                petname: petname
+            )
+        case .renamePeer(let from, let to):
+            return renamePeer(
+                state: state,
+                environment: environment,
+                from: from,
+                to: to
+            )
+        case .failRenamePeer(let error):
+            return failRenamePeer(
+                state: state,
+                environment: environment,
+                error: error
+            )
+        case .succeedRenamePeer(let identity, let from, let to):
+            return succeedRenamePeer(
+                state: state,
+                environment: environment,
+                identity: identity,
+                from: from,
+                to: to
+            )
+        case .unfollowPeer(let identity, let petname):
+            return unfollowPeer(
+                state: state,
+                environment: environment,
+                identity: identity,
+                petname: petname
+            )
+        case .failUnfollowPeer(let error):
+            return failUnfollowPeer(
+                state: state,
+                environment: environment,
+                error: error
+            )
+        case .succeedUnfollowPeer(let identity, let petname):
+            return succeedUnfollowPeer(
+                state: state,
+                environment: environment,
+                identity: identity,
+                petname: petname
+            )
+        // MARK: Note management
         case let .deleteMemo(address):
             return deleteMemo(
                 state: state,
@@ -2431,14 +2498,157 @@ struct AppModel: ModelProtocol {
         )
     }
     
-    static func notifySucceedUnfollow(
+    static func followPeer(
+        state: AppModel,
+        environment: AppEnvironment,
+        identity: Did,
+        petname: Petname
+    ) -> Update<AppModel> {
+        let fx: Fx<AppAction> =
+            environment.addressBook
+                .followUserPublisher(
+                    did: identity,
+                    petname: petname,
+                    preventOverwrite: true
+                )
+                .map({ _ in
+                    .succeedFollowPeer(petname)
+                })
+                .recover { error in
+                    .failFollowPeer(
+                        error: error.localizedDescription
+                    )
+                }
+                .eraseToAnyPublisher()
+        
+        return Update(state: state, fx: fx)
+    }
+
+    static func failFollowPeer(
+        state: AppModel,
+        environment: AppEnvironment,
+        error: String
+    ) -> Update<AppModel> {
+        logger.warning("Failed to follow user: \(error)")
+        return update(
+            state: state,
+            action: .pushToast(message: String(localized: "Failed to follow user")),
+            environment: environment
+        )
+    }
+
+    static func succeedFollowPeer(
+        state: AppModel,
+        environment: AppEnvironment,
+        petname: Petname
+    ) -> Update<AppModel> {
+        logger.log(
+            "Followed sphere",
+            metadata: [
+                "petname": petname.description
+            ]
+        )
+        
+        return update(
+            state: state,
+            actions: [
+                .pushToast(message: "Followed \(petname.markup)"),
+                .indexPeers([petname]),
+                .syncAll
+            ],
+            environment: environment
+        )
+    }
+
+    static func renamePeer(
+        state: AppModel,
+        environment: AppEnvironment,
+        from: Petname,
+        to: Petname
+    ) -> Update<AppModel> {
+        let fx: Fx<AppAction> =
+        Future.detached {
+            let did = try await environment.addressBook.unfollowUser(petname: from)
+            try await environment.addressBook.followUser(did: did, petname: to)
+            
+            return .succeedRenamePeer(identity: did, from: from, to: to)
+        }
+        .recover { error in
+            .failRenamePeer(error: error.localizedDescription)
+        }
+        .eraseToAnyPublisher()
+        
+        // Implement functionality
+        return Update(state: state, fx: fx)
+    }
+
+    static func failRenamePeer(
+        state: AppModel,
+        environment: AppEnvironment,
+        error: String
+    ) -> Update<AppModel> {
+        logger.warning("Failed to rename user: \(error)")
+        return update(
+            state: state,
+            action: .pushToast(message: String(localized: "Failed to rename user")),
+            environment: environment
+        )
+    }
+
+    static func succeedRenamePeer(
+        state: AppModel,
+        environment: AppEnvironment,
+        identity: Did,
+        from: Petname,
+        to: Petname
+    ) -> Update<AppModel> {
+        return update(
+            state: state,
+            action: .pushToast(message: String(localized: "Renamed to \(to.markup)")),
+            environment: environment
+        )
+    }
+
+    static func unfollowPeer(
+        state: AppModel,
+        environment: AppEnvironment,
+        identity: Did,
+        petname: Petname
+    ) -> Update<AppModel> {
+        let fx: Fx<AppAction> = environment.addressBook
+            .unfollowUserPublisher(petname: petname)
+            .map({ identity in
+                .succeedUnfollowPeer(identity: identity, petname: petname)
+            })
+            .recover({ error in
+                .failUnfollowPeer(error: error.localizedDescription)
+            })
+            .eraseToAnyPublisher()
+        
+        return Update(state: state, fx: fx)
+    }
+
+    static func failUnfollowPeer(
+        state: AppModel,
+        environment: AppEnvironment,
+        error: String
+    ) -> Update<AppModel> {
+        logger.warning("Failed to unfollow user: \(error)")
+        return update(
+            state: state,
+            action: .pushToast(message: String(localized: "Failed to unfollow user")),
+            environment: environment
+        )
+    }
+    
+    static func succeedUnfollowPeer(
         state: Self,
         environment: Environment,
         identity: Did,
         petname: Petname
     ) -> Update<Self> {
         logger.log(
-            "Notify unfollowed sphere",
+            "Unfollowed sphere",
             metadata: [
                 "did": identity.description,
                 "petname": petname.description
@@ -2446,7 +2656,11 @@ struct AppModel: ModelProtocol {
         )
         return update(
             state: state,
-            action: .purgePeer(petname),
+            actions: [
+                .pushToast(message: "Unfollowed \(petname.markup)"),
+                .purgePeer(petname),
+                .syncAll
+            ],
             environment: environment
         )
     }

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -229,8 +229,8 @@ enum AppAction: Hashable {
     case completeIndexPeers(results: [PeerIndexResult])
 
     /// Purge the contents of a sphere from the database
-    case purgePeer(_ did: Did)
-    case succeedPurgePeer(_ did: Did)
+    case purgePeer(_ petname: Petname)
+    case succeedPurgePeer(_ petname: Petname)
     case failPurgePeer(_ error: String)
 
     case followDefaultGeist
@@ -1002,17 +1002,17 @@ struct AppModel: ModelProtocol {
                 environment: environment,
                 results: results
             )
-        case .purgePeer(let identity):
+        case .purgePeer(let petname):
             return purgePeer(
                 state: state,
                 environment: environment,
-                identity: identity
+                petname: petname
             )
-        case .succeedPurgePeer(let identity):
+        case .succeedPurgePeer(let petname):
             return succeedPurgePeer(
                 state: state,
                 environment: environment,
-                identity: identity
+                petname: petname
             )
         case .failPurgePeer(let error):
             return failPurgePeer(
@@ -2177,14 +2177,14 @@ struct AppModel: ModelProtocol {
     static func purgePeer(
         state: Self,
         environment: Environment,
-        identity: Did
+        petname: Petname
     ) -> Update<Self> {
         let fx: Fx<Action> = Future.detached(priority: .utility) {
             do {
                 try environment.database.purgePeer(
-                    identity: identity
+                    petname: petname
                 )
-                return Action.succeedPurgePeer(identity)
+                return Action.succeedPurgePeer(petname)
             } catch {
                 return Action.failPurgePeer(error.localizedDescription)
             }
@@ -2192,7 +2192,7 @@ struct AppModel: ModelProtocol {
         logger.log(
             "Purging peer",
             metadata: [
-                "identity": identity.description
+                "identity": petname.description
             ]
         )
         return Update(state: state, fx: fx)
@@ -2201,12 +2201,12 @@ struct AppModel: ModelProtocol {
     static func succeedPurgePeer(
         state: Self,
         environment: Environment,
-        identity: Did
+        petname: Petname
     ) -> Update<Self> {
         logger.log(
             "Purged peer from database",
             metadata: [
-                "identity": identity.description
+                "identity": petname.description
             ]
         )
         return Update(state: state)
@@ -2446,7 +2446,7 @@ struct AppModel: ModelProtocol {
         )
         return update(
             state: state,
-            action: .purgePeer(identity),
+            action: .purgePeer(petname),
             environment: environment
         )
     }

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -2259,7 +2259,7 @@ struct AppModel: ModelProtocol {
         logger.log(
             "Purging peer",
             metadata: [
-                "identity": petname.description
+                "petname": petname.description
             ]
         )
         return Update(state: state, fx: fx)
@@ -2273,7 +2273,7 @@ struct AppModel: ModelProtocol {
         logger.log(
             "Purged peer from database",
             metadata: [
-                "identity": petname.description
+                "petname": petname.description
             ]
         )
         return Update(state: state)

--- a/xcode/Subconscious/Shared/Components/Common/Byline/PetnameView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Byline/PetnameView.swift
@@ -71,6 +71,7 @@ struct PetnameView: View {
             return aliases.filter { alias in
                 name != alias.leaf
             }
+            .uniquing(with: { $0 })
         case _:
             return []
         }

--- a/xcode/Subconscious/Shared/Components/Common/Byline/PetnameView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Byline/PetnameView.swift
@@ -68,10 +68,12 @@ struct PetnameView: View {
     var uniqueAliases: [Petname] {
         switch name {
         case .known(_, let name):
-            return aliases.filter { alias in
-                name != alias.leaf
-            }
-            .uniquing(with: { $0 })
+            return aliases
+                .filter { alias in
+                    name != alias.leaf
+                }
+                .uniquing(with: \.id)
+            
         case _:
             return []
         }

--- a/xcode/Subconscious/Shared/Components/Common/Profile/Sheets/FollowNewUserFormSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/Sheets/FollowNewUserFormSheet.swift
@@ -118,7 +118,7 @@ struct FollowNewUserFormSheetView_Previews: PreviewProvider {
 }
 
 // MARK: Actions
-enum FollowNewUserFormSheetAction {
+enum FollowNewUserFormSheetAction: Equatable {
     case form(FollowUserFormAction)
     
     case populate(_ did: Did)

--- a/xcode/Subconscious/Shared/Components/Common/Profile/Sheets/FollowNewUserFormSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/Sheets/FollowNewUserFormSheet.swift
@@ -174,7 +174,7 @@ struct FollowNewUserFormSheetCursor: CursorProtocol {
     static func tag(_ action: ViewModel.Action) -> Model.Action {
         switch action {
         case .attemptFollow:
-            return UserProfileDetailAction.attemptFollowNewUser
+            return UserProfileDetailAction.submitFollowNewUser
         case .dismissSheet:
             return UserProfileDetailAction.presentFollowNewUserFormSheet(false)
         default:

--- a/xcode/Subconscious/Shared/Components/Common/Profile/Sheets/FollowUserSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/Sheets/FollowUserSheet.swift
@@ -174,7 +174,7 @@ struct FollowUserSheetCursor: CursorProtocol {
     static func tag(_ action: ViewModel.Action) -> Model.Action {
         switch action {
         case .submit:
-            return .attemptFollow
+            return .submitFollow
         default:
             return .followUserSheet(action)
         }

--- a/xcode/Subconscious/Shared/Components/Common/Profile/Sheets/RenameUserSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/Sheets/RenameUserSheet.swift
@@ -48,7 +48,7 @@ struct RenameUserSheetCursor: CursorProtocol {
     static func tag(_ action: ViewModel.Action) -> Model.Action {
         switch action {
         case .submit:
-            return .attemptRename
+            return .submitRename
         default:
             return .renameUserSheet(action)
         }

--- a/xcode/Subconscious/Shared/Components/Common/Profile/Sheets/UnfollowUserSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/Sheets/UnfollowUserSheet.swift
@@ -25,7 +25,7 @@ struct UnfollowSheetModifier: ViewModifier {
                     "Unfollow \(store.state.unfollowCandidate?.displayName ?? "user")?",
                     role: .destructive
                 ) {
-                    store.send(.attemptUnfollow)
+                    store.send(.submitUnfollow)
                 }
             } message: {
                 Text("You cannot undo this action")

--- a/xcode/Subconscious/Shared/Components/Common/Profile/Sheets/UserProfileDetailMetaSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/Sheets/UserProfileDetailMetaSheet.swift
@@ -123,7 +123,7 @@ struct UserProfileDetailMetaSheetCursor: CursorProtocol {
     }
 }
 
-enum UserProfileDetailMetaSheetAction: Hashable {
+enum UserProfileDetailMetaSheetAction: Equatable, Hashable {
     case populate(_ user: UserProfile)
     /// Show/hide delete confirmation dialog
     case presentDeleteConfirmationDialog(Bool)

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -60,6 +60,7 @@ struct RecentTabView: View {
                 
                 Divider()
             }
+            .transition(.opacity)
             
             if recent.count == 0 {
                 let name = user.address.peer?.markup ?? "This user"
@@ -70,8 +71,6 @@ struct RecentTabView: View {
                 FabSpacerView()
             }
         }
-        
-        
     }
 }
 
@@ -103,6 +102,7 @@ struct FollowTabView: View {
                 
                 Divider()
             }
+            .transition(.opacity)
             
             if following.count == 0 {
                 let name = store.state.user?.address.peer?.markup ?? "This user"
@@ -173,7 +173,6 @@ struct UserProfileView: View {
                             action: { action in
                                 store.send(UserProfileDetailAction.from(user, action))
                             },
-                            hideActionButton: state.loadingState != .loaded,
                             onTapStatistics: {
                                 send(
                                     .tabIndexSelected(
@@ -182,6 +181,7 @@ struct UserProfileView: View {
                                 )
                             }
                         )
+                        .disabled(state.loadingState != .loaded)
                         .padding(
                             .init([.top, .horizontal]),
                             AppTheme.padding
@@ -190,8 +190,10 @@ struct UserProfileView: View {
                         ProfileHeaderPlaceholderView()
                     }
                     
-                    if let recent = state.recentEntries,
-                       let following = state.following {
+                    // Only render these if we have data, each subcomponent fetches its own data
+                    // so discard the value.
+                    if let _ = state.recentEntries,
+                       let _ = state.following {
                         TabbedTwoColumnView(
                             columnA: columnRecent,
                             columnB: columnFollowing,

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -244,7 +244,7 @@ struct UserProfileView: View {
                     onTapOmnibox: {
                         send(.presentMetaSheet(true))
                     },
-                    status: store.readOnlyBinding(get: \.loadingState)
+                    status: store.state.loadingState
                 )
             } else {
                 DetailToolbarContent(
@@ -252,7 +252,7 @@ struct UserProfileView: View {
                     onTapOmnibox: {
                         send(.presentMetaSheet(true))
                     },
-                    status: store.readOnlyBinding(get: \.loadingState)
+                    status: store.state.loadingState
                 )
             }
         })
@@ -261,17 +261,6 @@ struct UserProfileView: View {
         .unfollow(store: store)
         .editProfile(app: app, store: store)
         .rename(store: store)
-    }
-}
-
-extension ObservableStore.StoreProtocol {
-    public func readOnlyBinding<Value>(
-        get: @escaping (Self.Model) -> Value
-    ) -> Binding<Value> {
-        Binding(
-            get: { get(self.state) },
-            set: { _ in }
-        )
     }
 }
 

--- a/xcode/Subconscious/Shared/Components/Detail/DetailToolbarContent.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/DetailToolbarContent.swift
@@ -12,7 +12,7 @@ struct DetailToolbarContent: ToolbarContent {
     var address: Slashlink?
     var defaultAudience: Audience
     var onTapOmnibox: () -> Void
-    var status: LoadingState = .loaded
+    @Binding var status: LoadingState
 
     var body: some ToolbarContent {
         ToolbarItem(placement: .principal) {
@@ -20,7 +20,7 @@ struct DetailToolbarContent: ToolbarContent {
                 OmniboxView(
                     address: address,
                     defaultAudience: defaultAudience,
-                    status: status
+                    status: $status
                 )
             }
         }
@@ -36,7 +36,8 @@ struct DetailToolbarContent_Previews: PreviewProvider {
             .toolbar(content: {
                 DetailToolbarContent(
                     defaultAudience: .local,
-                    onTapOmnibox: {}
+                    onTapOmnibox: {},
+                    status: Binding(get: { LoadingState.loaded }, set: { _ in })
                 )
             })
         }

--- a/xcode/Subconscious/Shared/Components/Detail/DetailToolbarContent.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/DetailToolbarContent.swift
@@ -12,7 +12,7 @@ struct DetailToolbarContent: ToolbarContent {
     var address: Slashlink?
     var defaultAudience: Audience
     var onTapOmnibox: () -> Void
-    @Binding var status: LoadingState
+    var status: LoadingState
 
     var body: some ToolbarContent {
         ToolbarItem(placement: .principal) {
@@ -20,7 +20,7 @@ struct DetailToolbarContent: ToolbarContent {
                 OmniboxView(
                     address: address,
                     defaultAudience: defaultAudience,
-                    status: $status
+                    status: status
                 )
             }
         }
@@ -37,7 +37,7 @@ struct DetailToolbarContent_Previews: PreviewProvider {
                 DetailToolbarContent(
                     defaultAudience: .local,
                     onTapOmnibox: {},
-                    status: Binding(get: { LoadingState.loaded }, set: { _ in })
+                    status: LoadingState.loaded
                 )
             })
         }

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -1089,6 +1089,7 @@ struct MemoEditorDetailModel: ModelProtocol {
     ) -> Update<MemoEditorDetailModel> {
         var model = state
         model.saveState = saveState
+        model.loadingState = .loaded
         model.headers.modified = modified
         return update(
             state: model,

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -88,7 +88,7 @@ struct MemoEditorDetailView: View {
                 onTapOmnibox: {
                     store.send(.presentMetaSheet(true))
                 },
-                status: store.readOnlyBinding(get: \.loadingState)
+                status: store.state.loadingState
             )
         })
         .onAppear {

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -87,7 +87,8 @@ struct MemoEditorDetailView: View {
                 defaultAudience: store.state.defaultAudience,
                 onTapOmnibox: {
                     store.send(.presentMetaSheet(true))
-                }
+                },
+                status: store.readOnlyBinding(get: \.loadingState)
             )
         })
         .onAppear {
@@ -613,7 +614,7 @@ struct MemoEditorDetailModel: ModelProtocol {
     var saveState = SaveState.saved
     
     /// Is editor in loading state?
-    var isLoading = true
+    var loadingState = LoadingState.loading
     /// When was the last time the editor issued a fetch from source of truth?
     var lastLoadStarted = Date.distantPast
     
@@ -1207,7 +1208,7 @@ struct MemoEditorDetailModel: ModelProtocol {
     static func prepareLoadDetail(_ state: MemoEditorDetailModel) -> MemoEditorDetailModel {
         var model = state
         // Mark loading state
-        model.isLoading = true
+        model.loadingState = .loading
         // Mark time of load start
         model.lastLoadStarted = Date.now
         return model
@@ -1313,7 +1314,7 @@ struct MemoEditorDetailModel: ModelProtocol {
         detail: MemoEditorDetailResponse
     ) -> Update<MemoEditorDetailModel> {
         var model = state
-        model.isLoading = false
+        model.loadingState = .loaded
         model.address = detail.entry.address
         model.defaultAudience = detail.entry.address.toAudience()
         model.headers = detail.entry.contents.wellKnownHeaders()
@@ -1349,7 +1350,7 @@ struct MemoEditorDetailModel: ModelProtocol {
     ) -> Update<MemoEditorDetailModel> {
         var model = state
         // Mark loading finished
-        model.isLoading = false
+        model.loadingState = .loaded
         
         let change = FileFingerprintChange.create(
             left: FileFingerprint(state),
@@ -1475,7 +1476,7 @@ struct MemoEditorDetailModel: ModelProtocol {
         model.additionalHeaders = []
         model.editor = SubtextTextModel()
         model.backlinks = []
-        model.isLoading = true
+        model.loadingState = .loading
         model.saveState = .saved
         return Update(state: model)
     }

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -69,7 +69,7 @@ struct MemoViewerDetailView: View {
                 onTapOmnibox: {
                     store.send(.presentMetaSheet(true))
                 },
-                status: store.readOnlyBinding(get: \.loadingState)
+                status: store.state.loadingState
             )
         })
         .onAppear {

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -69,7 +69,7 @@ struct MemoViewerDetailView: View {
                 onTapOmnibox: {
                     store.send(.presentMetaSheet(true))
                 },
-                status: store.state.loadingState
+                status: store.readOnlyBinding(get: \.loadingState)
             )
         })
         .onAppear {

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -133,7 +133,7 @@ extension UserProfileDetailAction {
     }
 }
 
-enum UserProfileDetailAction {
+enum UserProfileDetailAction: Equatable {
     static let logger = Logger(
         subsystem: Config.default.rdns,
         category: "UserProfileDetailAction"

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -605,7 +605,7 @@ struct UserProfileDetailModel: ModelProtocol {
             state: model,
             action: .appear(user.address, state.initialTabIndex),
             environment: environment
-        )
+        ).animation(.default)
     }
     
     static func appear(
@@ -901,7 +901,7 @@ struct UserProfileDetailModel: ModelProtocol {
                 .requestWaitForFollowedUserResolution(to) // TODO: refactor
             ],
             environment: environment
-        )
+        ).animation(.default)
     }
     
     static func requestWaitForFollowedUserResolution(

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -764,7 +764,7 @@ struct UserProfileDetailModel: ModelProtocol {
         return update(
             state: state,
             actions: [
-                .presentFollowSheet(false),
+                .presentFollowSheet(false)
             ],
             environment: environment
         ).mergeFx(fx)
@@ -791,7 +791,7 @@ struct UserProfileDetailModel: ModelProtocol {
         return update(
             state: state,
             actions: [
-                .presentFollowNewUserFormSheet(false),
+                .presentFollowNewUserFormSheet(false)
             ],
             environment: environment
         ).mergeFx(fx)
@@ -817,10 +817,8 @@ struct UserProfileDetailModel: ModelProtocol {
             }
         }
         
-        var model = state
-        
         return update(
-            state: model,
+            state: state,
             actions: actions,
             environment: environment
         )
@@ -1019,10 +1017,9 @@ struct UserProfileDetailModel: ModelProtocol {
                 "did:": identity.description
             ]
         )
-        var model = state
         
         return update(
-            state: model,
+            state: state,
             actions: [
                 .presentUnfollowConfirmation(false),
                 .refresh(forceSync: false)

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -354,6 +354,9 @@ struct UserProfileDetailModel: ModelProtocol {
     var address: Slashlink? = nil
     var user: UserProfile? = nil
     
+    // These are optional so we can differentiate between 
+    // (1) first load (no content, show placeholder state)
+    // (2) a refresh (existing content, keep showing old content during load)
     var recentEntries: [EntryStub]? = nil
     var following: [StoryUser]? = nil
     

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -76,16 +76,12 @@ extension UserProfileDetailAction {
         switch action {
         case let .succeedResolveFollowedUser(petname, cid):
             return .notifySucceedResolveFollowedUser(petname: petname, cid: cid)
-        case let .succeedUnfollow(identity, petname):
-            return .notifySucceedUnfollow(identity: identity, petname: petname)
-        case .failRename:
-            return AppAction.pushToast(message: String(localized: "Failed to rename user"))
-        case .failUnfollow:
-            return AppAction.pushToast(message: String(localized: "Failed to unfollow user"))
-        case .failEditProfile:
-            return AppAction.pushToast(message: String(localized: "Failed to edit profile"))
-        case .failFollow:
-            return AppAction.pushToast(message: String(localized: "Failed to follow user"))
+        case let .attemptFollow(did, petname):
+            return .followPeer(identity: did, petname: petname)
+        case let .attemptUnfollow(did, petname):
+            return .unfollowPeer(identity: did, petname: petname)
+        case let .attemptRename(from, to):
+            return .renamePeer(from: from, to: to)
         default:
             return nil
         }
@@ -101,6 +97,14 @@ extension UserProfileDetailAction {
             return .refresh(forceSync: false)
         case .succeedRecoverOurSphere:
             return .refresh(forceSync: false)
+            
+        case let .succeedFollowPeer(petname):
+            return .succeedFollow(petname)
+        case let .succeedUnfollowPeer(identity, petname):
+            return .succeedUnfollow(identity: identity, petname: petname)
+        case let .succeedRenamePeer(did, from, to):
+            return .succeedRename(identity: did, from: from, to: to)
+            
         default:
             return nil
         }
@@ -118,11 +122,11 @@ extension UserProfileDetailAction {
     static func from(_ user: UserProfile, _ action: UserProfileAction) -> UserProfileDetailAction {
         switch (action) {
         case .requestFollow:
-            return .requestFollow(user)
+            return .prepareFollow(user)
         case .requestUnfollow:
-            return .requestUnfollow(user)
+            return .prepareUnfollow(user)
         case .requestRename:
-            return .requestRename(user)
+            return .prepareRename(user)
         case .editOwnProfile:
             return .presentEditProfile(true)
         }
@@ -155,25 +159,25 @@ enum UserProfileDetailAction {
     case editProfileSheet(EditProfileSheetAction)
     case followNewUserFormSheet(FollowNewUserFormSheetAction)
     
-    case requestFollow(UserProfile)
-    case attemptFollow
-    case attemptFollowNewUser
-    case failFollow(error: String)
+    case prepareFollow(UserProfile)
+    case submitFollow
+    case submitFollowNewUser
+    case attemptFollow(identity: Did, petname: Petname)
     case succeedFollow(_ petname: Petname)
     
-    case requestRename(UserProfile)
-    case attemptRename
-    case failRename(error: String)
-    case succeedRename(from: Petname, to: Petname)
+    case prepareRename(UserProfile)
+    case submitRename
+    case attemptRename(from: Petname, to: Petname)
+    case succeedRename(identity: Did, from: Petname, to: Petname)
+    
+    case prepareUnfollow(UserProfile)
+    case submitUnfollow
+    case attemptUnfollow(identity: Did, petname: Petname)
+    case succeedUnfollow(identity: Did, petname: Petname)
     
     case requestWaitForFollowedUserResolution(_ petname: Petname)
     case succeedResolveFollowedUser(petname: Petname, cid: Cid?)
     case failResolveFollowedUser(_ message: String)
-    
-    case requestUnfollow(UserProfile)
-    case attemptUnfollow
-    case failUnfollow(error: String)
-    case succeedUnfollow(identity: Did, petname: Petname)
     
     case requestEditProfile
     case failEditProfile(error: String)
@@ -350,8 +354,8 @@ struct UserProfileDetailModel: ModelProtocol {
     var address: Slashlink? = nil
     var user: UserProfile? = nil
     
-    var recentEntries: [EntryStub] = []
-    var following: [StoryUser] = []
+    var recentEntries: [EntryStub]? = nil
+    var following: [StoryUser]? = nil
     
     var statistics: UserProfileStatistics? = nil
     var unfollowCandidate: UserProfile? = nil
@@ -447,19 +451,19 @@ struct UserProfileDetailModel: ModelProtocol {
                 isPresented: isPresented
             )
         // MARK: Following
-        case .requestFollow(let user):
+        case .prepareFollow(let user):
             return requestFollow(
                 state: state,
                 environment: environment,
                 user: user
             )
-        case .attemptFollow:
-            return attemptFollow(
+        case .submitFollow:
+            return submitFollow(
                 state: state,
                 environment: environment
             )
-        case .attemptFollowNewUser:
-            return attemptFollowNewUser(
+        case .submitFollowNewUser:
+            return submitFollowNewUser(
                 state: state,
                 environment: environment
             )
@@ -469,12 +473,6 @@ struct UserProfileDetailModel: ModelProtocol {
                 environment: environment,
                 petname: petname
             )
-        case .failFollow(let error):
-            return failFollow(
-                state: state,
-                environment: environment,
-                error: error
-            )
         // MARK: Rename
         case .presentRenameSheet(let isPresented):
             return presentRenameSheet(
@@ -482,29 +480,24 @@ struct UserProfileDetailModel: ModelProtocol {
                 environment: environment,
                 isPresented: isPresented
             )
-        case .requestRename(let user):
+        case .prepareRename(let user):
             return requestRename(
                 state: state,
                 environment: environment,
                 user: user
             )
-        case .attemptRename:
-            return attemptRename(
+        case .submitRename:
+            return submitRename(
                 state: state,
                 environment: environment
             )
-        case let .succeedRename(from, to):
+        case let .succeedRename(did, from, to):
             return succeedRename(
                 state: state,
                 environment: environment,
+                identity: did,
                 from: from,
                 to: to
-            )
-        case .failRename(let error):
-            return failRename(
-                state: state,
-                environment: environment,
-                error: error
             )
         case let .requestWaitForFollowedUserResolution(petname):
             return requestWaitForFollowedUserResolution(
@@ -530,14 +523,14 @@ struct UserProfileDetailModel: ModelProtocol {
                 environment: environment,
                 isPresented: isPresented
             )
-        case .requestUnfollow(let user):
+        case .prepareUnfollow(let user):
             return requestUnfollow(
                 state: state,
                 environment: environment,
                 user: user
             )
-        case .attemptUnfollow:
-            return attemptUnfollow(
+        case .submitUnfollow:
+            return submitUnfollow(
                 state: state,
                 environment: environment
             )
@@ -547,12 +540,6 @@ struct UserProfileDetailModel: ModelProtocol {
                 environment: environment,
                 identity: identity,
                 petname: petname
-            )
-        case let .failUnfollow(error):
-            return failUnfollow(
-                state: state,
-                environment: environment,
-                error: error
             )
         // MARK: Edit Profile
         case .presentEditProfile(let isPresented):
@@ -583,6 +570,13 @@ struct UserProfileDetailModel: ModelProtocol {
                 environment: environment,
                 results: results
             )
+        // Notifications to app level
+        case .attemptFollow:
+            return Update(state: state)
+        case .attemptRename:
+            return Update(state: state)
+        case .attemptUnfollow:
+            return Update(state: state)
         }
     }
     
@@ -601,8 +595,11 @@ struct UserProfileDetailModel: ModelProtocol {
             return Update(state: state)
         }
         
+        var model = state
+        model.loadingState = .loading
+        
         return update(
-            state: state,
+            state: model,
             action: .appear(user.address, state.initialTabIndex),
             environment: environment
         )
@@ -746,7 +743,7 @@ struct UserProfileDetailModel: ModelProtocol {
         )
     }
     
-    static func attemptFollow(
+    static func submitFollow(
         state: Self,
         environment: Environment
     ) -> Update<Self> {
@@ -759,34 +756,21 @@ struct UserProfileDetailModel: ModelProtocol {
             return Update(state: state)
         }
         
-        let fx: Fx<UserProfileDetailAction> =
-        environment.addressBook
-            .followUserPublisher(
-                did: did,
-                petname: petname,
-                preventOverwrite: true
-            )
-            .map({ _ in
-                UserProfileDetailAction.succeedFollow(petname)
-            })
-            .recover { error in
-                .failFollow(
-                    error: error.localizedDescription
-                )
-            }
-            .eraseToAnyPublisher()
+        let fx: Fx<UserProfileDetailAction> = Just(
+            .attemptFollow(identity: did, petname: petname)
+        ).eraseToAnyPublisher()
         
         // Dimiss sheet immediately
         return update(
             state: state,
             actions: [
-                .presentFollowSheet(false)
+                .presentFollowSheet(false),
             ],
             environment: environment
         ).mergeFx(fx)
     }
     
-    static func attemptFollowNewUser(
+    static func submitFollowNewUser(
         state: Self,
         environment: Environment
     ) -> Update<Self> {
@@ -799,28 +783,15 @@ struct UserProfileDetailModel: ModelProtocol {
             return Update(state: state)
         }
         
-        let fx: Fx<UserProfileDetailAction> =
-        environment.addressBook
-            .followUserPublisher(
-                did: did,
-                petname: petname,
-                preventOverwrite: true
-            )
-            .map({ _ in
-                UserProfileDetailAction.succeedFollow(petname)
-            })
-            .recover { error in
-                .failFollow(
-                    error: error.localizedDescription
-                )
-            }
-            .eraseToAnyPublisher()
+        let fx: Fx<UserProfileDetailAction> = Just(
+            .attemptFollow(identity: did, petname: petname)
+        ).eraseToAnyPublisher()
         
         // Dimiss sheet immediately
         return update(
             state: state,
             actions: [
-                .presentFollowNewUserFormSheet(false)
+                .presentFollowNewUserFormSheet(false),
             ],
             environment: environment
         ).mergeFx(fx)
@@ -834,7 +805,7 @@ struct UserProfileDetailModel: ModelProtocol {
         var actions: [UserProfileDetailAction] = [
             .presentFollowSheet(false),
             .presentFollowNewUserFormSheet(false),
-            .refresh(forceSync: true),
+            .refresh(forceSync: false),
             .requestWaitForFollowedUserResolution(petname)
         ]
         
@@ -846,22 +817,13 @@ struct UserProfileDetailModel: ModelProtocol {
             }
         }
         
+        var model = state
+        
         return update(
-            state: state,
+            state: model,
             actions: actions,
             environment: environment
         )
-    }
-    
-    static func failFollow(
-        state: Self,
-        environment: Environment,
-        error: String
-    ) -> Update<Self> {
-        var model = state
-        model.isFollowSheetPresented = false
-        model.isFollowNewUserFormSheetPresented = false
-        return Update(state: model)
     }
     
     static func presentRenameSheet(
@@ -898,7 +860,7 @@ struct UserProfileDetailModel: ModelProtocol {
         )
     }
     
-    static func attemptRename(
+    static func submitRename(
         state: Self,
         environment: Environment
     ) -> Update<Self> {
@@ -911,27 +873,20 @@ struct UserProfileDetailModel: ModelProtocol {
             return Update(state: state)
         }
         
-        let fx: Fx<UserProfileDetailAction> =
-        Future.detached {
-            let did = try await environment.addressBook.unfollowUser(petname: from)
-            try await environment.addressBook.followUser(did: did, petname: to)
-            
-            return .succeedRename(from: from, to: to)
-        }
-        .recover { error in
-            .failRename(error: error.localizedDescription)
-        }
-        .eraseToAnyPublisher()
-        
         // Dimiss sheet immediately
         var model = state
         model.isRenameSheetPresented = false
-        return Update(state: state, fx: fx)
+        let fx: Fx<UserProfileDetailAction> = Just(
+            .attemptRename(from: from, to: to)
+        ).eraseToAnyPublisher()
+        
+        return Update(state: model, fx: fx)
     }
     
     static func succeedRename(
         state: Self,
         environment: Environment,
+        identity: Did,
         from: Petname,
         to: Petname
     ) -> Update<Self> {
@@ -941,21 +896,11 @@ struct UserProfileDetailModel: ModelProtocol {
         return update(
             state: model,
             actions: [
-                .presentRenameSheet(false),
-                .refresh(forceSync: true)
+                .refresh(forceSync: false),
+                .requestWaitForFollowedUserResolution(to) // TODO: refactor
             ],
             environment: environment
         )
-    }
-    
-    static func failRename(
-        state: Self,
-        environment: Environment,
-        error: String
-    ) -> Update<Self> {
-        var model = state
-        model.isRenameSheetPresented = false
-        return Update(state: model)
     }
     
     static func requestWaitForFollowedUserResolution(
@@ -975,7 +920,7 @@ struct UserProfileDetailModel: ModelProtocol {
         
         return update(
             state: state,
-            action: .refresh(forceSync: true),
+            action: .refresh(forceSync: false),
             environment: environment
         ).mergeFx(fx)
     }
@@ -1035,7 +980,7 @@ struct UserProfileDetailModel: ModelProtocol {
         )
     }
     
-    static func attemptUnfollow(
+    static func submitUnfollow(
         state: Self,
         environment: Environment
     ) -> Update<Self> {
@@ -1048,20 +993,16 @@ struct UserProfileDetailModel: ModelProtocol {
             return Update(state: state)
         case .following(let name):
             let petname = name.toPetname()
-            let fx: Fx<UserProfileDetailAction> = environment.addressBook
-                .unfollowUserPublisher(petname: petname)
-                .map({ identity in
-                    Action.succeedUnfollow(identity: identity, petname: petname)
-                })
-                .recover({ error in
-                    Action.failUnfollow(error: error.localizedDescription)
-                })
-                .eraseToAnyPublisher()
             
             // Dimiss confirmation immediately
             var model = state
             model.isUnfollowConfirmationPresented = false
-            return Update(state: state, fx: fx)
+            
+            let fx: Fx<UserProfileDetailAction> = Just(
+                .attemptUnfollow(identity: candidate.did, petname: petname)
+            ).eraseToAnyPublisher()
+            
+            return Update(state: model, fx: fx)
         }
     }
     
@@ -1078,26 +1019,18 @@ struct UserProfileDetailModel: ModelProtocol {
                 "did:": identity.description
             ]
         )
+        var model = state
+        
         return update(
-            state: state,
+            state: model,
             actions: [
                 .presentUnfollowConfirmation(false),
-                .refresh(forceSync: true)
+                .refresh(forceSync: false)
             ],
             environment: environment
         )
     }
    
-    static func failUnfollow(
-        state: Self,
-        environment: Environment,
-        error: String
-    ) -> Update<Self> {
-        var model = state
-        model.isUnfollowConfirmationPresented = false
-        return Update(state: model)
-    }
-    
     static func presentEditProfile(
         state: Self,
         environment: Environment,

--- a/xcode/Subconscious/Shared/Components/OmniboxView.swift
+++ b/xcode/Subconscious/Shared/Components/OmniboxView.swift
@@ -171,8 +171,6 @@ struct OmniboxView_Previews: PreviewProvider {
             }
         }
     }
-    
-    static let status = Binding(get: { LoadingState.loaded }, set: { _ in })
 
     static var previews: some View {
         VStack {

--- a/xcode/Subconscious/Shared/Components/OmniboxView.swift
+++ b/xcode/Subconscious/Shared/Components/OmniboxView.swift
@@ -18,7 +18,7 @@ struct OmniboxView: View {
     
     var address: Slashlink?
     var defaultAudience: Audience
-    var status: LoadingState = .loaded
+    @Binding var status: LoadingState
 
     private func icon() -> Image {
         guard let address = address else {
@@ -71,22 +71,26 @@ struct OmniboxView: View {
                 .stroke(Color.separator, lineWidth: 0.5)
         )
         .overlay(
-            // Loading pulse
-            RoundedRectangle(cornerRadius: AppTheme.cornerRadius)
-                .stroke(
-                    .conicGradient(
-                        gradient,
-                        center: .center,
-                        angle: Angle.radians(phase)),
-                    lineWidth: 2
-                )
-                .animation(
-                    .linear(duration: Duration.loading * 2)
-                        .repeatForever(autoreverses: false),
-                    value: phase
-                )
-                // Keep the view mounted but invisible
-                .opacity(status == .loading ? 0.5 : 0)
+            VStack {
+                if status == .loading {
+                // Loading pulse
+                RoundedRectangle(cornerRadius: AppTheme.cornerRadius)
+                    .stroke(
+                        .conicGradient(
+                            gradient,
+                            center: .center,
+                            angle: Angle.radians(phase)),
+                        lineWidth: 2
+                    )
+                    .animation(
+                        .linear(duration: Duration.loading * 2)
+                            .repeatForever(autoreverses: false),
+                        value: phase
+                    )
+                    // Keep the view mounted but invisible
+                    .opacity(status == .loading ? 0.5 : 0)
+                }
+            }
         )
         .frame(minWidth: 100, idealWidth: 240, maxWidth: 240)
         .task {
@@ -94,6 +98,13 @@ struct OmniboxView: View {
                 phase = Self.initialAngle + Self.fullRotation
             }
         }
+        .onChange(of: status, perform: { s in
+            if s == .loading {
+                phase = Self.initialAngle + Self.fullRotation
+            } else {
+                phase = Self.initialAngle
+            }
+        })
     }
 }
 
@@ -147,22 +158,25 @@ struct OmniboxView_Previews: PreviewProvider {
         ]
         
         @State private var address: Slashlink? = nil
+        @State private var status: LoadingState = [LoadingState.loaded, LoadingState.loading].randomElement()!
         var defaultAudience = Audience.local
-        let status = [LoadingState.loaded, LoadingState.loading].randomElement()!
 
         var body: some View {
             OmniboxView(
                 address: address,
                 defaultAudience: defaultAudience,
-                status: .loading
+                status: $status
             )
             .onTapGesture {
                 withAnimation {
                     self.address = addresses.randomElement()
+                    self.status = [LoadingState.loaded, LoadingState.loading].randomElement()!
                 }
             }
         }
     }
+    
+    static let status = Binding(get: { LoadingState.loaded }, set: { _ in })
 
     static var previews: some View {
         VStack {
@@ -174,59 +188,73 @@ struct OmniboxView_Previews: PreviewProvider {
             Group {
                 OmniboxView(
                     address: Slashlink("@here/red-mars")!,
-                    defaultAudience: .local
+                    defaultAudience: .local,
+                    status: status
                 )
                 OmniboxView(
                     address: Slashlink("@here.now/red-mars-very-long-slug")!,
-                    defaultAudience: .local
+                    defaultAudience: .local,
+                    status: status
                 )
                 OmniboxView(
                     address: Slashlink(petname: Petname("ksr")!),
-                    defaultAudience: .local
+                    defaultAudience: .local,
+                    status: status
                 )
                 OmniboxView(
                     address: Slashlink(petname: Petname("ksr.biz.gov")!),
-                    defaultAudience: .local
+                    defaultAudience: .local,
+                    status: status
                 )
                 OmniboxView(
                     address: Slashlink("/red-mars")!,
-                    defaultAudience: .local
+                    defaultAudience: .local,
+                    status: status
                 )
             }
             Group {
                 OmniboxView(
                     address: Slashlink(slug: Slug.profile),
-                    defaultAudience: .local
+                    defaultAudience: .local,
+                    status: status
                 )
                 OmniboxView(
                     address: Slashlink.local(Slug("red-mars")!),
-                    defaultAudience: .local
+                    defaultAudience: .local,
+                    status: status
                 )
                 OmniboxView(
                     address: Slashlink.local(Slug("BLUE-mars")!),
-                    defaultAudience: .local
+                    defaultAudience: .local,
+                    status: status
                 )
                 OmniboxView(
                     address: Slashlink("@KSR.scifi/GREEN-mars")!,
-                    defaultAudience: .local
+                    defaultAudience: .local,
+                    status: status
                 )
                 OmniboxView(
                     address: Slashlink("did:key:abc123/GREEN-mars")!,
-                    defaultAudience: .local
+                    defaultAudience: .local,
+                    status: status
                 )
                 OmniboxView(
                     address: Slashlink("did:key:abc123")!,
-                    defaultAudience: .local
+                    defaultAudience: .local,
+                    status: status
                 )
                 OmniboxView(
                     address: Slashlink("/_profile_")!,
-                    defaultAudience: .local
+                    defaultAudience: .local,
+                    status: status
                 )
                 OmniboxView(
-                    defaultAudience: .local
+                    defaultAudience: .local,
+                    status: status
                 )
                 OmniboxView(
-                    defaultAudience: .public
+                    defaultAudience: .public,
+                    status: status
                 )
             }
         }

--- a/xcode/Subconscious/Shared/Components/OmniboxView.swift
+++ b/xcode/Subconscious/Shared/Components/OmniboxView.swift
@@ -18,7 +18,7 @@ struct OmniboxView: View {
     
     var address: Slashlink?
     var defaultAudience: Audience
-    @Binding var status: LoadingState
+    var status: LoadingState = .loaded
 
     private func icon() -> Image {
         guard let address = address else {
@@ -89,22 +89,18 @@ struct OmniboxView: View {
                     )
                     // Keep the view mounted but invisible
                     .opacity(status == .loading ? 0.5 : 0)
+                    .task {
+                        if status == .loading {
+                            phase = Self.initialAngle + Self.fullRotation
+                        } 
+                    }
+                    .onDisappear() {
+                        phase = Self.initialAngle
+                    }
                 }
             }
         )
         .frame(minWidth: 100, idealWidth: 240, maxWidth: 240)
-        .task {
-            if status == .loading {
-                phase = Self.initialAngle + Self.fullRotation
-            }
-        }
-        .onChange(of: status, perform: { s in
-            if s == .loading {
-                phase = Self.initialAngle + Self.fullRotation
-            } else {
-                phase = Self.initialAngle
-            }
-        })
     }
 }
 
@@ -165,7 +161,7 @@ struct OmniboxView_Previews: PreviewProvider {
             OmniboxView(
                 address: address,
                 defaultAudience: defaultAudience,
-                status: $status
+                status: status
             )
             .onTapGesture {
                 withAnimation {
@@ -188,73 +184,59 @@ struct OmniboxView_Previews: PreviewProvider {
             Group {
                 OmniboxView(
                     address: Slashlink("@here/red-mars")!,
-                    defaultAudience: .local,
-                    status: status
+                    defaultAudience: .local
                 )
                 OmniboxView(
                     address: Slashlink("@here.now/red-mars-very-long-slug")!,
-                    defaultAudience: .local,
-                    status: status
+                    defaultAudience: .local
                 )
                 OmniboxView(
                     address: Slashlink(petname: Petname("ksr")!),
-                    defaultAudience: .local,
-                    status: status
+                    defaultAudience: .local
                 )
                 OmniboxView(
                     address: Slashlink(petname: Petname("ksr.biz.gov")!),
-                    defaultAudience: .local,
-                    status: status
+                    defaultAudience: .local
                 )
                 OmniboxView(
                     address: Slashlink("/red-mars")!,
-                    defaultAudience: .local,
-                    status: status
+                    defaultAudience: .local
                 )
             }
             Group {
                 OmniboxView(
                     address: Slashlink(slug: Slug.profile),
-                    defaultAudience: .local,
-                    status: status
+                    defaultAudience: .local
                 )
                 OmniboxView(
                     address: Slashlink.local(Slug("red-mars")!),
-                    defaultAudience: .local,
-                    status: status
+                    defaultAudience: .local
                 )
                 OmniboxView(
                     address: Slashlink.local(Slug("BLUE-mars")!),
-                    defaultAudience: .local,
-                    status: status
+                    defaultAudience: .local
                 )
                 OmniboxView(
                     address: Slashlink("@KSR.scifi/GREEN-mars")!,
-                    defaultAudience: .local,
-                    status: status
+                    defaultAudience: .local
                 )
                 OmniboxView(
                     address: Slashlink("did:key:abc123/GREEN-mars")!,
-                    defaultAudience: .local,
-                    status: status
+                    defaultAudience: .local
                 )
                 OmniboxView(
                     address: Slashlink("did:key:abc123")!,
-                    defaultAudience: .local,
-                    status: status
+                    defaultAudience: .local
                 )
                 OmniboxView(
                     address: Slashlink("/_profile_")!,
-                    defaultAudience: .local,
-                    status: status
+                    defaultAudience: .local
                 )
                 OmniboxView(
-                    defaultAudience: .local,
-                    status: status
+                    defaultAudience: .local
                 )
                 OmniboxView(
-                    defaultAudience: .public,
-                    status: status
+                    defaultAudience: .public
                 )
             }
         }

--- a/xcode/Subconscious/Shared/Models/StoryEntry.swift
+++ b/xcode/Subconscious/Shared/Models/StoryEntry.swift
@@ -13,7 +13,7 @@ struct StoryEntry:
     Identifiable,
     CustomStringConvertible
 {
-    var id = UUID()
+    var id: String { entry.id.description }
     var entry: EntryStub
     var author: UserProfile
 

--- a/xcode/Subconscious/Shared/Models/StoryUser.swift
+++ b/xcode/Subconscious/Shared/Models/StoryUser.swift
@@ -15,7 +15,7 @@ struct StoryUser:
     CustomStringConvertible,
     Codable {
     
-    var id = UUID()
+    var id: String { user.address.id }
     var entry: AddressBookEntry
     var user: UserProfile
     var statistics: UserProfileStatistics?

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -130,7 +130,7 @@ actor DataService {
         )
         let version = try await sphere.version()
         // Get peer info from last sync
-        let peer = try? database.readPeer(identity: identity)
+        let peer = try? database.readPeer(petname: petname)
         // Get changes since the last time we indexed this peer,
         // or get all changes if this is the first time we've tried to index.
         let changes = try await sphere.changes(since: peer?.since)
@@ -333,7 +333,7 @@ actor DataService {
                     if let removedPeer = try? database.readPeer(
                         petname: petname
                     ) {
-                        try database.purgePeer(identity: removedPeer.identity)
+                        try database.purgePeer(petname: removedPeer.petname)
                         logger.log(
                             "Purged peer",
                             metadata: [

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -309,10 +309,14 @@ final class DatabaseService {
             return
         }
 
-        // Otherwise, we only delete the peer
-        // The other alias still references all the indexed memos
         try database.savepoint(savepoint)
         do {
+            // We (currently) do need to delete all memos even though we may know this peer by
+            // another name. The petname is baked into the `slashlink` column and leaving them
+            // as-is will leave stale slashlinks in the feed.
+            
+            // We should consider doing a "smart" check where we update the rows in-place if
+            // we have another name, or perhaps reconsider the modelling of the `slashlink` column.
             try database.execute(
                 sql: """
                 DELETE FROM memo WHERE did = ?

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -31,8 +31,6 @@
 		B5293B8A2A426645001C4DA7 /* Sentry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5293B882A426645001C4DA7 /* Sentry.swift */; };
 		B532F8C329B1752E00CE9256 /* TranscludeBlockLayoutFragment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532F8C229B1752E00CE9256 /* TranscludeBlockLayoutFragment.swift */; };
 		B540F8BA2A0C748C00876256 /* Line.swift in Sources */ = {isa = PBXBuildFile; fileRef = B540F8B92A0C748C00876256 /* Line.swift */; };
-		B54187B829EF5CA00056E4A9 /* FollowUserFormSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54187B729EF5CA00056E4A9 /* FollowUserFormSheet.swift */; };
-		B542EF802AF4B88500BE29F1 /* ResolvedAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = B542EF7F2AF4B88500BE29F1 /* ResolvedAddress.swift */; };
 		B54187B829EF5CA00056E4A9 /* FollowUserFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54187B729EF5CA00056E4A9 /* FollowUserFormView.swift */; };
 		B542EF672AF48F2100BE29F1 /* StoreUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B542EF662AF48F2100BE29F1 /* StoreUtilities.swift */; };
 		B542EF682AF48F2100BE29F1 /* StoreUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B542EF662AF48F2100BE29F1 /* StoreUtilities.swift */; };
@@ -50,6 +48,7 @@
 		B542EF7B2AF4963700BE29F1 /* UserProfileDetialMetaSheetModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B542EF792AF4963700BE29F1 /* UserProfileDetialMetaSheetModifier.swift */; };
 		B542EF7D2AF4967900BE29F1 /* FollowUserSheetModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B542EF7C2AF4967900BE29F1 /* FollowUserSheetModifier.swift */; };
 		B542EF7E2AF4967900BE29F1 /* FollowUserSheetModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B542EF7C2AF4967900BE29F1 /* FollowUserSheetModifier.swift */; };
+		B542EF802AF4B88500BE29F1 /* ResolvedAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = B542EF7F2AF4B88500BE29F1 /* ResolvedAddress.swift */; };
 		B5432B8329F8BAED003BBB23 /* Tests_UserProfileService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5432B8229F8BAED003BBB23 /* Tests_UserProfileService.swift */; };
 		B54930B12A2F0FE300958F12 /* StoryPlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54930B02A2F0FE300958F12 /* StoryPlaceholderView.swift */; };
 		B549B16B2A0CDAC10070C6AD /* FirstRunRecoveryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B549B16A2A0CDAC10070C6AD /* FirstRunRecoveryView.swift */; };
@@ -114,6 +113,7 @@
 		B5D769CC29F770440015385A /* GenerativeProfilePic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D769CA29F770440015385A /* GenerativeProfilePic.swift */; };
 		B5D8FEB72AAC426C002CBF00 /* MainToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D8FEB62AAC426C002CBF00 /* MainToolbar.swift */; };
 		B5D8FEB82AAC426C002CBF00 /* MainToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D8FEB62AAC426C002CBF00 /* MainToolbar.swift */; };
+		B5E07B322B0337A100F302EA /* Tests_UserProfileDetailModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E07B312B0337A100F302EA /* Tests_UserProfileDetailModel.swift */; };
 		B5E60C8B2A145F04007065A1 /* UserProfileBio.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E60C8A2A145F04007065A1 /* UserProfileBio.swift */; };
 		B5E60C8D2A146838007065A1 /* Tests_UserProfileBio.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E60C8C2A146838007065A1 /* Tests_UserProfileBio.swift */; };
 		B5E816B92AB0458E00C61500 /* RecoveryPhrase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E816B82AB0458E00C61500 /* RecoveryPhrase.swift */; };
@@ -556,8 +556,6 @@
 		B5293B882A426645001C4DA7 /* Sentry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sentry.swift; sourceTree = "<group>"; };
 		B532F8C229B1752E00CE9256 /* TranscludeBlockLayoutFragment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscludeBlockLayoutFragment.swift; sourceTree = "<group>"; };
 		B540F8B92A0C748C00876256 /* Line.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Line.swift; sourceTree = "<group>"; };
-		B54187B729EF5CA00056E4A9 /* FollowUserFormSheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FollowUserFormSheet.swift; sourceTree = "<group>"; };
-		B542EF7F2AF4B88500BE29F1 /* ResolvedAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolvedAddress.swift; sourceTree = "<group>"; };
 		B54187B729EF5CA00056E4A9 /* FollowUserFormView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FollowUserFormView.swift; sourceTree = "<group>"; };
 		B542EF662AF48F2100BE29F1 /* StoreUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreUtilities.swift; sourceTree = "<group>"; };
 		B542EF692AF493F800BE29F1 /* RenameUserSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenameUserSheet.swift; sourceTree = "<group>"; };
@@ -567,6 +565,7 @@
 		B542EF762AF495F200BE29F1 /* FollowNewUserSheetModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowNewUserSheetModifier.swift; sourceTree = "<group>"; };
 		B542EF792AF4963700BE29F1 /* UserProfileDetialMetaSheetModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileDetialMetaSheetModifier.swift; sourceTree = "<group>"; };
 		B542EF7C2AF4967900BE29F1 /* FollowUserSheetModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowUserSheetModifier.swift; sourceTree = "<group>"; };
+		B542EF7F2AF4B88500BE29F1 /* ResolvedAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolvedAddress.swift; sourceTree = "<group>"; };
 		B5432B8229F8BAED003BBB23 /* Tests_UserProfileService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_UserProfileService.swift; sourceTree = "<group>"; };
 		B54930B02A2F0FE300958F12 /* StoryPlaceholderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryPlaceholderView.swift; sourceTree = "<group>"; };
 		B549B16A2A0CDAC10070C6AD /* FirstRunRecoveryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstRunRecoveryView.swift; sourceTree = "<group>"; };
@@ -616,6 +615,7 @@
 		B5D769CA29F770440015385A /* GenerativeProfilePic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerativeProfilePic.swift; sourceTree = "<group>"; };
 		B5D8D30029AF1F9B0011D820 /* Did.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Did.swift; sourceTree = "<group>"; };
 		B5D8FEB62AAC426C002CBF00 /* MainToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainToolbar.swift; sourceTree = "<group>"; };
+		B5E07B312B0337A100F302EA /* Tests_UserProfileDetailModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_UserProfileDetailModel.swift; sourceTree = "<group>"; };
 		B5E60C8A2A145F04007065A1 /* UserProfileBio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileBio.swift; sourceTree = "<group>"; };
 		B5E60C8C2A146838007065A1 /* Tests_UserProfileBio.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_UserProfileBio.swift; sourceTree = "<group>"; };
 		B5E816B82AB0458E00C61500 /* RecoveryPhrase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveryPhrase.swift; sourceTree = "<group>"; };
@@ -1126,6 +1126,7 @@
 				B8D328B929A69D2D00850A37 /* Tests_URLUtilities.swift */,
 				B8E62AE729D61E69008F7E74 /* Tests_UserDefaultProperty.swift */,
 				B5E60C8C2A146838007065A1 /* Tests_UserProfileBio.swift */,
+				B5E07B312B0337A100F302EA /* Tests_UserProfileDetailModel.swift */,
 				B5432B8229F8BAED003BBB23 /* Tests_UserProfileService.swift */,
 				B5908BEA29DAB05B00225B1A /* TestUtilities.swift */,
 			);
@@ -2010,6 +2011,7 @@
 				B8D328BA29A69D2D00850A37 /* Tests_URLUtilities.swift in Sources */,
 				B8F164252AE1B4A300A05CE7 /* Tests_StoryUser.swift in Sources */,
 				B831BDB72824DA9700C4CE92 /* Tests_Tape.swift in Sources */,
+				B5E07B322B0337A100F302EA /* Tests_UserProfileDetailModel.swift in Sources */,
 				B800248A2AE6BCC900CE6778 /* Tests_FeedAction.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/xcode/Subconscious/SubconsciousTests/Tests_DatabaseService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DatabaseService.swift
@@ -1035,16 +1035,25 @@ class Tests_DatabaseService: XCTestCase {
             )
         )
         
+        let alice = Petname("alice")!
+        let version = "bafyxyz123"
+        
         // Write fake sphere sync info so we can purge it
         try service.writePeer(
             PeerRecord(
-                petname: Petname("alice")!,
+                petname: alice,
                 identity: did,
-                since: "bafyxyz123"
+                since: version
             )
         )
         
-        try service.purgePeer(petname: Petname("alice")!)
+        let peer = try service.readPeer(petname: alice)
+        XCTAssertNotNil(peer)
+        XCTAssertEqual(peer?.identity, did)
+        XCTAssertEqual(peer?.petname, alice)
+        XCTAssertEqual(peer?.since, version)
+        
+        try service.purgePeer(petname: alice)
         
         let syncInfo = try service.readPeer(identity: did)
         XCTAssertNil(syncInfo)

--- a/xcode/Subconscious/SubconsciousTests/Tests_DatabaseService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DatabaseService.swift
@@ -1044,7 +1044,7 @@ class Tests_DatabaseService: XCTestCase {
             )
         )
         
-        try service.purgePeer(identity: did)
+        try service.purgePeer(petname: Petname("alice")!)
         
         let syncInfo = try service.readPeer(identity: did)
         XCTAssertNil(syncInfo)

--- a/xcode/Subconscious/SubconsciousTests/Tests_Detail.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Detail.swift
@@ -44,8 +44,8 @@ class Tests_Detail: XCTestCase {
         )
         
         XCTAssertEqual(
-            update.state.isLoading,
-            false,
+            update.state.loadingState,
+            .loaded,
             "isDetailLoading set to false"
         )
         XCTAssertEqual(

--- a/xcode/Subconscious/SubconsciousTests/Tests_UserProfileDetailModel.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_UserProfileDetailModel.swift
@@ -1,0 +1,126 @@
+//
+//  Tests_UserProfileDetailModel.swift
+//  SubconsciousTests
+//
+//  Created by Ben Follington on 14/11/2023.
+//
+
+import XCTest
+@testable import Subconscious
+
+class Tests_UserProfileDetailModel: XCTestCase {
+    func testProfileActionMapping() throws {
+        let did = Did.dummyData()
+        let petname = Petname.dummyData()
+        
+        XCTAssertEqual(
+            UserProfileDetailAction.toAppAction(
+                .attemptFollow(
+                    identity: did,
+                    petname: petname
+                )
+            ),
+            .followPeer(
+                identity: did,
+                petname: petname
+            )
+        )
+        
+        XCTAssertEqual(
+            UserProfileDetailAction.toAppAction(
+                .attemptUnfollow(
+                    identity: did,
+                    petname: petname
+                )
+            ),
+            .unfollowPeer(
+                identity: did,
+                petname: petname
+            )
+        )
+        
+        let newName = Petname.dummyData()
+        
+        XCTAssertEqual(
+            UserProfileDetailAction.toAppAction(
+                .attemptRename(
+                    from: petname,
+                    to: newName
+                )
+            ),
+            .renamePeer(
+                from: petname,
+                to: newName
+            )
+        )
+    }
+    
+    func testProfileNotificationReaction() throws {
+        let did = Did.dummyData()
+        let petname = Petname.dummyData()
+        
+        XCTAssertEqual(
+            UserProfileDetailAction.from(
+                .completeIndexPeers(results: [])
+            ),
+            .completeIndexPeers([])
+        )
+        
+        XCTAssertEqual(
+            UserProfileDetailAction.from(
+                .succeedFollowPeer(petname)
+            ),
+            .succeedFollow(petname)
+        )
+        
+        XCTAssertEqual(
+            UserProfileDetailAction.from(
+                .succeedUnfollowPeer(
+                    identity: did,
+                    petname: petname
+                )
+            ),
+            .succeedUnfollow(
+                identity: did,
+                petname: petname
+            )
+        )
+        
+        let newName = Petname.dummyData()
+        
+        XCTAssertEqual(
+            UserProfileDetailAction.from(
+                .succeedRenamePeer(
+                    identity: did,
+                    from: petname,
+                    to: newName
+                )
+            ),
+            .succeedRename(
+                identity: did,
+                from: petname,
+                to: newName
+            )
+        )
+    }
+    
+    func testProfileRefresh() throws {
+        let did = Did.dummyData()
+        let petname = Petname.dummyData()
+        let since = String.dummyDataMedium()
+        
+        XCTAssertEqual(
+            UserProfileDetailAction.from(
+                .succeedIndexOurSphere(OurSphereRecord(identity: did, since: since))
+            ),
+            .refresh(forceSync: false)
+        )
+        
+        XCTAssertEqual(
+            UserProfileDetailAction.from(
+                .succeedRecoverOurSphere
+            ),
+            .refresh(forceSync: false)
+        )
+    }
+}


### PR DESCRIPTION
Improves https://github.com/subconsciousnetwork/subconscious/issues/989
Fixes https://github.com/subconsciousnetwork/subconscious/issues/946
Fixes https://github.com/subconsciousnetwork/subconscious/issues/977

This PR remodels the follow/unfollow/rename operations and refresh lifecycle. It also introduces support for indexing multiple peers that point to the same DID.

https://github.com/subconsciousnetwork/subconscious/assets/5009316/58541708-99e1-4975-b2c1-97f079c0c66b

I intend to refactor the "wait for petname resolution" logic and background jobs in general as a follow up in https://github.com/subconsciousnetwork/subconscious/pull/996

# Tasks
- [x] Fix edgecase with alias rendering
- [x] Index peers by petname rather than DID
- [x] Move all follow/unfollow/rename communication to app root
- [x] Allow refreshing profile while displaying existing loaded content
- [x] Allow omnibar animation to start and stop multiple times
- [x] Refresh profile immediately after follow / unfollow
- [x] Kick off resolution immediately after rename
- [x] Kick off re-index immediately after follow / unfollow / resolve / rename
- [x] Trigger toast notifications for follow / unfollow / rename