### PR TITLE
Fix edit link menu

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/Profile/Sheets/EditProfileSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/Sheets/EditProfileSheet.swift
@@ -169,7 +169,7 @@ struct EditProfileSheet: View {
                             placeholder: "nickname",
                             field: store.viewStore(
                                 get: \.nicknameField,
-                                tag: EditProfileSheetAction.nicknameField
+                                tag: NicknameFieldCursor.tag
                             ),
                             caption: String(
                                 localized: "Lowercase letters, numbers and dashes only."
@@ -188,7 +188,7 @@ struct EditProfileSheet: View {
                             placeholder: "bio",
                             field: store.viewStore(
                                 get: \.bioField,
-                                tag: EditProfileSheetAction.bioField
+                                tag: BioFieldCursor.tag
                             ),
                             caption: bioCaption,
                             axis: .vertical

--- a/xcode/Subconscious/Shared/Components/Common/Profile/Sheets/FollowUserFormView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/Sheets/FollowUserFormView.swift
@@ -27,7 +27,7 @@ struct FollowUserFormView: View {
                     placeholder: "DID",
                     field: store.viewStore(
                         get: \.did,
-                        tag: FollowUserFormAction.didField
+                        tag: DidFieldCursor.tag
                     ),
                     caption: String(
                         localized: "e.g. did:key:z6MkmCJAZansQ3p1Qwx6wrF4c64yt2rcM8wMrH5Rh7DGb2K7"
@@ -47,7 +47,7 @@ struct FollowUserFormView: View {
                     placeholder: "petname",
                     field: store.viewStore(
                         get: \.petname,
-                        tag: FollowUserFormAction.petnameField
+                        tag: PetnameFieldCursor.tag
                     ),
                     caption: petnameCaption
                 )
@@ -128,7 +128,7 @@ struct FollowUserFormModel: ModelProtocol {
 
 // MARK: Cursors
 
-private struct PetnameFieldCursor: CursorProtocol {
+struct PetnameFieldCursor: CursorProtocol {
     typealias Model = FollowUserFormModel
     typealias ViewModel = FormField<String, Petname.Name>
 
@@ -147,7 +147,7 @@ private struct PetnameFieldCursor: CursorProtocol {
     }
 }
 
-private struct DidFieldCursor: CursorProtocol {
+struct DidFieldCursor: CursorProtocol {
     typealias Model = FollowUserFormModel
     typealias ViewModel = FormField<String, Did>
 

--- a/xcode/Subconscious/Shared/Components/Common/Profile/Sheets/FollowUserSheet.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/Sheets/FollowUserSheet.swift
@@ -198,7 +198,7 @@ struct FollowUserSheet: View {
                     placeholder: "petname",
                     field: store.viewStore(
                         get: \.followUserForm.petname,
-                        tag: { a in FollowUserSheetAction.followUserForm(.petnameField(a)) }
+                        tag: { a in FollowUserSheetAction.followUserForm(PetnameFieldCursor.tag(a)) }
                     ),
                     caption: caption
                 )

--- a/xcode/Subconscious/Shared/Components/Common/Recovery/RecoveryModeFormPanelView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Recovery/RecoveryModeFormPanelView.swift
@@ -32,7 +32,7 @@ struct RecoveryModeFormPanelView: View {
                 placeholder: "one two three four five six seven eight...",
                 field: store.viewStore(
                     get: \.recoveryPhraseField,
-                    tag: RecoveryModeAction.recoveryPhraseField
+                    tag: RecoveryPhraseFormFieldCursor.tag
                 ),
                 axis: .vertical
             )
@@ -60,7 +60,7 @@ struct RecoveryModeFormPanelView: View {
                         placeholder: "did:key:abc",
                         field: store.viewStore(
                             get: \.recoveryDidField,
-                            tag: RecoveryModeAction.recoveryDidField
+                            tag: RecoveryDidFormFieldCursor.tag
                         ),
                         caption: "The identity of your sphere",
                         axis: .vertical
@@ -74,7 +74,7 @@ struct RecoveryModeFormPanelView: View {
                         placeholder: "http://example.com",
                         field: store.viewStore(
                             get: \.recoveryGatewayURLField,
-                            tag: RecoveryModeAction.recoveryGatewayURLField
+                            tag: RecoveryGatewayURLFormFieldCursor.tag
                         ),
                         caption: String(localized: "The URL of your preferred Noosphere gateway"),
                         axis: .vertical

--- a/xcode/Subconscious/Shared/Components/Detail/RenameSearchView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/RenameSearchView.swift
@@ -21,7 +21,7 @@ struct RenameSearchView: View {
                     placeholder: String(localized: "Enter link for note"),
                     field: store.viewStore(
                         get: \.queryField,
-                        tag: RenameSearchAction.queryField
+                        tag: QueryFieldCursor.tag
                     ),
                     autoFocus: true
                 )

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunInviteView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunInviteView.swift
@@ -92,7 +92,7 @@ struct FirstRunInviteView: View {
                     placeholder: "Enter your invite code",
                     field: app.viewStore(
                         get: \.inviteCodeFormField,
-                        tag: AppAction.inviteCodeFormField
+                        tag: InviteCodeFormFieldCursor.tag
                     ),
                     caption: inviteCodeCaption,
                     onFocusChanged: { focused in

--- a/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/FirstRun/FirstRunProfileView.swift
@@ -52,7 +52,7 @@ struct FirstRunProfileView: View {
                     placeholder: "nickname",
                     field: app.viewStore(
                         get: \.nicknameFormField,
-                        tag: AppAction.nicknameFormField
+                        tag: NicknameFormFieldCursor.tag
                     ),
                     caption: "Lowercase letters, numbers and dashes only.",
                     autoFocus: true,

--- a/xcode/Subconscious/Shared/Components/Settings/AuthorizationSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/AuthorizationSettingsView.swift
@@ -53,7 +53,7 @@ struct AuthorizationSettingsView: View {
                         placeholder: "DID",
                         field: app.viewStore(
                             get: \.authorization.form.did,
-                            tag: { a in .authorization(.form(.didField(a))) }
+                            tag: { a in .authorization(.form(AuthorizationDidFieldCursor.tag(a))) }
                         ),
                         caption: String(
                             localized:
@@ -70,7 +70,7 @@ struct AuthorizationSettingsView: View {
                         placeholder: "name",
                         field: app.viewStore(
                             get: \.authorization.form.name,
-                            tag: { a in .authorization(.form(.nameField(a))) }
+                            tag: { a in .authorization(.form(AuthorizationNameFieldCursor.tag(a))) }
                         ),
                         caption: String(
                             localized: "The name for this authorization"
@@ -226,13 +226,13 @@ struct AuthorizationSettingsFormModel: ModelProtocol {
     ) -> Update<Self> {
         switch action {
         case .didField(let action):
-            return DidFieldCursor.update(
+            return AuthorizationDidFieldCursor.update(
                 state: state,
                 action: action,
                 environment: FormFieldEnvironment()
             )
         case .nameField(let action):
-            return NameFieldCursor.update(
+            return AuthorizationNameFieldCursor.update(
                 state: state,
                 action: action,
                 environment: FormFieldEnvironment()
@@ -486,7 +486,7 @@ struct AuthorizationSettingsFormCursor: CursorProtocol {
     }
 }
 
-private struct DidFieldCursor: CursorProtocol {
+private struct AuthorizationDidFieldCursor: CursorProtocol {
     typealias Model = AuthorizationSettingsFormModel
     typealias ViewModel = FormField<String, Did>
 
@@ -505,7 +505,7 @@ private struct DidFieldCursor: CursorProtocol {
     }
 }
 
-private struct NameFieldCursor: CursorProtocol {
+private struct AuthorizationNameFieldCursor: CursorProtocol {
     typealias Model = AuthorizationSettingsFormModel
     typealias ViewModel = FormField<String, String>
 

--- a/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/GatewayURLSettingsView.swift
@@ -19,7 +19,7 @@ struct GatewayURLSettingsView: View {
                         placeholder: "http://example.com",
                         field: app.viewStore(
                             get: \.gatewayURLField,
-                            tag: AppAction.gatewayURLField
+                            tag: GatewayUrlFormFieldCursor.tag
                         ),
                         caption: String(localized: "The URL of your preferred Noosphere gateway")
                     )

--- a/xcode/Subconscious/Shared/Components/Settings/InviteCodeSettingsSection.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/InviteCodeSettingsSection.swift
@@ -64,7 +64,7 @@ struct ValidatedInviteCodeFormField: View {
             placeholder: "Enter an invite code",
             field: app.viewStore(
                 get: \.inviteCodeFormField,
-                tag: AppAction.inviteCodeFormField
+                tag: InviteCodeFormFieldCursor.tag
             ),
             caption: caption
         )

--- a/xcode/Subconscious/Shared/Components/Settings/ProfileSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/ProfileSettingsView.swift
@@ -18,7 +18,7 @@ struct ProfileSettingsView: View {
                     placeholder: "nickname",
                     field: app.viewStore(
                         get: \.nicknameFormField,
-                        tag: AppAction.nicknameFormField
+                        tag: NicknameFormFieldCursor.tag
                     ),
                     caption: String(localized: "Lowercase letters, numbers and dashes only.")
                 )

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -893,7 +893,9 @@ final class DatabaseService {
         // audience as current.
         let queryAddress = Func.run({
             let audience = current.toAudience()
-            return Slug(formatting: query)?.toSlashlink(audience: audience)
+            // Try literal slug first to preserve slashes
+            // If that fails, try best effort formatting
+            return (Slug(query) ?? Slug(formatting: query))?.toSlashlink(audience: audience)
         })
         
         var dids = [Did.local.description]


### PR DESCRIPTION
It turns out when I refactored our form fields to use `ViewStore` I accidentally routed around the cursors which means some actions (like populating rename results) were not being dispatched.

I've restored cursors at every use site of `ValidatedFormField`.

Fixes https://github.com/subconsciousnetwork/subconscious/issues/992
Fixes https://github.com/subconsciousnetwork/subconscious/issues/1021