### PR TITLE
Move recovery to Advanced settings pane

### DIFF
--- a/xcode/Subconscious/Shared/Components/Settings/AdvancedSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/AdvancedSettingsView.swift
@@ -1,0 +1,36 @@
+//
+//  AdvancedSettingsView.swift
+//  Subconscious (iOS)
+//
+//  Created by Gordon Brander on 12/18/23.
+//
+
+import SwiftUI
+import ObservableStore
+
+struct AdvancedSettingsView: View {
+    @ObservedObject var app: Store<AppModel>
+    var body: some View {
+        Form {
+            Section(footer: Text("Recovery mode rebuilds your local database from your sphere in the cloud.")) {
+                Button(
+                    action: {
+                        app.send(.requestRecoveryMode(.userInitiated))
+                    },
+                    label: {
+                        Text("Recovery Mode")
+                    }
+                )
+            }
+        }
+    }
+}
+
+#Preview {
+    AdvancedSettingsView(
+        app: Store(
+            state: AppModel(),
+            environment: AppEnvironment()
+        )
+    )
+}

--- a/xcode/Subconscious/Shared/Components/Settings/AdvancedSettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/AdvancedSettingsView.swift
@@ -26,11 +26,13 @@ struct AdvancedSettingsView: View {
     }
 }
 
-#Preview {
-    AdvancedSettingsView(
-        app: Store(
-            state: AppModel(),
-            environment: AppEnvironment()
+struct AdvancedSettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        AdvancedSettingsView(
+            app: Store(
+                state: AppModel(),
+                environment: AppEnvironment()
+            )
         )
-    )
+    }
 }

--- a/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
+++ b/xcode/Subconscious/Shared/Components/Settings/SettingsView.swift
@@ -116,15 +116,10 @@ struct SettingsView: View {
                 
                 Section(
                     content: {
-                        Button(
-                            action: {
-                                app.send(.requestRecoveryMode(.userInitiated))
-                            },
-                            label: {
-                                Text("Recovery Mode")
-                            }
-                        )
-                        NavigationLink("Developer Settings") {
+                        NavigationLink("Advanced") {
+                            AdvancedSettingsView(app: app)
+                        }
+                        NavigationLink("Developer") {
                             DeveloperSettingsView(app: app)
                         }
                     },

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -514,6 +514,7 @@
 		B8F164252AE1B4A300A05CE7 /* Tests_StoryUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F164242AE1B4A300A05CE7 /* Tests_StoryUser.swift */; };
 		B8F27EE42970CD8F00A33E78 /* Tests_Sphere.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F27EE32970CD8F00A33E78 /* Tests_Sphere.swift */; };
 		B8F832E329B9292C00DFDFA8 /* Tests_SubtextAttributedStringRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F832E229B9292C00DFDFA8 /* Tests_SubtextAttributedStringRenderer.swift */; };
+		B8FB38B42B309096008A329C /* AdvancedSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FB38B32B309096008A329C /* AdvancedSettingsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -915,6 +916,7 @@
 		B8F164242AE1B4A300A05CE7 /* Tests_StoryUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_StoryUser.swift; sourceTree = "<group>"; };
 		B8F27EE32970CD8F00A33E78 /* Tests_Sphere.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_Sphere.swift; sourceTree = "<group>"; };
 		B8F832E229B9292C00DFDFA8 /* Tests_SubtextAttributedStringRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_SubtextAttributedStringRenderer.swift; sourceTree = "<group>"; };
+		B8FB38B32B309096008A329C /* AdvancedSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1293,13 +1295,14 @@
 		B88B1CDC298DE65E0062CB7F /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				B8FB38B32B309096008A329C /* AdvancedSettingsView.swift */,
 				B5C918ED2A67A16A004C6CD5 /* AuthorizationSettingsView.swift */,
 				B848FDA82991836900245115 /* DeveloperSettingsView.swift */,
 				B58FD6702A4E4BF000826548 /* GatewayProvisioningSettingsSection.swift */,
 				B88B1CE6298EEC240062CB7F /* GatewayURLSettingsView.swift */,
 				B58FD6722A4E4C0E00826548 /* InviteCodeSettingsSection.swift */,
-				B88B1CDD298DE66E0062CB7F /* SettingsView.swift */,
 				B8E00A2F2992DAA9003B40C1 /* ProfileSettingsView.swift */,
+				B88B1CDD298DE66E0062CB7F /* SettingsView.swift */,
 				B5C918EF2A67ADEF004C6CD5 /* SphereSettingsView.swift */,
 			);
 			path = Settings;
@@ -2116,6 +2119,7 @@
 				B86DD56A2A9FF49500E1DEA5 /* BlockEditorRelatedModel.swift in Sources */,
 				B8B4251828FDE8AA0081B8D5 /* MemoData.swift in Sources */,
 				B5C918F02A67ADEF004C6CD5 /* SphereSettingsView.swift in Sources */,
+				B8FB38B42B309096008A329C /* AdvancedSettingsView.swift in Sources */,
 				B8E2B02B29AD0E4D004A78B3 /* Slug.swift in Sources */,
 				B8AB08D02A9D522D00998099 /* UIViewDivider.swift in Sources */,
 				B8E6AACF2B0D41F500A3A11B /* BlocksModel.swift in Sources */,


### PR DESCRIPTION
Having the recovery button so close to the developer settings feels a bit scary to me, like I might accidentally tap it. This is a rarely-needed feature, so I created an advanced settings pane and moved it there, including some explanatory help text.