### PR TITLE
Block editor: save when editor is backgrounded or un-presented

### DIFF
--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -313,6 +313,11 @@ extension MemoEditorDetailNotification {
 extension MemoEditorDetailNotification {
     static func from(_ action: BlockEditor.Action) -> Self? {
         switch action {
+        case let .succeedSave(entry):
+            return .succeedSaveEntry(
+                address: entry.address,
+                modified: entry.contents.modified
+            )
         case let .requestFindLinkDetail(link):
             return .requestFindLinkDetail(link)
         default:

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -106,7 +106,8 @@ struct MemoEditorDetailView: View {
         // See https://developer.apple.com/documentation/swiftui/scenephase
         // 2022-02-08 Gordon Brander
         .onChange(of: self.scenePhase) { phase in
-            store.send(MemoEditorDetailAction.scenePhaseChange(phase))
+            store.send(.scenePhaseChange(phase))
+            blockEditorStore.send(.scenePhaseChange(phase))
         }
         // Save when back button pressed.
         // Note that .onDisappear is too late, because by the time the save
@@ -117,6 +118,7 @@ struct MemoEditorDetailView: View {
         .onChange(of: self.isPresented) { isPresented in
             if !isPresented {
                 store.send(.autosave)
+                blockEditorStore.send(.autosave)
             }
         }
         /// Catch link taps and handle them here

--- a/xcode/Subconscious/Shared/UIKit/BlockEditor/BlockEditorModel.swift
+++ b/xcode/Subconscious/Shared/UIKit/BlockEditor/BlockEditorModel.swift
@@ -79,6 +79,8 @@ extension BlockEditor {
 extension BlockEditor {
     // MARK: Actions
     enum Action {
+        /// Handle app backgrounding, etec
+        case scenePhaseChange(ScenePhase)
         /// View is ready for updates.
         /// Sent during viewDidLoad after performing first view update for
         /// initial state and subscribing to changes.
@@ -242,6 +244,11 @@ extension BlockEditor.Model: ModelProtocol {
         environment: Environment
     ) -> Update {
         switch action {
+        case .scenePhaseChange:
+            return scenePhaseChange(
+                state: state,
+                environment: environment
+            )
         case .ready:
             return ready(
                 state: state,
@@ -508,6 +515,17 @@ extension BlockEditor.Model: ModelProtocol {
                 environment: environment
             )
         }
+    }
+
+    static func scenePhaseChange(
+        state: Self,
+        environment: Environment
+    ) -> Update {
+        return update(
+            state: state,
+            action: .autosave,
+            environment: environment
+        )
     }
     
     static func ready(


### PR DESCRIPTION
Fixes #1041

## Testing

Setup:

- Go to Settings > Developer > Block Editor, and turn on block editor.

Scenario 1:

- Create a new note or edit an existing note
- Type some text
- Swipe back

What should happen: note should be saved.

Scenario 2:

- Create a new note or edit an existing note
- Type some text
- Background the app

What should happen: note should be saved.