### PR TITLE
Prefer basic Slug constructor for DB queries

### DIFF
--- a/xcode/Subconscious/Shared/Models/Slug.swift
+++ b/xcode/Subconscious/Shared/Models/Slug.swift
@@ -181,6 +181,6 @@ extension URL {
 
 extension String {
     func toSlug() -> Slug? {
-        Slug(formatting: self)
+        Slug(self)
     }
 }


### PR DESCRIPTION
Fixes #980 

`formatting:` drops deep slashlinks which is unsuitable for reading backlinks, we were not relying on this behaviour in any calls to `toSlug()` so I've updated the constructor within that helper.