### PR TITLE
Fix transclude link rebasing

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
@@ -18,11 +18,9 @@ struct EntryRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.unit) {
             SubtextView(
+                peer: entry.toPeer(),
                 subtext: entry.excerpt,
-                onLink: { link in
-                    let rebasedLink = link.rebaseIfNeeded(peer: entry.toPeer())
-                    onLink(rebasedLink)
-                }
+                onLink: onLink
             )
             .font(.callout)
             .multilineTextAlignment(.leading)

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
@@ -71,14 +71,10 @@ struct StoryEntryView: View {
                     
                     // MARK: excerpt
                     SubtextView(
+                        peer: story.entry.toPeer(),
                         subtext: story.entry.excerpt,
                         transcludePreviews: [:],
-                        onLink: { link in
-                            let rebasedLink = link.rebaseIfNeeded(
-                                peer: story.entry.toPeer()
-                            )
-                            onLink(rebasedLink)
-                        }
+                        onLink: onLink
                     )
                     .padding([.leading, .trailing], AppTheme.padding)
                     

--- a/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
@@ -14,6 +14,7 @@ struct RenderableBlock: Hashable {
 
 struct SubtextView: View {
     private static var renderer = SubtextAttributedStringRenderer()
+    var peer: Peer? = nil
     var subtext: Subtext
     var transcludePreviews: [Slashlink: EntryStub] = [:]
     var onLink: (EntryLink) -> Void
@@ -91,7 +92,8 @@ struct SubtextView: View {
             guard let link = url.toSubSlashlinkLink()?.toEntryLink() else {
                 return .systemAction
             }
-            onLink(link)
+            
+            onLink(link.rebaseIfNeeded(peer: peer))
             return .handled
         })
     }

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeView.swift
@@ -33,13 +33,9 @@ struct TranscludeView: View {
                     )
                     
                     SubtextView(
+                        peer: entry.toPeer(),
                         subtext: entry.excerpt,
-                        onLink: { link in
-                            let rebasedLink = link.rebaseIfNeeded(
-                                peer: entry.toPeer()
-                            )
-                            onLink(rebasedLink)
-                        }
+                        onLink: onLink
                     )
                 }
                 .tint(highlight)

--- a/xcode/Subconscious/Shared/Components/Deck/CardStackView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/CardStackView.swift
@@ -35,10 +35,9 @@ struct CardView: View {
             switch entry.card {
             case let .entry(entry, _, backlinks):
                 SubtextView(
+                    peer: entry.toPeer(),
                     subtext: entry.excerpt,
-                    onLink: { link in
-                        onLink(link.rebaseIfNeeded(peer: entry.toPeer()))
-                    }
+                    onLink: onLink
                 )
                 // Opacity allows blendMode to show through
                 .foregroundStyle(.primary.opacity(0.8))
@@ -64,6 +63,8 @@ struct CardView: View {
                 }
                 .font(.caption)
                 .foregroundStyle(highlight)
+                .padding(DeckTheme.cardPadding)
+            
             case .action(let string):
                 // TEMP
                 VStack {

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -140,17 +140,11 @@ struct MemoViewerDetailLoadedView: View {
                 VStack {
                     VStack {
                         SubtextView(
+                            peer: store.state.owner?.address.peer,
                             subtext: store.state.dom,
                             transcludePreviews: store.state.transcludePreviews,
                             onLink: { link in
-                                notify(
-                                    .requestFindLinkDetail(
-                                        link.rebaseIfNeeded(
-                                            peer: store.state.owner?
-                                                .address.peer
-                                        )
-                                    )
-                                )
+                                notify(.requestFindLinkDetail(link))
                             }
                         ).textSelection(
                             .enabled


### PR DESCRIPTION
Discovered a bug we introduced in #1006 while I was playtesting: tapping transcludes resulted in double rebasing. For example:

1. viewing `@gordon/test`
2. tap a transclude block for `@gordon/hello`
3. I go to `@gordon.gordon/hello`

We need to pass more context down to `SubtextView` so it can appropriately handle link taps (need rebasing) vs. transclude taps (do not need rebasing).