### PR TITLE
Fix loading state for block editor

### DIFF
--- a/xcode/Subconscious/Shared/UIKit/BlockEditor/Appendix/Related/BlockEditorRelatedModel.swift
+++ b/xcode/Subconscious/Shared/UIKit/BlockEditor/Appendix/Related/BlockEditorRelatedModel.swift
@@ -10,8 +10,6 @@ import Foundation
 extension BlockEditor {
     /// A collection of related notes
     struct RelatedModel: Hashable {
-        /// Is related loading?
-        var loadingState = LoadingState.loading
         var related: [EntryStub] = []
     }
 }

--- a/xcode/Subconscious/Shared/UIKit/BlockEditor/BlockEditorModel.swift
+++ b/xcode/Subconscious/Shared/UIKit/BlockEditor/BlockEditorModel.swift
@@ -745,7 +745,9 @@ extension BlockEditor.Model: ModelProtocol {
     ) -> Update {
         let address = state.address?.description ?? "nil"
         logger.warning("Failed to load detail for \(address). Error: \(error)")
-        return Update(state: state)
+        var model = state
+        model.loadingState = .notFound
+        return Update(state: model)
     }
     
     /// Set editor state, replacing whatever was previously there.
@@ -759,8 +761,6 @@ extension BlockEditor.Model: ModelProtocol {
         environment: Environment
     ) -> Update {
         var model = state
-        // Finished loading. We have the data.
-        model.loadingState = .loaded
         model.setSaveState(detail.saveState)
         model.address = detail.entry.address
         model.created = detail.entry.contents.created


### PR DESCRIPTION
Minor cleanup following #1043

- Remove loading state from related. We don't need it.
- Mark loading state `notFound` if editor fails to load
- Mark loading state in succeedLoadEditor, not in setEditor

Part of #214 