### PR TITLE
Fix action logging in XCode 15

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -16,7 +16,12 @@ struct AppView: View {
     @StateObject private var store = Store(
         state: AppModel(),
         action: .start,
-        environment: AppEnvironment.default
+        environment: AppEnvironment.default,
+        loggingEnabled: true,
+        logger: Logger(
+            subsystem: Config.default.rdns,
+            category: "AppStore"
+        )
     )
     @Environment(\.scenePhase) private var scenePhase: ScenePhase
 
@@ -73,9 +78,6 @@ struct AppView: View {
         .onAppear {
             store.send(.appear)
         }
-        .onReceive(store.actions) { action in
-            AppAction.logger.debug("\(String(describing: action))")
-        }
         // Track changes to scene phase so we know when app gets
         // foregrounded/backgrounded.
         // See https://developer.apple.com/documentation/swiftui/scenephase
@@ -99,11 +101,6 @@ typealias PeerIndexResult = Result<PeerRecord, PeerIndexError>
 
 // MARK: Action
 enum AppAction: Hashable {
-    // Logger for actions
-    static let logger = Logger(
-        subsystem: Config.default.rdns,
-        category: "AppAction"
-    )
     /// Sent immediately upon store creation
     case start
 

--- a/xcode/Subconscious/Shared/Components/Deck/DeckView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/DeckView.swift
@@ -14,7 +14,12 @@ struct DeckView: View {
     @ObservedObject var app: Store<AppModel>
     @StateObject var store: Store<DeckModel> = Store(
         state: DeckModel(),
-        environment: AppEnvironment.default
+        environment: AppEnvironment.default,
+        loggingEnabled: true,
+        logger: Logger(
+            subsystem: Config.default.rdns,
+            category: "DeckStore"
+        )
     )
     
     var body: some View {
@@ -68,19 +73,11 @@ struct DeckView: View {
             store.actions.compactMap(AppAction.from),
             perform: app.send
         )
-        .onReceive(store.actions) { action in
-            DeckAction.logger.debug("\(String(describing: action))")
-        }
     }
 }
 
 // MARK: Actions
 enum DeckAction: Hashable {
-    static let logger = Logger(
-        subsystem: Config.default.rdns,
-        category: "DeckAction"
-    )
-    
     case detailStack(DetailStackAction)
     
     case setSearchPresented(Bool)

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -17,6 +17,11 @@ struct MemoEditorDetailView: View {
         category: "BlockEditorStore"
     )
 
+    private static let memoEditorDetailStoreLogger = Logger(
+        subsystem: Config.default.rdns,
+        category: "MemoEditorDetailStore"
+    )
+
     typealias Action = MemoEditorDetailAction
     @ObservedObject var app: Store<AppModel>
     
@@ -28,7 +33,9 @@ struct MemoEditorDetailView: View {
     @StateObject private var store = Store(
         state: MemoEditorDetailModel(),
         action: .start,
-        environment: AppEnvironment.default
+        environment: AppEnvironment.default,
+        loggingEnabled: true,
+        logger: memoEditorDetailStoreLogger
     )
     
     @StateObject private var blockEditorStore = Store(
@@ -134,11 +141,6 @@ struct MemoEditorDetailView: View {
             
             return .systemAction
         })
-        .onReceive(store.actions) { action in
-            MemoEditorDetailAction.logger.debug(
-                "\(String(describing: action))"
-            )
-        }
         // Filtermap actions to outer actions, and forward them to parent
         .onReceive(
             store.actions.compactMap(MemoEditorDetailNotification.from)
@@ -325,11 +327,6 @@ extension MemoEditorDetailNotification {
 
 /// Actions handled by detail's private store.
 enum MemoEditorDetailAction: Hashable {
-    static let logger = Logger(
-        subsystem: Config.default.rdns,
-        category: "MemoEditorDetailAction"
-    )
-
     /// Tagging action for detail meta bottom sheet
     case metaSheet(MemoEditorDetailMetaSheetAction)
 

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -17,7 +17,12 @@ struct MemoViewerDetailView: View {
     
     @StateObject private var store = Store(
         state: MemoViewerDetailModel(),
-        environment: AppEnvironment.default
+        environment: AppEnvironment.default,
+        loggingEnabled: true,
+        logger: Logger(
+            subsystem: Config.default.rdns,
+            category: "MemoViewerDetailStore"
+        )
     )
     
     var metaSheet: ViewStore<MemoViewerDetailMetaSheetModel> {
@@ -74,11 +79,6 @@ struct MemoViewerDetailView: View {
         })
         .onAppear {
             store.send(.appear(description))
-        }
-        .onReceive(store.actions) { action in
-            MemoViewerDetailAction.logger.debug(
-                "\(String(describing: action))"
-            )
         }
         .onReceive(
             store.actions.compactMap(MemoViewerDetailNotification.from),
@@ -304,11 +304,6 @@ struct MemoViewerDetailDescription: Hashable {
 
 // MARK: Actions
 enum MemoViewerDetailAction: Hashable {
-    static let logger = Logger(
-        subsystem: Config.default.rdns,
-        category: "MemoViewerDetailAction"
-    )
-
     case metaSheet(MemoViewerDetailMetaSheetAction)
     case appear(_ description: MemoViewerDetailDescription)
     case refreshAll

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -16,7 +16,12 @@ struct UserProfileDetailView: View {
     @ObservedObject var app: Store<AppModel>
     @StateObject private var store = Store(
         state: UserProfileDetailModel(),
-        environment: AppEnvironment.default
+        environment: AppEnvironment.default,
+        loggingEnabled: true,
+        logger: Logger(
+            subsystem: Config.default.rdns,
+            category: "UserProfileDetailStore"
+        )
     )
     
     static let logger = Logger(
@@ -52,11 +57,6 @@ struct UserProfileDetailView: View {
             app.actions.compactMap(UserProfileDetailAction.from),
             perform: store.send
         )
-        .onReceive(store.actions) { action in
-            UserProfileDetailAction.logger.debug(
-                "\(String(describing: action))"
-            )
-        }
     }
 }
 
@@ -134,11 +134,6 @@ extension UserProfileDetailAction {
 }
 
 enum UserProfileDetailAction: Equatable {
-    static let logger = Logger(
-        subsystem: Config.default.rdns,
-        category: "UserProfileDetailAction"
-    )
-
     case appear(Slashlink, Int)
     case refresh(forceSync: Bool)
     case populate(UserProfileContentResponse)

--- a/xcode/Subconscious/Shared/Components/Feed/Feed.swift
+++ b/xcode/Subconscious/Shared/Components/Feed/Feed.swift
@@ -77,7 +77,12 @@ struct FeedView: View {
     @ObservedObject var app: Store<AppModel>
     @StateObject private var store = Store(
         state: FeedModel(),
-        environment: AppEnvironment.default
+        environment: AppEnvironment.default,
+        loggingEnabled: true,
+        logger: Logger(
+            subsystem: Config.default.rdns,
+            category: "FeedStore"
+        )
     )
     
     var body: some View {
@@ -128,19 +133,11 @@ struct FeedView: View {
             store.actions.compactMap(AppAction.from),
             perform: app.send
         )
-        .onReceive(store.actions) { action in
-            FeedAction.logger.debug("\(String(describing: action))")
-        }
     }
 }
 
 // MARK: Action
 enum FeedAction: Hashable {
-    static let logger = Logger(
-        subsystem: Config.default.rdns,
-        category: "FeedAction"
-    )
-
     case search(SearchAction)
     case activatedSuggestion(Suggestion)
     case detailStack(DetailStackAction)

--- a/xcode/Subconscious/Shared/Components/HomeProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/HomeProfileView.swift
@@ -48,7 +48,12 @@ struct HomeProfileView: View {
     @ObservedObject var app: Store<AppModel>
     @StateObject private var store = Store(
         state: HomeProfileModel(),
-        environment: AppEnvironment.default
+        environment: AppEnvironment.default,
+        loggingEnabled: true,
+        logger: Logger(
+            subsystem: Config.default.rdns,
+            category: "HomeProfileStore"
+        )
     )
 
     var body: some View {
@@ -105,20 +110,12 @@ struct HomeProfileView: View {
             store.actions.compactMap(AppAction.from),
             perform: app.send
         )
-        .onReceive(store.actions) { action in
-            HomeProfileAction.logger.debug("\(String(describing: action))")
-        }
     }
 }
 
 
 // MARK: Action
 enum HomeProfileAction: Hashable {
-    static let logger = Logger(
-        subsystem: Config.default.rdns,
-        category: "HomeProfileAction"
-    )
-    
     case search(SearchAction)
     case activatedSuggestion(Suggestion)
     case detailStack(DetailStackAction)

--- a/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
@@ -20,7 +20,12 @@ struct NotebookView: View {
     /// Local major view store
     @StateObject private var store = Store(
         state: NotebookModel(),
-        environment: AppEnvironment.default
+        environment: AppEnvironment.default,
+        loggingEnabled: true,
+        logger: Logger(
+            subsystem: Config.default.rdns,
+            category: "NotebookStore"
+        )
     )
 
     var body: some View {
@@ -85,9 +90,6 @@ struct NotebookView: View {
             store.actions.compactMap(AppAction.from),
             perform: app.send
         )
-        .onReceive(store.actions) { action in
-            NotebookAction.logger.debug("\(String(describing: action))")
-        }
     }
 }
 
@@ -97,11 +99,6 @@ struct NotebookView: View {
 /// For action naming convention, see
 /// https://github.com/gordonbrander/subconscious/wiki/action-naming-convention
 enum NotebookAction: Hashable {
-    static let logger = Logger(
-        subsystem: Config.default.rdns,
-        category: "NotebookAction"
-    )
-    
     /// Tagged action for search HUD
     case search(SearchAction)
     /// Tagged action for detail stack

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -2981,8 +2981,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/gordonbrander/ObservableStore";
 			requirement = {
-				branch = "2023-12-04-public-logging";
-				kind = branch;
+				kind = exactVersion;
+				version = 0.6.0;
 			};
 		};
 		B82C3A6D26F6B1C000833CC8 /* XCRemoteSwiftPackageReference "swift-collections" */ = {

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -2981,8 +2981,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/gordonbrander/ObservableStore";
 			requirement = {
-				kind = exactVersion;
-				version = 0.5.0;
+				branch = "2023-12-04-public-logging";
+				kind = branch;
 			};
 		};
 		B82C3A6D26F6B1C000833CC8 /* XCRemoteSwiftPackageReference "swift-collections" */ = {

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gordonbrander/ObservableStore",
       "state" : {
-        "revision" : "e648004489af5aa886335ec0cd833fb0c556f849",
-        "version" : "0.5.0"
+        "branch" : "2023-12-04-public-logging",
+        "revision" : "bb4ac94c12b7e8c2109067340ff655aac042694a"
       }
     },
     {

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gordonbrander/ObservableStore",
       "state" : {
-        "branch" : "2023-12-04-public-logging",
-        "revision" : "bb4ac94c12b7e8c2109067340ff655aac042694a"
+        "revision" : "371a014b535fe9941f71041f1bded9e4e7a49fba",
+        "version" : "0.6.0"
       }
     },
     {


### PR DESCRIPTION
Fixes #1012.

Requires https://github.com/subconsciousnetwork/ObservableStore/pull/44 to land. Will leave this PR as a draft until we review + cut a new release for ObservableStore including this change.

It seems that logging behavior changed in XCode 15. Now strings and objects are masked private by default.

This change updates ObservableStore to a new version that logs actions at the public level by default. It also updates all of our stores to use ObservableStore's logger instead of logging on `onReceive`.

