### PR TITLE
Notify on sync failure and success

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -1996,7 +1996,12 @@ struct AppModel: ModelProtocol {
         
         return update(
             state: model,
-            action: .indexOurSphere,
+            actions: [
+                .indexOurSphere,
+                .toastStack(
+                    .pushToast(message: "Sync complete")
+                )
+            ],
             environment: environment
         )
     }
@@ -2018,7 +2023,12 @@ struct AppModel: ModelProtocol {
         
         return update(
             state: model,
-            action: .indexOurSphere,
+            actions: [
+                .indexOurSphere,
+                .toastStack(
+                    .pushToast(message: "Failed to sync")
+                )
+            ],
             environment: environment
         )
     }


### PR DESCRIPTION
The app never notifies the user that sync failed (or that it succeeded for that matter) which would've made it easier to diagnose an issue @justinabrahms ran into today.

This also provides some feedback that a drag-to-refresh did something.