### PR TITLE
User customizable note colors

### DIFF
--- a/xcode/Subconscious/Shared/AppTheme.swift
+++ b/xcode/Subconscious/Shared/AppTheme.swift
@@ -109,7 +109,7 @@ extension Color {
         .opacity(0.5)
     static let primaryButtonBackgroundDisabled = primaryButtonBackground
         .opacity(0.3)
-    static let primaryButtonText = SwiftUI.Color.accentColor
+    static var primaryButtonText: Color { SwiftUI.Color.accentColor }
     static let primaryButtonTextPressed = primaryButtonText.opacity(0.5)
     static let primaryButtonTextDisabled = primaryButtonText.opacity(0.3)
     static let fabBackground = primaryButtonBackground

--- a/xcode/Subconscious/Shared/Assets.xcassets/CardThemeColorA.colorset/Contents.json
+++ b/xcode/Subconscious/Shared/Assets.xcassets/CardThemeColorA.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.94",
+          "green" : "0.96",
+          "red" : "0.98"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.5",
+          "green" : "0.58",
+          "red" : "0.63"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/xcode/Subconscious/Shared/Assets.xcassets/CardThemeColorB.colorset/Contents.json
+++ b/xcode/Subconscious/Shared/Assets.xcassets/CardThemeColorB.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.97",
+          "green" : "0.98",
+          "red" : "0.92"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.58",
+          "green" : "0.56",
+          "red" : "0.52"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/xcode/Subconscious/Shared/Assets.xcassets/CardThemeColorC.colorset/Contents.json
+++ b/xcode/Subconscious/Shared/Assets.xcassets/CardThemeColorC.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.97",
+          "green" : "0.93",
+          "red" : "0.97"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.59",
+          "green" : "0.45",
+          "red" : "0.67"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/xcode/Subconscious/Shared/Assets.xcassets/CardThemeColorD.colorset/Contents.json
+++ b/xcode/Subconscious/Shared/Assets.xcassets/CardThemeColorD.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.94",
+          "green" : "0.92",
+          "red" : "0.98"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.48",
+          "green" : "0.44",
+          "red" : "0.66"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/xcode/Subconscious/Shared/Assets.xcassets/CardThemeColorE.colorset/Contents.json
+++ b/xcode/Subconscious/Shared/Assets.xcassets/CardThemeColorE.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.97",
+          "green" : "0.94",
+          "red" : "0.93"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.63",
+          "green" : "0.47",
+          "red" : "0.53"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/xcode/Subconscious/Shared/Assets.xcassets/CardThemeHighlightColorA.colorset/Contents.json
+++ b/xcode/Subconscious/Shared/Assets.xcassets/CardThemeHighlightColorA.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.73",
+          "green" : "0.62",
+          "blue" : "0.45",
+          "alpha" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.82",
+          "green" : "0.930",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/xcode/Subconscious/Shared/Assets.xcassets/CardThemeHighlightColorB.colorset/Contents.json
+++ b/xcode/Subconscious/Shared/Assets.xcassets/CardThemeHighlightColorB.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.66",
+          "green" : "0.71",
+          "red" : "0.36"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.9",
+          "green" : "0.88",
+          "red" : "0.88"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/xcode/Subconscious/Shared/Assets.xcassets/CardThemeHighlightColorC.colorset/Contents.json
+++ b/xcode/Subconscious/Shared/Assets.xcassets/CardThemeHighlightColorC.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.640",
+          "green" : "0.410",
+          "red" : "0.660"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.920",
+          "green" : "0.750",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/xcode/Subconscious/Shared/Assets.xcassets/CardThemeHighlightColorD.colorset/Contents.json
+++ b/xcode/Subconscious/Shared/Assets.xcassets/CardThemeHighlightColorD.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.45",
+          "green" : "0.36",
+          "red" : "0.71"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.78",
+          "green" : "0.740",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/xcode/Subconscious/Shared/Assets.xcassets/CardThemeHighlightColorE.colorset/Contents.json
+++ b/xcode/Subconscious/Shared/Assets.xcassets/CardThemeHighlightColorE.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.66",
+          "green" : "0.48",
+          "red" : "0.39"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.95",
+          "green" : "0.78",
+          "red" : "0.89"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -302,7 +302,7 @@ enum AppAction: Hashable {
     case mergeEntry(parent: Slashlink, child: Slashlink)
     case moveEntry(from: Slashlink, to: Slashlink)
     case updateAudience(address: Slashlink, audience: Audience)
-    case assignColor(addess: Slashlink, color: NoteColor)
+    case assignColor(addess: Slashlink, color: ThemeColor)
     
     // These notifications will be passe down to child stores to update themselves accordingly.
     case succeedSaveEntry(address: Slashlink, modified: Date)
@@ -310,7 +310,7 @@ enum AppAction: Hashable {
     case succeedMoveEntry(from: Slashlink, to: Slashlink)
     case succeedMergeEntry(parent: Slashlink, child: Slashlink)
     case succeedUpdateAudience(MoveReceipt)
-    case succeedAssignNoteColor(address: Slashlink, color: NoteColor)
+    case succeedAssignNoteColor(address: Slashlink, color: ThemeColor)
     case failSaveEntry(address: Slashlink, error: String)
     case failDeleteMemo(String)
     case failMoveEntry(from: Slashlink, to: Slashlink, error: String)
@@ -3121,7 +3121,7 @@ struct AppModel: ModelProtocol {
         state: Self,
         environment: Environment,
         address: Slashlink,
-        color: NoteColor
+        color: ThemeColor
     ) -> Update<Self> {
         let fx: Fx<Action> = Future.detached {
             try await environment.data.assignNoteColor(

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -302,7 +302,7 @@ enum AppAction: Hashable {
     case mergeEntry(parent: Slashlink, child: Slashlink)
     case moveEntry(from: Slashlink, to: Slashlink)
     case updateAudience(address: Slashlink, audience: Audience)
-    case assignColor(addess: Slashlink, color: ThemeColor)
+    case assignColor(address: Slashlink, color: ThemeColor)
     
     // These notifications will be passe down to child stores to update themselves accordingly.
     case succeedSaveEntry(address: Slashlink, modified: Date)

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -302,6 +302,7 @@ enum AppAction: Hashable {
     case mergeEntry(parent: Slashlink, child: Slashlink)
     case moveEntry(from: Slashlink, to: Slashlink)
     case updateAudience(address: Slashlink, audience: Audience)
+    case assignColor(addess: Slashlink, color: NoteColor)
     
     // These notifications will be passe down to child stores to update themselves accordingly.
     case succeedSaveEntry(address: Slashlink, modified: Date)
@@ -309,11 +310,13 @@ enum AppAction: Hashable {
     case succeedMoveEntry(from: Slashlink, to: Slashlink)
     case succeedMergeEntry(parent: Slashlink, child: Slashlink)
     case succeedUpdateAudience(MoveReceipt)
+    case succeedAssignNoteColor(address: Slashlink, color: NoteColor)
     case failSaveEntry(address: Slashlink, error: String)
     case failDeleteMemo(String)
     case failMoveEntry(from: Slashlink, to: Slashlink, error: String)
     case failMergeEntry(parent: Slashlink, child: Slashlink, error: String)
     case failUpdateAudience(address: Slashlink, audience: Audience, error: String)
+    case failAssignNoteColor(address: Slashlink, error: String)
     
     case succeedLogActivity
     case failLogActivity(_ error: String)
@@ -1220,7 +1223,8 @@ struct AppModel: ModelProtocol {
                 state: state,
                 environment: environment
             )
-        case .succeedMoveEntry, .succeedMergeEntry, .succeedLogActivity, .succeedUpdateAudience:
+        case .succeedMoveEntry, .succeedMergeEntry, .succeedLogActivity, .succeedUpdateAudience,
+                .succeedAssignNoteColor:
             return Update(state: state)
         case .succeedSaveEntry(address: let address, modified: let modified):
             return succeedSaveEntry(
@@ -1255,6 +1259,13 @@ struct AppModel: ModelProtocol {
                 environment: environment,
                 address: address,
                 audience: audience
+            )
+        case let .assignColor(address, color):
+            return assignNoteColor(
+                state: state,
+                environment: environment,
+                address: address,
+                color: color
             )
         case .failSaveEntry(address: let address, error: let error):
             logger.warning(
@@ -1320,6 +1331,20 @@ struct AppModel: ModelProtocol {
                 """
             )
             return Update(state: state)
+        case let .failAssignNoteColor(address, error):
+            logger.warning(
+                """
+                Failed to assign color for entry: \(address)
+                \(error)
+                """
+            )
+            return update(
+                state: state,
+                action: .pushToast(
+                    message: "Could not set color"
+                ),
+                environment: environment
+            )
         }
     }
     
@@ -3090,6 +3115,34 @@ struct AppModel: ModelProtocol {
             state: state,
             fx: fx
         )
+    }
+    
+    static func assignNoteColor(
+        state: Self,
+        environment: Environment,
+        address: Slashlink,
+        color: NoteColor
+    ) -> Update<Self> {
+        let fx: Fx<Action> = Future.detached {
+            try await environment.data.assignNoteColor(
+                address: address,
+                color: color
+            )
+            
+            return .succeedAssignNoteColor(
+                address: address,
+                color: color
+            )
+        }
+        .recover { error in
+            return .failAssignNoteColor(
+                address: address,
+                error: error.localizedDescription
+            )
+        }
+        .eraseToAnyPublisher()
+        
+        return Update(state: state, fx: fx)
     }
 }
 

--- a/xcode/Subconscious/Shared/Components/BacklinksView.swift
+++ b/xcode/Subconscious/Shared/Components/BacklinksView.swift
@@ -49,7 +49,6 @@ struct BacklinksView_Previews: PreviewProvider {
                         did: Did.dummyData(),
                         address: Slashlink("@handle/short")!,
                         excerpt: Subtext(markup: "Short"),
-                        modified: Date.now,
                         headers: WellKnownHeaders.emptySubtext
                     ),
                     EntryStub(
@@ -58,7 +57,6 @@ struct BacklinksView_Previews: PreviewProvider {
                         excerpt: Subtext(
                             markup: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi."
                         ),
-                        modified: Date.now,
                         headers: WellKnownHeaders.emptySubtext
                     ),
                     EntryStub(
@@ -67,7 +65,6 @@ struct BacklinksView_Previews: PreviewProvider {
                         excerpt: Subtext(
                             markup: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi."
                         ),
-                        modified: Date.now,
                         headers: WellKnownHeaders.emptySubtext
                     ),
                     EntryStub(
@@ -76,7 +73,6 @@ struct BacklinksView_Previews: PreviewProvider {
                         excerpt: Subtext(
                             markup: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi."
                         ),
-                        modified: Date.now,
                         headers: WellKnownHeaders.emptySubtext
                     )
                 ],

--- a/xcode/Subconscious/Shared/Components/BacklinksView.swift
+++ b/xcode/Subconscious/Shared/Components/BacklinksView.swift
@@ -49,7 +49,7 @@ struct BacklinksView_Previews: PreviewProvider {
                         did: Did.dummyData(),
                         address: Slashlink("@handle/short")!,
                         excerpt: Subtext(markup: "Short"),
-                        headers: WellKnownHeaders.emptySubtext
+                        headers: .emptySubtext
                     ),
                     EntryStub(
                         did: Did.dummyData(),
@@ -57,7 +57,7 @@ struct BacklinksView_Previews: PreviewProvider {
                         excerpt: Subtext(
                             markup: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi."
                         ),
-                        headers: WellKnownHeaders.emptySubtext
+                        headers: .emptySubtext
                     ),
                     EntryStub(
                         did: Did.dummyData(),
@@ -65,7 +65,7 @@ struct BacklinksView_Previews: PreviewProvider {
                         excerpt: Subtext(
                             markup: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi."
                         ),
-                        headers: WellKnownHeaders.emptySubtext
+                        headers: .emptySubtext
                     ),
                     EntryStub(
                         did: Did.local,
@@ -73,7 +73,7 @@ struct BacklinksView_Previews: PreviewProvider {
                         excerpt: Subtext(
                             markup: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi."
                         ),
-                        headers: WellKnownHeaders.emptySubtext
+                        headers: .emptySubtext
                     )
                 ],
                 onLink: { link in }

--- a/xcode/Subconscious/Shared/Components/BacklinksView.swift
+++ b/xcode/Subconscious/Shared/Components/BacklinksView.swift
@@ -49,7 +49,8 @@ struct BacklinksView_Previews: PreviewProvider {
                         did: Did.dummyData(),
                         address: Slashlink("@handle/short")!,
                         excerpt: Subtext(markup: "Short"),
-                        modified: Date.now
+                        modified: Date.now,
+                        headers: WellKnownHeaders.emptySubtext
                     ),
                     EntryStub(
                         did: Did.dummyData(),
@@ -57,7 +58,8 @@ struct BacklinksView_Previews: PreviewProvider {
                         excerpt: Subtext(
                             markup: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi."
                         ),
-                        modified: Date.now
+                        modified: Date.now,
+                        headers: WellKnownHeaders.emptySubtext
                     ),
                     EntryStub(
                         did: Did.dummyData(),
@@ -65,7 +67,8 @@ struct BacklinksView_Previews: PreviewProvider {
                         excerpt: Subtext(
                             markup: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi."
                         ),
-                        modified: Date.now
+                        modified: Date.now,
+                        headers: WellKnownHeaders.emptySubtext
                     ),
                     EntryStub(
                         did: Did.local,
@@ -73,7 +76,8 @@ struct BacklinksView_Previews: PreviewProvider {
                         excerpt: Subtext(
                             markup: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi."
                         ),
-                        modified: Date.now
+                        modified: Date.now,
+                        headers: WellKnownHeaders.emptySubtext
                     )
                 ],
                 onLink: { link in }

--- a/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListView.swift
@@ -95,7 +95,8 @@ struct EntryListView_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "Anything that can be derived should be derived. Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply."
                     ),
-                    modified: Date.now
+                    modified: Date.now,
+                    headers: WellKnownHeaders.emptySubtext
                 ),
                 EntryStub(
                     did: Did.dummyData(),
@@ -105,7 +106,8 @@ struct EntryListView_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "Anything that can be derived should be derived. Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply."
                     ),
-                    modified: Date.now
+                    modified: Date.now,
+                    headers: WellKnownHeaders.emptySubtext
                 )
             ],
             onEntryPress: { entry in },

--- a/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListView.swift
@@ -95,8 +95,7 @@ struct EntryListView_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "Anything that can be derived should be derived. Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply."
                     ),
-                    modified: Date.now,
-                    headers: WellKnownHeaders.emptySubtext
+                    headers: .emptySubtext
                 ),
                 EntryStub(
                     did: Did.dummyData(),
@@ -106,8 +105,7 @@ struct EntryListView_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "Anything that can be derived should be derived. Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply."
                     ),
-                    modified: Date.now,
-                    headers: WellKnownHeaders.emptySubtext
+                    headers: .emptySubtext
                 )
             ],
             onEntryPress: { entry in },

--- a/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
@@ -75,7 +75,8 @@ struct EntryRow_Previews: PreviewProvider {
                               Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply.
                               """
                     ),
-                    modified: Date.now
+                    modified: Date.now,
+                    headers: WellKnownHeaders.emptySubtext
                 )
             )
             EntryRow(
@@ -87,7 +88,8 @@ struct EntryRow_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "Anything that can be derived should be derived. Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply."
                     ),
-                    modified: Date.now
+                    modified: Date.now,
+                    headers: WellKnownHeaders.emptySubtext
                 )
             )
             EntryRow(
@@ -99,7 +101,8 @@ struct EntryRow_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "Anything that can be derived should be derived. Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply."
                     ),
-                    modified: Date.now
+                    modified: Date.now,
+                    headers: WellKnownHeaders.emptySubtext
                 )
             )
             EntryRow(
@@ -111,7 +114,8 @@ struct EntryRow_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "Anything that can be derived should be derived. Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply."
                     ),
-                    modified: Date.now
+                    modified: Date.now,
+                    headers: WellKnownHeaders.emptySubtext
                 )
             )
         }

--- a/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
@@ -75,7 +75,7 @@ struct EntryRow_Previews: PreviewProvider {
                               Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply.
                               """
                     ),
-                    headers: WellKnownHeaders.emptySubtext
+                    headers: .emptySubtext
                 )
             )
             EntryRow(
@@ -87,7 +87,7 @@ struct EntryRow_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "Anything that can be derived should be derived. Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply."
                     ),
-                    headers: WellKnownHeaders.emptySubtext
+                    headers: .emptySubtext
                 )
             )
             EntryRow(
@@ -99,7 +99,7 @@ struct EntryRow_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "Anything that can be derived should be derived. Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply."
                     ),
-                    headers: WellKnownHeaders.emptySubtext
+                    headers: .emptySubtext
                 )
             )
             EntryRow(
@@ -111,7 +111,7 @@ struct EntryRow_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "Anything that can be derived should be derived. Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply."
                     ),
-                    headers: WellKnownHeaders.emptySubtext
+                    headers: .emptySubtext
                 )
             )
         }

--- a/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
@@ -42,7 +42,7 @@ struct EntryRow: View {
 
                 Text(
                     NiceDateFormatter.shared.string(
-                        from: entry.modified,
+                        from: entry.headers.modified,
                         relativeTo: Date.now
                     )
                 )
@@ -75,7 +75,6 @@ struct EntryRow_Previews: PreviewProvider {
                               Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply.
                               """
                     ),
-                    modified: Date.now,
                     headers: WellKnownHeaders.emptySubtext
                 )
             )
@@ -88,7 +87,6 @@ struct EntryRow_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "Anything that can be derived should be derived. Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply."
                     ),
-                    modified: Date.now,
                     headers: WellKnownHeaders.emptySubtext
                 )
             )
@@ -101,7 +99,6 @@ struct EntryRow_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "Anything that can be derived should be derived. Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply."
                     ),
-                    modified: Date.now,
                     headers: WellKnownHeaders.emptySubtext
                 )
             )
@@ -114,7 +111,6 @@ struct EntryRow_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "Anything that can be derived should be derived. Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply."
                     ),
-                    modified: Date.now,
                     headers: WellKnownHeaders.emptySubtext
                 )
             )

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
@@ -97,7 +97,7 @@ struct StoryEntryView: View {
                             
                             Text(
                                 NiceDateFormatter.shared.string(
-                                    from: story.entry.modified,
+                                    from: story.entry.headers.modified,
                                     relativeTo: Date.now
                                 )
                             )

--- a/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
@@ -146,7 +146,8 @@ struct SubtextView_Previews: PreviewProvider {
                                 "/wanderer-your-footsteps-are-the-road"
                             )!,
                             excerpt: Subtext(markup: "hello"),
-                            modified: Date.now
+                            modified: Date.now,
+                            headers: WellKnownHeaders.emptySubtext
                         ),
                         Slashlink("/voice")!: EntryStub(
                             did: Did.dummyData(),
@@ -154,7 +155,8 @@ struct SubtextView_Previews: PreviewProvider {
                                 "/voice"
                             )!,
                             excerpt: Subtext(markup: "hello"),
-                            modified: Date.now
+                            modified: Date.now,
+                            headers: WellKnownHeaders.emptySubtext
                         ),
                         Slashlink("/memory")!: EntryStub(
                             did: Did.dummyData(),
@@ -162,7 +164,8 @@ struct SubtextView_Previews: PreviewProvider {
                                 "/memory"
                             )!,
                             excerpt: Subtext(markup: "hello world"),
-                            modified: Date.now
+                            modified: Date.now,
+                            headers: WellKnownHeaders.emptySubtext
                         )
                     ],
                     onLink: { link in }

--- a/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextView.swift
@@ -146,8 +146,7 @@ struct SubtextView_Previews: PreviewProvider {
                                 "/wanderer-your-footsteps-are-the-road"
                             )!,
                             excerpt: Subtext(markup: "hello"),
-                            modified: Date.now,
-                            headers: WellKnownHeaders.emptySubtext
+                            headers: .emptySubtext
                         ),
                         Slashlink("/voice")!: EntryStub(
                             did: Did.dummyData(),
@@ -155,8 +154,7 @@ struct SubtextView_Previews: PreviewProvider {
                                 "/voice"
                             )!,
                             excerpt: Subtext(markup: "hello"),
-                            modified: Date.now,
-                            headers: WellKnownHeaders.emptySubtext
+                            headers: .emptySubtext
                         ),
                         Slashlink("/memory")!: EntryStub(
                             did: Did.dummyData(),
@@ -164,8 +162,7 @@ struct SubtextView_Previews: PreviewProvider {
                                 "/memory"
                             )!,
                             excerpt: Subtext(markup: "hello world"),
-                            modified: Date.now,
-                            headers: WellKnownHeaders.emptySubtext
+                            headers: .emptySubtext
                         )
                     ],
                     onLink: { link in }

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeListView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeListView.swift
@@ -45,7 +45,6 @@ struct TranscludeListView_Previews: PreviewProvider {
                               Some years ago- never mind how long precisely
                               """
                     ),
-                    modified: Date.now,
                     headers: .emptySubtext
                 ),
             ],

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeListView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeListView.swift
@@ -23,9 +23,7 @@ struct TranscludeListView: View {
                     )
                 }
                 .tint(
-                    entry.headers.color?.toHighlightColor(
-                        colorScheme: colorScheme
-                    )
+                    entry.headers.themeColor?.toHighlightColor()
                 )
             }
         }

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeListView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeListView.swift
@@ -23,7 +23,7 @@ struct TranscludeListView: View {
                     )
                 }
                 .tint(
-                    entry.address.noteColor.toHighlightColor(
+                    entry.headers.color.toHighlightColor(
                         colorScheme: colorScheme
                     )
                 )

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeListView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeListView.swift
@@ -23,7 +23,7 @@ struct TranscludeListView: View {
                     )
                 }
                 .tint(
-                    entry.headers.color.toHighlightColor(
+                    entry.headers.color?.toHighlightColor(
                         colorScheme: colorScheme
                     )
                 )

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeListView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeListView.swift
@@ -45,7 +45,8 @@ struct TranscludeListView_Previews: PreviewProvider {
                               Some years ago- never mind how long precisely
                               """
                     ),
-                    modified: Date.now
+                    modified: Date.now,
+                    headers: .emptySubtext
                 ),
             ],
             onLink: { _ in }

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeListView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeListView.swift
@@ -23,7 +23,7 @@ struct TranscludeListView: View {
                     )
                 }
                 .tint(
-                    entry.address.highlightColor(
+                    entry.address.noteColor.toHighlightColor(
                         colorScheme: colorScheme
                     )
                 )

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeView.swift
@@ -64,7 +64,8 @@ struct TranscludeView_Previews: PreviewProvider {
                     did: Did.dummyData(),
                     address: Slashlink("/short")!,
                     excerpt: Subtext(markup: "Short."),
-                    modified: Date.now
+                    modified: Date.now,
+                    headers: WellKnownHeaders.emptySubtext
                 ),
                 onLink: { _ in }
             )
@@ -75,7 +76,8 @@ struct TranscludeView_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "Call me Ishmael. Some years ago- never mind how long precisely- having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little and see the watery part of the world. It is a way I have of driving off the spleen and regulating the circulation."
                     ),
-                    modified: Date.now
+                    modified: Date.now,
+                    headers: WellKnownHeaders.emptySubtext
                 ),
                 onLink: { _ in }
             )
@@ -86,7 +88,8 @@ struct TranscludeView_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "Call me Ishmael. Some years ago- never mind how long precisely"
                     ),
-                    modified: Date.now
+                    modified: Date.now,
+                    headers: WellKnownHeaders.emptySubtext
                 ),
                 onLink: { _ in }
             )
@@ -100,7 +103,8 @@ struct TranscludeView_Previews: PreviewProvider {
                               Some years ago- never mind how long precisely
                               """
                     ),
-                    modified: Date.now
+                    modified: Date.now,
+                    headers: WellKnownHeaders.emptySubtext
                 ),
                 onLink: { _ in }
             )
@@ -111,7 +115,8 @@ struct TranscludeView_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "Call me Ishmael. Some years ago- never mind how long precisely"
                     ),
-                    modified: Date.now
+                    modified: Date.now,
+                    headers: WellKnownHeaders.emptySubtext
                 ),
                 onLink: { _ in }
             )

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeView.swift
@@ -64,8 +64,7 @@ struct TranscludeView_Previews: PreviewProvider {
                     did: Did.dummyData(),
                     address: Slashlink("/short")!,
                     excerpt: Subtext(markup: "Short."),
-                    modified: Date.now,
-                    headers: WellKnownHeaders.emptySubtext
+                    headers: .emptySubtext
                 ),
                 onLink: { _ in }
             )
@@ -76,8 +75,7 @@ struct TranscludeView_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "Call me Ishmael. Some years ago- never mind how long precisely- having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little and see the watery part of the world. It is a way I have of driving off the spleen and regulating the circulation."
                     ),
-                    modified: Date.now,
-                    headers: WellKnownHeaders.emptySubtext
+                    headers: .emptySubtext
                 ),
                 onLink: { _ in }
             )
@@ -88,8 +86,7 @@ struct TranscludeView_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "Call me Ishmael. Some years ago- never mind how long precisely"
                     ),
-                    modified: Date.now,
-                    headers: WellKnownHeaders.emptySubtext
+                    headers: .emptySubtext
                 ),
                 onLink: { _ in }
             )
@@ -103,8 +100,7 @@ struct TranscludeView_Previews: PreviewProvider {
                               Some years ago- never mind how long precisely
                               """
                     ),
-                    modified: Date.now,
-                    headers: WellKnownHeaders.emptySubtext
+                    headers: .emptySubtext
                 ),
                 onLink: { _ in }
             )
@@ -115,8 +111,7 @@ struct TranscludeView_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "Call me Ishmael. Some years ago- never mind how long precisely"
                     ),
-                    modified: Date.now,
-                    headers: WellKnownHeaders.emptySubtext
+                    headers: .emptySubtext
                 ),
                 onLink: { _ in }
             )

--- a/xcode/Subconscious/Shared/Components/Deck/DeckTheme.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/DeckTheme.swift
@@ -148,34 +148,26 @@ private extension Hashable {
             : DeckTheme.lightCardHighlightColors
     }
     
-    func color(colorScheme: ColorScheme) -> Color {
-        let colors = colors(colorScheme: colorScheme)
-        return colors[abs(self.hashValue) % colors.count]
-    }
-    
-    func highlightColor(colorScheme: ColorScheme) -> Color {
-        let colors = highlightColors(colorScheme: colorScheme)
+    var noteColor: NoteColor {
+        let colors = NoteColor.allCases
         return colors[abs(self.hashValue) % colors.count]
     }
 }
 
 extension Slashlink {
-    func color(colorScheme: ColorScheme) -> Color {
-        description.color(colorScheme: colorScheme)
-    }
-    
-    func highlightColor(colorScheme: ColorScheme) -> Color {
-        description.highlightColor(colorScheme: colorScheme)
+    var noteColor: NoteColor {
+        description.noteColor
     }
 }
 
-
 extension EntryStub {
     func color(colorScheme: ColorScheme) -> Color {
-        self.color?.toColor(colorScheme: colorScheme) ?? .secondaryBackground
+        self.color?.toColor(colorScheme: colorScheme) 
+            ?? self.address.noteColor.toColor(colorScheme: colorScheme)
     }
     
     func highlightColor(colorScheme: ColorScheme) -> Color {
-        self.color?.toHighlightColor(colorScheme: colorScheme) ?? .accentColor
+        self.color?.toHighlightColor(colorScheme: colorScheme)
+            ?? self.address.noteColor.toHighlightColor(colorScheme: colorScheme)
     }
 }

--- a/xcode/Subconscious/Shared/Components/Deck/DeckTheme.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/DeckTheme.swift
@@ -87,6 +87,54 @@ extension DeckTheme {
     static let cardHeaderTint = Color.brandMarkPink.opacity(0.025)
 }
 
+public enum NoteColor: String, Hashable, CaseIterable {
+    case tan
+    case cyan
+    case pink
+    case orange
+    case blue
+}
+
+public extension NoteColor {
+    func toColor(colorScheme: ColorScheme) -> Color {
+        let colors = colorScheme == .dark
+            ? DeckTheme.darkCardColors
+            : DeckTheme.lightCardColors
+        
+        switch self {
+        case .tan:
+            return colors[0]
+        case .cyan:
+            return colors[1]
+        case .pink:
+            return colors[2]
+        case .orange:
+            return colors[3]
+        case .blue:
+            return colors[4]
+        }
+    }
+    
+    func toHighlightColor(colorScheme: ColorScheme) -> Color {
+        let colors = colorScheme == .dark
+            ? DeckTheme.darkCardHighlightColors
+            : DeckTheme.lightCardHighlightColors
+        
+        switch self {
+        case .tan:
+            return colors[0]
+        case .cyan:
+            return colors[1]
+        case .pink:
+            return colors[2]
+        case .orange:
+            return colors[3]
+        case .blue:
+            return colors[4]
+        }
+    }
+}
+
 private extension Hashable {
     private func colors(colorScheme: ColorScheme) -> [Color] {
         colorScheme == .dark
@@ -124,10 +172,10 @@ extension Slashlink {
 
 extension EntryStub {
     func color(colorScheme: ColorScheme) -> Color {
-        address.color(colorScheme: colorScheme)
+        self.color?.toColor(colorScheme: colorScheme) ?? .secondaryBackground
     }
     
     func highlightColor(colorScheme: ColorScheme) -> Color {
-        address.highlightColor(colorScheme: colorScheme)
+        self.color?.toHighlightColor(colorScheme: colorScheme) ?? .accentColor
     }
 }

--- a/xcode/Subconscious/Shared/Components/Deck/DeckTheme.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/DeckTheme.swift
@@ -55,12 +55,12 @@ extension DeckTheme {
     static let cardHeaderTint = Color.brandMarkPink.opacity(0.025)
 }
 
-public enum ThemeColor: String, Hashable, CaseIterable {
-    case a
-    case b
-    case c
-    case d
-    case e
+public enum ThemeColor: Int, Hashable, CaseIterable {
+    case a = 0
+    case b = 1
+    case c = 2
+    case d = 3
+    case e = 4
 }
 
 public extension Color {

--- a/xcode/Subconscious/Shared/Components/Deck/DeckTheme.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/DeckTheme.swift
@@ -63,34 +63,68 @@ public enum ThemeColor: String, Hashable, CaseIterable {
     case e
 }
 
+public extension Color {
+    static var cardThemeColorA: Color {
+        Color("CardThemeColorA")
+    }
+    static var cardThemeColorB: Color {
+        Color("CardThemeColorB")
+    }
+    static var cardThemeColorC: Color {
+        Color("CardThemeColorC")
+    }
+    static var cardThemeColorD: Color {
+        Color("CardThemeColorD")
+    }
+    static var cardThemeColorE: Color {
+        Color("CardThemeColorE")
+    }
+    
+    static var cardThemeHighlightColorA: Color {
+        Color("CardThemeHighlightColorA")
+    }
+    static var cardThemeHighlightColorB: Color {
+        Color("CardThemeHighlightColorB")
+    }
+    static var cardThemeHighlightColorC: Color {
+        Color("CardThemeHighlightColorC")
+    }
+    static var cardThemeHighlightColorD: Color {
+        Color("CardThemeHighlightColorD")
+    }
+    static var cardThemeHighlightColorE: Color {
+        Color("CardThemeHighlightColorE")
+    }
+}
+
 public extension ThemeColor {
     func toColor() -> Color {
         switch self {
         case .a:
-            return Color(.cardThemeColorA)
+            return .cardThemeColorA
         case .b:
-            return Color(.cardThemeColorB)
+            return .cardThemeColorB
         case .c:
-            return Color(.cardThemeColorC)
+            return .cardThemeColorC
         case .d:
-            return Color(.cardThemeColorD)
+            return .cardThemeColorD
         case .e:
-            return Color(.cardThemeColorE)
+            return .cardThemeColorE
         }
     }
     
     func toHighlightColor() -> Color {
         switch self {
         case .a:
-            return Color(.cardThemeHighlightColorA)
+            return .cardThemeHighlightColorA
         case .b:
-            return Color(.cardThemeHighlightColorB)
+            return .cardThemeHighlightColorB
         case .c:
-            return Color(.cardThemeHighlightColorC)
+            return .cardThemeHighlightColorC
         case .d:
-            return Color(.cardThemeHighlightColorD)
+            return .cardThemeHighlightColorD
         case .e:
-            return Color(.cardThemeHighlightColorE)
+            return .cardThemeHighlightColorE
         }
     }
 }

--- a/xcode/Subconscious/Shared/Components/Deck/DeckTheme.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/DeckTheme.swift
@@ -162,12 +162,12 @@ extension Slashlink {
 
 extension EntryStub {
     func color(colorScheme: ColorScheme) -> Color {
-        self.color?.toColor(colorScheme: colorScheme) 
+        self.headers.color?.toColor(colorScheme: colorScheme)
             ?? self.address.noteColor.toColor(colorScheme: colorScheme)
     }
     
     func highlightColor(colorScheme: ColorScheme) -> Color {
-        self.color?.toHighlightColor(colorScheme: colorScheme)
+        self.headers.color?.toHighlightColor(colorScheme: colorScheme)
             ?? self.address.noteColor.toHighlightColor(colorScheme: colorScheme)
     }
 }

--- a/xcode/Subconscious/Shared/Components/Deck/DeckTheme.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/DeckTheme.swift
@@ -52,122 +52,70 @@ extension DeckTheme {
         endPoint: UnitPoint(x: 0.5, y: 1)
     )
     
-    static let lightCardColors: [Color] = [
-        Color(red: 0.98, green: 0.96, blue: 0.94),
-        Color(red: 0.92, green: 0.98, blue: 0.97),
-        Color(red: 0.97, green: 0.93, blue: 0.97),
-        Color(red: 0.98, green: 0.92, blue: 0.94),
-        Color(red: 0.93, green: 0.94, blue: 0.97)
-    ]
-    
-    static let lightCardHighlightColors: [Color] = [
-        Color(red: 0.73, green: 0.62, blue: 0.45),
-        Color(red: 0.36, green: 0.71, blue: 0.66),
-        Color(red: 0.66, green: 0.41, blue: 0.64),
-        Color(red: 0.71, green: 0.36, blue: 0.45),
-        Color(red: 0.39, green: 0.48, blue: 0.66)
-    ]
-    
-    static let darkCardColors: [Color] = [
-        Color(red: 0.63, green: 0.58, blue: 0.5),
-        Color(red: 0.52, green: 0.56, blue: 0.58),
-        Color(red: 0.67, green: 0.45, blue: 0.59),
-        Color(red: 0.66, green: 0.44, blue: 0.48),
-        Color(red: 0.53, green: 0.47, blue: 0.63)
-    ]
-    
-    static let darkCardHighlightColors: [Color] = [
-        (Color(red: 1, green: 0.93, blue: 0.82)),
-        (Color(red: 0.88, green: 0.88, blue: 0.9)),
-        (Color(red: 1, green: 0.75, blue: 0.92)),
-        (Color(red: 1, green: 0.74, blue: 0.78)),
-        (Color(red: 0.89, green: 0.78, blue: 0.95))
-    ]
-    
     static let cardHeaderTint = Color.brandMarkPink.opacity(0.025)
 }
 
-public enum NoteColor: String, Hashable, CaseIterable {
-    case tan
-    case cyan
-    case pink
-    case orange
-    case blue
+public enum ThemeColor: String, Hashable, CaseIterable {
+    case a
+    case b
+    case c
+    case d
+    case e
 }
 
-public extension NoteColor {
-    func toColor(colorScheme: ColorScheme) -> Color {
-        let colors = colorScheme == .dark
-            ? DeckTheme.darkCardColors
-            : DeckTheme.lightCardColors
-        
+public extension ThemeColor {
+    func toColor() -> Color {
         switch self {
-        case .tan:
-            return colors[0]
-        case .cyan:
-            return colors[1]
-        case .pink:
-            return colors[2]
-        case .orange:
-            return colors[3]
-        case .blue:
-            return colors[4]
+        case .a:
+            return Color(.cardThemeColorA)
+        case .b:
+            return Color(.cardThemeColorB)
+        case .c:
+            return Color(.cardThemeColorC)
+        case .d:
+            return Color(.cardThemeColorD)
+        case .e:
+            return Color(.cardThemeColorE)
         }
     }
     
-    func toHighlightColor(colorScheme: ColorScheme) -> Color {
-        let colors = colorScheme == .dark
-            ? DeckTheme.darkCardHighlightColors
-            : DeckTheme.lightCardHighlightColors
-        
+    func toHighlightColor() -> Color {
         switch self {
-        case .tan:
-            return colors[0]
-        case .cyan:
-            return colors[1]
-        case .pink:
-            return colors[2]
-        case .orange:
-            return colors[3]
-        case .blue:
-            return colors[4]
+        case .a:
+            return Color(.cardThemeHighlightColorA)
+        case .b:
+            return Color(.cardThemeHighlightColorB)
+        case .c:
+            return Color(.cardThemeHighlightColorC)
+        case .d:
+            return Color(.cardThemeHighlightColorD)
+        case .e:
+            return Color(.cardThemeHighlightColorE)
         }
     }
 }
 
 private extension Hashable {
-    private func colors(colorScheme: ColorScheme) -> [Color] {
-        colorScheme == .dark
-            ? DeckTheme.darkCardColors
-            : DeckTheme.lightCardColors
-    }
-    
-    private func highlightColors(colorScheme: ColorScheme) -> [Color] {
-        colorScheme == .dark
-            ? DeckTheme.darkCardHighlightColors
-            : DeckTheme.lightCardHighlightColors
-    }
-    
-    var noteColor: NoteColor {
-        let colors = NoteColor.allCases
+    var themeColor: ThemeColor {
+        let colors = ThemeColor.allCases
         return colors[abs(self.hashValue) % colors.count]
     }
 }
 
 extension Slashlink {
-    var noteColor: NoteColor {
-        description.noteColor
+    var themeColor: ThemeColor {
+        description.themeColor
     }
 }
 
 extension EntryStub {
     func color(colorScheme: ColorScheme) -> Color {
-        self.headers.color?.toColor(colorScheme: colorScheme)
-            ?? self.address.noteColor.toColor(colorScheme: colorScheme)
+        self.headers.themeColor?.toColor()
+            ?? self.address.themeColor.toColor()
     }
     
     func highlightColor(colorScheme: ColorScheme) -> Color {
-        self.headers.color?.toHighlightColor(colorScheme: colorScheme)
-            ?? self.address.noteColor.toHighlightColor(colorScheme: colorScheme)
+        self.headers.themeColor?.toHighlightColor()
+            ?? self.address.themeColor.toHighlightColor()
     }
 }

--- a/xcode/Subconscious/Shared/Components/Deck/DeckView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/DeckView.swift
@@ -120,8 +120,8 @@ enum DeckAction: Hashable {
     case succeedMergeEntry(parent: Slashlink, child: Slashlink)
     case requestUpdateAudience(_ address: Slashlink, _ audience: Audience)
     case succeedUpdateAudience(_ receipt: MoveReceipt)
-    case requestAssignNoteColor(_ address: Slashlink, _ color: NoteColor)
-    case succeedAssignNoteColor(_ address: Slashlink, _ color: NoteColor)
+    case requestAssignNoteColor(_ address: Slashlink, _ color: ThemeColor)
+    case succeedAssignNoteColor(_ address: Slashlink, _ color: ThemeColor)
 }
 
 extension AppAction {

--- a/xcode/Subconscious/Shared/Components/Deck/DeckView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/DeckView.swift
@@ -138,7 +138,7 @@ extension AppAction {
         case let .requestUpdateAudience(address, audience):
             return .updateAudience(address: address, audience: audience)
         case let .requestAssignNoteColor(address, color):
-            return .assignColor(addess: address, color: color)
+            return .assignColor(address: address, color: color)
         default:
             return nil
         }

--- a/xcode/Subconscious/Shared/Components/Deck/ShuffleProgressView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/ShuffleProgressView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct CardShuffleView: View {
     @Environment (\.colorScheme) var colorScheme
-    @State private var cards = [0, 1, 2, 3, 4]
+    @State private var cards: [ThemeColor] = ThemeColor.allCases
     @State private var offset: CGFloat = 0
     @State private var behind: Bool = false
     
@@ -79,16 +79,12 @@ struct CardShuffleView: View {
         }
     }
 
-    private func colorForCard(card: Int) -> Color {
-        let colors = colorScheme == .dark
-            ? DeckTheme.darkCardColors
-            : DeckTheme.lightCardColors
-        
-        return colors[card]
+    private func colorForCard(card: ThemeColor) -> Color {
+        card.toColor()
     }
 
-    private func zIndexForCard(card: Int) -> Double {
-        return Double(cards.count) - Double((cards.firstIndex(of: card) ?? 0))
+    private func zIndexForCard(card: ThemeColor) -> Double {
+        Double(cards.count) - Double((cards.firstIndex(of: card) ?? 0))
     }
 }
 

--- a/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
@@ -149,6 +149,8 @@ enum DetailStackAction: Hashable {
     case succeedMergeEntry(parent: Slashlink, child: Slashlink)
     case requestUpdateAudience(_ address: Slashlink, _ audience: Audience)
     case succeedUpdateAudience(_ receipt: MoveReceipt)
+    case requestAssignNoteColor(_ address: Slashlink, _ color: NoteColor)
+    case succeedAssignNoteColor(_ address: Slashlink, _ color: NoteColor)
 
     /// Synonym for `.pushDetail` that wraps editor detail in `.editor()`
     static func pushDetail(
@@ -271,8 +273,15 @@ struct DetailStackModel: Hashable, ModelProtocol {
                 environment: environment,
                 receipt: receipt
             )
+        case let .succeedAssignNoteColor(address, color):
+            return succeedAssignNoteColor(
+                state: state,
+                environment: environment,
+                address: address,
+                color: color
+            )
         case .requestDeleteEntry, .requestSaveEntry, .requestMoveEntry,
-                .requestMergeEntry, .requestUpdateAudience:
+                .requestMergeEntry, .requestUpdateAudience, .requestAssignNoteColor:
             return Update(state: state)
         }
     }
@@ -587,6 +596,14 @@ struct DetailStackModel: Hashable, ModelProtocol {
         )
     }
 
+    static func succeedAssignNoteColor(
+        state: Self,
+        environment: Environment,
+        address: Slashlink,
+        color: NoteColor
+    ) -> Update<Self> {
+        return Update(state: state)
+    }
 }
 
 extension DetailStackAction {
@@ -602,19 +619,13 @@ extension DetailStackAction {
             return .requestMergeEntry(parent: parent, child: child)
         case let .requestUpdateAudience(address, audience):
             return .requestUpdateAudience(address, audience)
+        case let .requestAssignNoteColor(address, color):
+            return .requestAssignNoteColor(address, color)
             
         case let .requestDetail(detail):
             return .pushDetail(detail)
         case let .requestFindLinkDetail(link):
             return .findAndPushLinkDetail(link)
-        case let .succeedMoveEntry(from, to):
-            return .succeedMoveEntry(from: from, to: to)
-        case let .succeedMergeEntry(parent, child):
-            return .succeedMergeEntry(parent: parent, child: child)
-        case let .succeedSaveEntry(address, modified):
-            return .succeedSaveEntry(address, modified)
-        case let .succeedUpdateAudience(receipt):
-            return .succeedUpdateAudience(receipt)
         }
     }
 

--- a/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
@@ -140,8 +140,8 @@ enum DetailStackAction: Hashable {
     case succeedMergeEntry(parent: Slashlink, child: Slashlink)
     case requestUpdateAudience(_ address: Slashlink, _ audience: Audience)
     case succeedUpdateAudience(_ receipt: MoveReceipt)
-    case requestAssignNoteColor(_ address: Slashlink, _ color: NoteColor)
-    case succeedAssignNoteColor(_ address: Slashlink, _ color: NoteColor)
+    case requestAssignNoteColor(_ address: Slashlink, _ color: ThemeColor)
+    case succeedAssignNoteColor(_ address: Slashlink, _ color: ThemeColor)
 
     /// Synonym for `.pushDetail` that wraps editor detail in `.editor()`
     static func pushDetail(
@@ -591,7 +591,7 @@ struct DetailStackModel: Hashable, ModelProtocol {
         state: Self,
         environment: Environment,
         address: Slashlink,
-        color: NoteColor
+        color: ThemeColor
     ) -> Update<Self> {
         return Update(state: state)
     }

--- a/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
@@ -59,13 +59,13 @@ struct DetailStackView<Root: View>: View {
         }
         // Tint using the current detail's highlight color.
         // BUT only for notes.
-        .tint(
-            (store.state.details.last?.address?.isProfile ?? false)
-                ? nil
-                : store.state.details.last?.address?.highlightColor(
-                    colorScheme: colorScheme
-                )
-        )
+//        .tint(
+//            (store.state.details.last?.address?.isProfile ?? false)
+//                ? nil
+//                : store.state.details.last?.address?.highlightColor(
+//                    colorScheme: colorScheme
+//                )
+//        )
     }
 }
 

--- a/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
@@ -57,15 +57,6 @@ struct DetailStackView<Root: View>: View {
                 }
             }
         }
-        // Tint using the current detail's highlight color.
-        // BUT only for notes.
-//        .tint(
-//            (store.state.details.last?.address?.isProfile ?? false)
-//                ? nil
-//                : store.state.details.last?.address?.highlightColor(
-//                    colorScheme: colorScheme
-//                )
-//        )
     }
 }
 

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -210,9 +210,9 @@ struct MemoEditorDetailView: View {
                         .insets(
                             EdgeInsets(
                                 top: AppTheme.padding,
-                                leading: AppTheme.padding,
-                                bottom: AppTheme.padding,
-                                trailing: AppTheme.padding
+                                leading: DeckTheme.cardPadding,
+                                bottom: DeckTheme.cardPadding,
+                                trailing: DeckTheme.cardPadding
                             )
                         )
                         .frame(
@@ -221,10 +221,19 @@ struct MemoEditorDetailView: View {
                         .background(store.state.color?.toColor(colorScheme: colorScheme))
                         .foregroundStyle(.primary.opacity(0.8))
                         .accentColor(store.state.color?.toHighlightColor(colorScheme: colorScheme))
+                        .cornerRadius(DeckTheme.cornerRadius, corners: [.bottomLeft, .bottomRight])
+                        .padding(
+                            EdgeInsets(
+                                top: 0,
+                                leading: 0,
+                                bottom: AppTheme.padding,
+                                trailing: 0
+                            )
+                        )
                         
                         
-                        ThickDividerView()
-                            .padding(.bottom, AppTheme.unit4)
+//                        ThickDividerView()
+//                            .padding(.bottom, AppTheme.unit4)
                         BacklinksView(
                             backlinks: store.state.backlinks,
                             onLink: { link in

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -48,7 +48,6 @@ struct MemoEditorDetailView: View {
     /// Is this view presented? Used to detect when back button is pressed.
     /// We trigger an autosave when isPresented is false below.
     @Environment(\.isPresented) var isPresented
-    @Environment(\.colorScheme) var colorScheme
     @Environment(\.scenePhase) private var scenePhase: ScenePhase
     /// Initialization state passed down from parent
     var description: MemoEditorDetailDescription
@@ -195,7 +194,7 @@ struct MemoEditorDetailView: View {
     }
     
     var highlight: Color? {
-        store.state.color?.toHighlightColor()
+        store.state.themeColor?.toHighlightColor()
     }
 
     /// Constructs a plain text editor for the view
@@ -624,11 +623,10 @@ struct MemoEditorDetailModel: ModelProtocol {
         modified: Date.distantPast,
         fileExtension: ContentType.subtext.fileExtension
     )
-    var color: ThemeColor? = nil
+    var themeColor: ThemeColor? = nil
     
     /// Additional headers that are not well-known headers.
     var additionalHeaders: Headers = []
-                            
     var backlinks: [EntryStub] = []
     
     /// Is editor saved?
@@ -1311,7 +1309,7 @@ struct MemoEditorDetailModel: ModelProtocol {
         model.address = detail.entry.address
         model.defaultAudience = detail.entry.address.toAudience()
         model.headers = detail.entry.contents.wellKnownHeaders()
-        model.color = model.headers.themeColor
+        model.themeColor = model.headers.themeColor
         model.additionalHeaders = detail.entry.contents.additionalHeaders
         model.saveState = detail.saveState
         
@@ -1322,7 +1320,7 @@ struct MemoEditorDetailModel: ModelProtocol {
             state: model,
             actions: [
                 .setMetaSheetAddress(model.address),
-                .setMetaSheetColor(model.color),
+                .setMetaSheetColor(model.themeColor),
                 .setEditor(
                     text: text,
                     saveState: detail.saveState,
@@ -1975,7 +1973,7 @@ struct MemoEditorDetailModel: ModelProtocol {
         }
         
         var model = state
-        model.color = color
+        model.themeColor = color
             
         return update(
             state: model,

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -493,6 +493,10 @@ enum MemoEditorDetailAction: Hashable {
     static func setMetaSheetAddress(_ address: Slashlink?) -> Self {
         .metaSheet(.setAddress(address))
     }
+    
+    static func setMetaSheetDefaultColor(_ color: NoteColor?) -> Self {
+        .metaSheet(.setDefaultNoteColor(color))
+    }
 
     static func setMetaSheetDefaultAudience(_ audience: Audience) -> Self {
         .metaSheet(.setDefaultAudience(audience))
@@ -1312,6 +1316,7 @@ struct MemoEditorDetailModel: ModelProtocol {
             state: model,
             actions: [
                 .setMetaSheetAddress(model.address),
+                .setMetaSheetDefaultColor(model.color),
                 .setEditor(
                     text: text,
                     saveState: detail.saveState,

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -217,7 +217,6 @@ struct MemoEditorDetailView: View {
                         .frame(
                             minHeight: UIFont.appTextMono.lineHeight * 8
                         )
-                        
                         ThickDividerView()
                             .padding(.bottom, AppTheme.unit4)
                         BacklinksView(

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -480,7 +480,7 @@ enum MemoEditorDetailAction: Hashable {
     }
     
     static func setMetaSheetDefaultColor(_ color: NoteColor?) -> Self {
-        .metaSheet(.setDefaultNoteColor(color))
+        .metaSheet(.setNoteColor(color))
     }
 
     static func setMetaSheetDefaultAudience(_ audience: Audience) -> Self {

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -48,7 +48,6 @@ struct MemoEditorDetailView: View {
     /// Is this view presented? Used to detect when back button is pressed.
     /// We trigger an autosave when isPresented is false below.
     @Environment(\.isPresented) var isPresented
-    @Environment(\.colorScheme) var colorScheme
     @Environment(\.scenePhase) private var scenePhase: ScenePhase
     /// Initialization state passed down from parent
     var description: MemoEditorDetailDescription
@@ -210,30 +209,17 @@ struct MemoEditorDetailView: View {
                         .insets(
                             EdgeInsets(
                                 top: AppTheme.padding,
-                                leading: DeckTheme.cardPadding,
-                                bottom: DeckTheme.cardPadding,
-                                trailing: DeckTheme.cardPadding
+                                leading: AppTheme.padding,
+                                bottom: AppTheme.padding,
+                                trailing: AppTheme.padding
                             )
                         )
                         .frame(
                             minHeight: UIFont.appTextMono.lineHeight * 8
                         )
-                        .background(store.state.color?.toColor(colorScheme: colorScheme))
-                        .foregroundStyle(.primary.opacity(0.8))
-                        .accentColor(store.state.color?.toHighlightColor(colorScheme: colorScheme))
-                        .cornerRadius(DeckTheme.cornerRadius, corners: [.bottomLeft, .bottomRight])
-                        .padding(
-                            EdgeInsets(
-                                top: 0,
-                                leading: 0,
-                                bottom: AppTheme.padding,
-                                trailing: 0
-                            )
-                        )
                         
-                        
-//                        ThickDividerView()
-//                            .padding(.bottom, AppTheme.unit4)
+                        ThickDividerView()
+                            .padding(.bottom, AppTheme.unit4)
                         BacklinksView(
                             backlinks: store.state.backlinks,
                             onLink: { link in

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -48,6 +48,7 @@ struct MemoEditorDetailView: View {
     /// Is this view presented? Used to detect when back button is pressed.
     /// We trigger an autosave when isPresented is false below.
     @Environment(\.isPresented) var isPresented
+    @Environment(\.colorScheme) var colorScheme
     @Environment(\.scenePhase) private var scenePhase: ScenePhase
     /// Initialization state passed down from parent
     var description: MemoEditorDetailDescription
@@ -217,6 +218,11 @@ struct MemoEditorDetailView: View {
                         .frame(
                             minHeight: UIFont.appTextMono.lineHeight * 8
                         )
+                        .background(store.state.color?.toColor(colorScheme: colorScheme))
+                        .foregroundStyle(.primary.opacity(0.8))
+                        .accentColor(store.state.color?.toHighlightColor(colorScheme: colorScheme))
+                        
+                        
                         ThickDividerView()
                             .padding(.bottom, AppTheme.unit4)
                         BacklinksView(
@@ -612,6 +618,11 @@ struct MemoEditorDetailModel: ModelProtocol {
     )
     /// Additional headers that are not well-known headers.
     var additionalHeaders: Headers = []
+    var color: NoteColor? {
+        NoteColor(rawValue: additionalHeaders.get(first: "Color") ?? "")
+            ?? address?.noteColor
+    }
+                            
     var backlinks: [EntryStub] = []
     
     /// Is editor saved?

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -617,12 +617,11 @@ struct MemoEditorDetailModel: ModelProtocol {
         modified: Date.distantPast,
         fileExtension: ContentType.subtext.fileExtension
     )
+    var color: NoteColor? {
+        headers.color
+    }
     /// Additional headers that are not well-known headers.
     var additionalHeaders: Headers = []
-    var color: NoteColor? {
-        NoteColor(rawValue: additionalHeaders.get(first: "Color") ?? "")
-            ?? address?.noteColor
-    }
                             
     var backlinks: [EntryStub] = []
     
@@ -2096,6 +2095,7 @@ extension MemoEntry {
             created: detail.headers.created,
             modified: detail.headers.modified,
             fileExtension: detail.headers.fileExtension,
+            color: detail.headers.color,
             additionalHeaders: detail.additionalHeaders,
             body: detail.editor.text
         )

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -478,7 +478,7 @@ enum MemoEditorDetailAction: Hashable {
         .metaSheet(.setAddress(address))
     }
     
-    static func setMetaSheetDefaultColor(_ color: NoteColor?) -> Self {
+    static func setMetaSheetColor(_ color: NoteColor?) -> Self {
         .metaSheet(.setNoteColor(color))
     }
 
@@ -1316,7 +1316,7 @@ struct MemoEditorDetailModel: ModelProtocol {
             state: model,
             actions: [
                 .setMetaSheetAddress(model.address),
-                .setMetaSheetDefaultColor(model.color),
+                .setMetaSheetColor(model.color),
                 .setEditor(
                     text: text,
                     saveState: detail.saveState,
@@ -1963,6 +1963,7 @@ struct MemoEditorDetailModel: ModelProtocol {
             return Update(state: state)
         }
         
+        // Only forward the event if the address matches
         guard state.address == address else {
             return Update(state: state)
         }

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -195,9 +195,7 @@ struct MemoEditorDetailView: View {
     }
     
     var highlight: Color? {
-        store.state.color?.toHighlightColor(
-            colorScheme: colorScheme
-        )
+        store.state.color?.toHighlightColor()
     }
 
     /// Constructs a plain text editor for the view
@@ -296,7 +294,7 @@ enum MemoEditorDetailNotification: Hashable {
     case requestMoveEntry(from: Slashlink, to: Slashlink)
     case requestMergeEntry(parent: Slashlink, child: Slashlink)
     case requestUpdateAudience(address: Slashlink, audience: Audience)
-    case requestAssignNoteColor(_ address: Slashlink, _ color: NoteColor)
+    case requestAssignNoteColor(_ address: Slashlink, _ color: ThemeColor)
 }
 
 extension MemoEditorDetailNotification {
@@ -430,9 +428,9 @@ enum MemoEditorDetailAction: Hashable {
     case requestUpdateAudience(_ audience: Audience)
     case forwardRequestUpdateAudience(address: Slashlink, _ audience: Audience)
     case succeedUpdateAudience(_ receipt: MoveReceipt)
-    case requestAssignNoteColor(_ color: NoteColor)
-    case forwardRequestAssignNoteColor(address: Slashlink, _ color: NoteColor)
-    case succeedAssignNoteColor(_ address: Slashlink, _ color: NoteColor)
+    case requestAssignNoteColor(_ color: ThemeColor)
+    case forwardRequestAssignNoteColor(address: Slashlink, _ color: ThemeColor)
+    case succeedAssignNoteColor(_ address: Slashlink, _ color: ThemeColor)
     
 
     // Editor
@@ -487,7 +485,7 @@ enum MemoEditorDetailAction: Hashable {
         .metaSheet(.setAddress(address))
     }
     
-    static func setMetaSheetColor(_ color: NoteColor?) -> Self {
+    static func setMetaSheetColor(_ color: ThemeColor?) -> Self {
         .metaSheet(.setNoteColor(color))
     }
 
@@ -626,7 +624,7 @@ struct MemoEditorDetailModel: ModelProtocol {
         modified: Date.distantPast,
         fileExtension: ContentType.subtext.fileExtension
     )
-    var color: NoteColor? = nil
+    var color: ThemeColor? = nil
     
     /// Additional headers that are not well-known headers.
     var additionalHeaders: Headers = []
@@ -1313,7 +1311,7 @@ struct MemoEditorDetailModel: ModelProtocol {
         model.address = detail.entry.address
         model.defaultAudience = detail.entry.address.toAudience()
         model.headers = detail.entry.contents.wellKnownHeaders()
-        model.color = model.headers.color
+        model.color = model.headers.themeColor
         model.additionalHeaders = detail.entry.contents.additionalHeaders
         model.saveState = detail.saveState
         
@@ -1938,7 +1936,7 @@ struct MemoEditorDetailModel: ModelProtocol {
     static func requestAssignNoteColor(
         state: MemoEditorDetailModel,
         environment: AppEnvironment,
-        color: NoteColor
+        color: ThemeColor
     ) -> Update<MemoEditorDetailModel> {
         guard let address = state.address else {
             return Update(state: state)
@@ -1965,7 +1963,7 @@ struct MemoEditorDetailModel: ModelProtocol {
         state: MemoEditorDetailModel,
         environment: AppEnvironment,
         address: Slashlink,
-        color: NoteColor
+        color: ThemeColor
     ) -> Update<MemoEditorDetailModel> {
         guard state.address != nil else {
             return Update(state: state)
@@ -2107,7 +2105,7 @@ extension MemoEntry {
             created: detail.headers.created,
             modified: detail.headers.modified,
             fileExtension: detail.headers.fileExtension,
-            color: detail.headers.color,
+            themeColor: detail.headers.themeColor,
             additionalHeaders: detail.additionalHeaders,
             body: detail.editor.text
         )

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetailMetaSheetView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetailMetaSheetView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import ObservableStore
-import Combine
 
 struct MemoEditorDetailMetaSheetView: View {
     @Environment(\.dismiss) private var dismiss

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetailMetaSheetView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetailMetaSheetView.swift
@@ -88,8 +88,10 @@ struct MemoEditorDetailMetaSheetView: View {
                                     .fill(color.toColor(colorScheme: colorScheme))
                                 Circle()
                                     .stroke(Color.separator)
-                                Image(systemName: "checkmark")
-                                    .foregroundColor(.secondary)
+                                if color == store.state.defaultColor {
+                                    Image(systemName: "checkmark")
+                                        .foregroundColor(.secondary)
+                                }
                             }
                             .frame(width: 32, height: 32)
                         }
@@ -140,11 +142,13 @@ enum MemoEditorDetailMetaSheetAction: Hashable {
     case selectRenameSuggestion(RenameSuggestion)
     case setAddress(_ address: Slashlink?)
     case setDefaultAudience(_ audience: Audience)
+    
     /// Requests that audience be updated.
     /// Should be handled by parent component.
     case requestUpdateAudience(_ audience: Audience)
     case succeedUpdateAudience(_ receipt: MoveReceipt)
     
+    case setDefaultNoteColor(_ color: NoteColor?)
     case requestAssignNoteColor(_ color: NoteColor?)
     case failAssignNoteColor
     case succeedAssignNoteColor
@@ -170,6 +174,7 @@ struct MemoEditorDetailMetaSheetModel: ModelProtocol {
     typealias Environment = AppEnvironment
     
     var address: Slashlink?
+    var defaultColor: NoteColor?
     var defaultAudience = Audience.local
     var audience: Audience {
         address?.toAudience() ?? defaultAudience
@@ -241,6 +246,12 @@ struct MemoEditorDetailMetaSheetModel: ModelProtocol {
             )
         case .requestDelete:
             return Update(state: state)
+        case let .setDefaultNoteColor(color):
+            return setDefaultNoteColor(
+                state: state,
+                environment: environment,
+                color: color
+            )
         case .requestAssignNoteColor(let color):
             return requestAssignNoteColor(state: state, environment: environment, color: color)
         case .failAssignNoteColor:
@@ -309,6 +320,17 @@ struct MemoEditorDetailMetaSheetModel: ModelProtocol {
     ) -> Update<Self> {
         var model = state
         model.defaultAudience = audience
+        return Update(state: model)
+    }
+    
+    static func setDefaultNoteColor(
+        state: Self,
+        environment: Environment,
+        color: NoteColor?
+    ) -> Update<Self> {
+        var model = state
+        model.defaultColor = color
+        
         return Update(state: model)
     }
     

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetailMetaSheetView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetailMetaSheetView.swift
@@ -10,7 +10,6 @@ import ObservableStore
 
 struct MemoEditorDetailMetaSheetView: View {
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.colorScheme) private var colorScheme
     var store: ViewStore<MemoEditorDetailMetaSheetModel>
     
     var body: some View {
@@ -87,7 +86,7 @@ struct MemoEditorDetailMetaSheetView: View {
                                     .fill(themeColor.toColor())
                                 Circle()
                                     .stroke(Color.separator)
-                                if themeColor == store.state.color {
+                                if themeColor == store.state.themeColor {
                                     Image(systemName: "checkmark")
                                         .foregroundColor(.secondary)
                                 }
@@ -172,7 +171,7 @@ struct MemoEditorDetailMetaSheetModel: ModelProtocol {
     typealias Environment = AppEnvironment
     
     var address: Slashlink?
-    var color: ThemeColor?
+    var themeColor: ThemeColor?
     var defaultAudience = Audience.local
     var audience: Audience {
         address?.toAudience() ?? defaultAudience
@@ -332,7 +331,7 @@ struct MemoEditorDetailMetaSheetModel: ModelProtocol {
         color: ThemeColor?
     ) -> Update<Self> {
         var model = state
-        model.color = color
+        model.themeColor = color
         
         return Update(state: model)
     }

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetailMetaSheetView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetailMetaSheetView.swift
@@ -88,7 +88,7 @@ struct MemoEditorDetailMetaSheetView: View {
                                     .fill(color.toColor(colorScheme: colorScheme))
                                 Circle()
                                     .stroke(Color.separator)
-                                if color == store.state.defaultColor {
+                                if color == store.state.color {
                                     Image(systemName: "checkmark")
                                         .foregroundColor(.secondary)
                                 }
@@ -148,7 +148,7 @@ enum MemoEditorDetailMetaSheetAction: Hashable {
     case requestUpdateAudience(_ audience: Audience)
     case succeedUpdateAudience(_ receipt: MoveReceipt)
     
-    case setDefaultNoteColor(_ color: NoteColor?)
+    case setNoteColor(_ color: NoteColor?)
     case requestAssignNoteColor(_ color: NoteColor)
     case succeedAssignNoteColor(_ color: NoteColor)
     
@@ -173,7 +173,7 @@ struct MemoEditorDetailMetaSheetModel: ModelProtocol {
     typealias Environment = AppEnvironment
     
     var address: Slashlink?
-    var defaultColor: NoteColor?
+    var color: NoteColor?
     var defaultAudience = Audience.local
     var audience: Audience {
         address?.toAudience() ?? defaultAudience
@@ -245,19 +245,23 @@ struct MemoEditorDetailMetaSheetModel: ModelProtocol {
             )
         case .requestDelete:
             return Update(state: state)
-        case let .setDefaultNoteColor(color):
-            return setDefaultNoteColor(
+        
+        // Editor passes us the current color when the sheet is opened
+        case let .setNoteColor(color):
+            return setNoteColor(
                 state: state,
                 environment: environment,
                 color: color
             )
         case .requestAssignNoteColor:
             return Update(state: state)
+        // Update internal color to match the updated value
         case let .succeedAssignNoteColor(color):
-            var model = state
-            model.defaultColor = color
-            
-            return Update(state: model)
+            return setNoteColor(
+                state: state,
+                environment: environment,
+                color: color
+            )
         }
     }
     
@@ -323,13 +327,13 @@ struct MemoEditorDetailMetaSheetModel: ModelProtocol {
         return Update(state: model)
     }
     
-    static func setDefaultNoteColor(
+    static func setNoteColor(
         state: Self,
         environment: Environment,
         color: NoteColor?
     ) -> Update<Self> {
         var model = state
-        model.defaultColor = color
+        model.color = color
         
         return Update(state: model)
     }

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetailMetaSheetView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetailMetaSheetView.swift
@@ -74,20 +74,20 @@ struct MemoEditorDetailMetaSheetView: View {
                 .padding()
                 
                 HStack(spacing: AppTheme.padding) {
-                    let colors = NoteColor.allCases
+                    let themeColors = ThemeColor.allCases
                     
-                    ForEach(colors, id: \.self) { color in
+                    ForEach(themeColors, id: \.self) { themeColor in
                         Button(
                             action: {
-                                store.send(.requestAssignNoteColor(color))
+                                store.send(.requestAssignNoteColor(themeColor))
                             }
                         ) {
                             ZStack {
                                 Circle()
-                                    .fill(color.toColor(colorScheme: colorScheme))
+                                    .fill(themeColor.toColor())
                                 Circle()
                                     .stroke(Color.separator)
-                                if color == store.state.color {
+                                if themeColor == store.state.color {
                                     Image(systemName: "checkmark")
                                         .foregroundColor(.secondary)
                                 }
@@ -147,9 +147,9 @@ enum MemoEditorDetailMetaSheetAction: Hashable {
     case requestUpdateAudience(_ audience: Audience)
     case succeedUpdateAudience(_ receipt: MoveReceipt)
     
-    case setNoteColor(_ color: NoteColor?)
-    case requestAssignNoteColor(_ color: NoteColor)
-    case succeedAssignNoteColor(_ color: NoteColor)
+    case setNoteColor(_ color: ThemeColor?)
+    case requestAssignNoteColor(_ color: ThemeColor)
+    case succeedAssignNoteColor(_ color: ThemeColor)
     
     //  Delete entry requests
     /// Show/hide delete confirmation dialog
@@ -172,7 +172,7 @@ struct MemoEditorDetailMetaSheetModel: ModelProtocol {
     typealias Environment = AppEnvironment
     
     var address: Slashlink?
-    var color: NoteColor?
+    var color: ThemeColor?
     var defaultAudience = Audience.local
     var audience: Audience {
         address?.toAudience() ?? defaultAudience
@@ -329,7 +329,7 @@ struct MemoEditorDetailMetaSheetModel: ModelProtocol {
     static func setNoteColor(
         state: Self,
         environment: Environment,
-        color: NoteColor?
+        color: ThemeColor?
     ) -> Update<Self> {
         var model = state
         model.color = color

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -153,30 +153,12 @@ struct MemoViewerDetailLoadedView: View {
                         
                         Spacer()
                     }
-                    .padding(
-                        EdgeInsets(
-                            top: AppTheme.padding,
-                            leading: DeckTheme.cardPadding,
-                            bottom: DeckTheme.cardPadding,
-                            trailing: DeckTheme.cardPadding
-                        )
-                    )
+                    .padding()
                     .frame(
                         minHeight: UIFont.appTextMono.lineHeight * 8
                     )
-                    .background(store.state.color?.toColor(colorScheme: colorScheme))
-                    .foregroundStyle(.primary.opacity(0.8))
-                    .accentColor(store.state.color?.toHighlightColor(colorScheme: colorScheme))
-                    .cornerRadius(DeckTheme.cornerRadius, corners: [.bottomLeft, .bottomRight])
-                    .padding(
-                        EdgeInsets(
-                            top: 0,
-                            leading: 0,
-                            bottom: AppTheme.padding,
-                            trailing: 0
-                        )
-                    )
-                    
+                    ThickDividerView()
+                        .padding(.bottom, AppTheme.unit4)
                     BacklinksView(
                         backlinks: store.state.backlinks,
                         onLink: { link in
@@ -286,12 +268,6 @@ struct MemoViewerDetailModel: ModelProtocol {
     var address: Slashlink?
     var defaultAudience = Audience.local
     var title = ""
-    /// Additional headers that are not well-known headers.
-    var additionalHeaders: Headers = []
-    var color: NoteColor? {
-        NoteColor(rawValue: additionalHeaders.get(first: "Color") ?? "")
-            ?? address?.noteColor
-    }
     var dom: Subtext = Subtext.empty
     var backlinks: [EntryStub] = []
     
@@ -475,7 +451,6 @@ struct MemoViewerDetailModel: ModelProtocol {
         let memo = entry.contents
         model.address = entry.address
         model.title = memo.title()
-        model.additionalHeaders = memo.additionalHeaders
         
         let dom = memo.dom()
         

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -125,7 +125,6 @@ struct MemoViewerDetailLoadingView: View {
 }
 
 struct MemoViewerDetailLoadedView: View {
-    @Environment(\.colorScheme) var colorScheme
     @ObservedObject var store: Store<MemoViewerDetailModel>
     var address: Slashlink
     var notify: (MemoViewerDetailNotification) -> Void

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -644,7 +644,6 @@ struct MemoViewerDetailView_Previews: PreviewProvider {
                             excerpt: Subtext(
                                 markup: "Say not, \"I have discovered the soul's destination,\" but rather, \"I have glimpsed the soul's journey, ever unfolding along the way.\""
                             ),
-                            modified: Date.now,
                             headers: .emptySubtext
                         )
                     ]
@@ -665,7 +664,6 @@ struct MemoViewerDetailView_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "The hidden well-spring of your soul must needs rise and run murmuring to the sea; And the treasure of your infinite depths would be revealed to your eyes. But let there be no scales to weigh your unknown treasure; And seek not the depths of your knowledge with staff or sounding line. For self is a sea boundless and measureless."
                     ),
-                    modified: Date.now,
                     headers: .emptySubtext
                 ),
                 EntryStub(
@@ -676,7 +674,6 @@ struct MemoViewerDetailView_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "Think you the spirit is a still pool which you can trouble with a staff? Oftentimes in denying yourself pleasure you do but store the desire in the recesses of your being. Who knows but that which seems omitted today, waits for tomorrow?"
                     ),
-                    modified: Date.now,
                     headers: .emptySubtext
                 )
             ],

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -644,7 +644,8 @@ struct MemoViewerDetailView_Previews: PreviewProvider {
                             excerpt: Subtext(
                                 markup: "Say not, \"I have discovered the soul's destination,\" but rather, \"I have glimpsed the soul's journey, ever unfolding along the way.\""
                             ),
-                            modified: Date.now
+                            modified: Date.now,
+                            headers: .emptySubtext
                         )
                     ]
                 ),
@@ -664,7 +665,8 @@ struct MemoViewerDetailView_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "The hidden well-spring of your soul must needs rise and run murmuring to the sea; And the treasure of your infinite depths would be revealed to your eyes. But let there be no scales to weigh your unknown treasure; And seek not the depths of your knowledge with staff or sounding line. For self is a sea boundless and measureless."
                     ),
-                    modified: Date.now
+                    modified: Date.now,
+                    headers: .emptySubtext
                 ),
                 EntryStub(
                     did: Did.dummyData(),
@@ -674,7 +676,8 @@ struct MemoViewerDetailView_Previews: PreviewProvider {
                     excerpt: Subtext(
                         markup: "Think you the spirit is a still pool which you can trouble with a staff? Oftentimes in denying yourself pleasure you do but store the desire in the recesses of your being. Who knows but that which seems omitted today, waits for tomorrow?"
                     ),
-                    modified: Date.now
+                    modified: Date.now,
+                    headers: .emptySubtext
                 )
             ],
             notify: {

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -125,6 +125,7 @@ struct MemoViewerDetailLoadingView: View {
 }
 
 struct MemoViewerDetailLoadedView: View {
+    @Environment(\.colorScheme) var colorScheme
     @ObservedObject var store: Store<MemoViewerDetailModel>
     var address: Slashlink
     var notify: (MemoViewerDetailNotification) -> Void
@@ -152,12 +153,30 @@ struct MemoViewerDetailLoadedView: View {
                         
                         Spacer()
                     }
-                    .padding()
+                    .padding(
+                        EdgeInsets(
+                            top: AppTheme.padding,
+                            leading: DeckTheme.cardPadding,
+                            bottom: DeckTheme.cardPadding,
+                            trailing: DeckTheme.cardPadding
+                        )
+                    )
                     .frame(
                         minHeight: UIFont.appTextMono.lineHeight * 8
                     )
-                    ThickDividerView()
-                        .padding(.bottom, AppTheme.unit4)
+                    .background(store.state.color?.toColor(colorScheme: colorScheme))
+                    .foregroundStyle(.primary.opacity(0.8))
+                    .accentColor(store.state.color?.toHighlightColor(colorScheme: colorScheme))
+                    .cornerRadius(DeckTheme.cornerRadius, corners: [.bottomLeft, .bottomRight])
+                    .padding(
+                        EdgeInsets(
+                            top: 0,
+                            leading: 0,
+                            bottom: AppTheme.padding,
+                            trailing: 0
+                        )
+                    )
+                    
                     BacklinksView(
                         backlinks: store.state.backlinks,
                         onLink: { link in
@@ -267,6 +286,12 @@ struct MemoViewerDetailModel: ModelProtocol {
     var address: Slashlink?
     var defaultAudience = Audience.local
     var title = ""
+    /// Additional headers that are not well-known headers.
+    var additionalHeaders: Headers = []
+    var color: NoteColor? {
+        NoteColor(rawValue: additionalHeaders.get(first: "Color") ?? "")
+            ?? address?.noteColor
+    }
     var dom: Subtext = Subtext.empty
     var backlinks: [EntryStub] = []
     
@@ -450,6 +475,7 @@ struct MemoViewerDetailModel: ModelProtocol {
         let memo = entry.contents
         model.address = entry.address
         model.title = memo.title()
+        model.additionalHeaders = memo.additionalHeaders
         
         let dom = memo.dom()
         

--- a/xcode/Subconscious/Shared/Components/HomeProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/HomeProfileView.swift
@@ -150,6 +150,8 @@ enum HomeProfileAction: Hashable {
     case succeedMergeEntry(parent: Slashlink, child: Slashlink)
     case requestUpdateAudience(_ address: Slashlink, _ audience: Audience)
     case succeedUpdateAudience(_ receipt: MoveReceipt)
+    case requestAssignNoteColor(_ address: Slashlink, _ color: NoteColor)
+    case succeedAssignNoteColor(_ address: Slashlink, _ color: NoteColor)
 }
 
 // MARK: Cursors and tagging functions
@@ -179,6 +181,8 @@ struct HomeProfileDetailStackCursor: CursorProtocol {
             return .requestMergeEntry(parent: parent, child: child)
         case let .requestUpdateAudience(address, audience):
             return .requestUpdateAudience(address, audience)
+        case let .requestAssignNoteColor(address, color):
+            return .requestAssignNoteColor(address, color)
         default:
             return .detailStack(action)
         }
@@ -202,6 +206,8 @@ extension HomeProfileAction {
             return .succeedMoveEntry(from: from, to: to)
         case let .succeedUpdateAudience(receipt):
             return .succeedUpdateAudience(receipt)
+        case let .succeedAssignNoteColor(address, color):
+            return .succeedAssignNoteColor(address, color)
         default:
             return nil
         }
@@ -221,6 +227,8 @@ extension AppAction {
             return .mergeEntry(parent: parent, child: child)
         case let .requestUpdateAudience(address, audience):
             return .updateAudience(address: address, audience: audience)
+        case let .requestAssignNoteColor(address, color):
+            return .assignColor(addess: address, color: color)
         default:
             return nil
         }
@@ -354,8 +362,18 @@ struct HomeProfileModel: ModelProtocol {
                 ],
                 environment: environment
             )
+        case let .succeedAssignNoteColor(address, color):
+            return update(
+                state: state,
+                actions: [
+                    .detailStack(.succeedAssignNoteColor(address, color)),
+                    .appear
+                ],
+                environment: environment
+            )
         case .requestDeleteEntry, .requestSaveEntry, .requestMoveEntry,
-                .requestMergeEntry, .requestUpdateAudience, .requestScrollToTop:
+                .requestMergeEntry, .requestUpdateAudience, .requestScrollToTop,
+                .requestAssignNoteColor:
             return Update(state: state)
         }
     }

--- a/xcode/Subconscious/Shared/Components/HomeProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/HomeProfileView.swift
@@ -150,8 +150,8 @@ enum HomeProfileAction: Hashable {
     case succeedMergeEntry(parent: Slashlink, child: Slashlink)
     case requestUpdateAudience(_ address: Slashlink, _ audience: Audience)
     case succeedUpdateAudience(_ receipt: MoveReceipt)
-    case requestAssignNoteColor(_ address: Slashlink, _ color: NoteColor)
-    case succeedAssignNoteColor(_ address: Slashlink, _ color: NoteColor)
+    case requestAssignNoteColor(_ address: Slashlink, _ color: ThemeColor)
+    case succeedAssignNoteColor(_ address: Slashlink, _ color: ThemeColor)
 }
 
 // MARK: Cursors and tagging functions

--- a/xcode/Subconscious/Shared/Components/HomeProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/HomeProfileView.swift
@@ -228,7 +228,7 @@ extension AppAction {
         case let .requestUpdateAudience(address, audience):
             return .updateAudience(address: address, audience: audience)
         case let .requestAssignNoteColor(address, color):
-            return .assignColor(addess: address, color: color)
+            return .assignColor(address: address, color: color)
         default:
             return nil
         }

--- a/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
@@ -291,7 +291,7 @@ extension AppAction {
         case let .requestUpdateAudience(address, audience):
             return .updateAudience(address: address, audience: audience)
         case let .requestAssignNoteColor(address, color):
-            return .assignColor(addess: address, color: color)
+            return .assignColor(address: address, color: color)
         default:
             return nil
         }

--- a/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
@@ -155,6 +155,8 @@ enum NotebookAction: Hashable {
     case succeedMergeEntry(parent: Slashlink, child: Slashlink)
     case requestUpdateAudience(_ address: Slashlink, _ audience: Audience)
     case succeedUpdateAudience(_ receipt: MoveReceipt)
+    case requestAssignNoteColor(_ address: Slashlink, _ color: NoteColor)
+    case succeedAssignNoteColor(_ address: Slashlink, _ color: NoteColor)
     
     //  Search
     /// Hit submit ("go") while focused on search field
@@ -233,6 +235,8 @@ struct NotebookDetailStackCursor: CursorProtocol {
             return .requestMergeEntry(parent: parent, child: child)
         case let .requestUpdateAudience(address, audience):
             return .requestUpdateAudience(address, audience)
+        case let .requestAssignNoteColor(address, color):
+            return .requestAssignNoteColor(address, color)
         case _:
             return .detailStack(action)
         }
@@ -265,6 +269,8 @@ extension NotebookAction {
             return .succeedMoveEntry(from: from, to: to)
         case let .succeedUpdateAudience(receipt):
             return .succeedUpdateAudience(receipt)
+        case let .succeedAssignNoteColor(address, color):
+            return .succeedAssignNoteColor(address, color)
         default:
             return nil
         }
@@ -284,6 +290,8 @@ extension AppAction {
             return .mergeEntry(parent: parent, child: child)
         case let .requestUpdateAudience(address, audience):
             return .updateAudience(address: address, audience: audience)
+        case let .requestAssignNoteColor(address, color):
+            return .assignColor(addess: address, color: color)
         default:
             return nil
         }
@@ -485,6 +493,13 @@ struct NotebookModel: ModelProtocol {
                 environment: environment,
                 receipt: receipt
             )
+        case let .succeedAssignNoteColor(address, color):
+            return succeedAssignNoteColor(
+                state: state,
+                environment: environment,
+                address: address,
+                color: color
+            )
         case .submitSearch(let query):
             return submitSearch(
                 state: state,
@@ -503,7 +518,8 @@ struct NotebookModel: ModelProtocol {
                 environment: environment
             )
         case .requestDeleteEntry, .requestSaveEntry, .requestMoveEntry,
-                .requestMergeEntry, .requestUpdateAudience, .requestScrollToTop:
+                .requestMergeEntry, .requestUpdateAudience, .requestScrollToTop,
+                .requestAssignNoteColor:
             return Update(state: state)
         }
     }
@@ -781,8 +797,6 @@ struct NotebookModel: ModelProtocol {
         )
     }
 
-    /// Retitle success lifecycle handler.
-    /// Updates UI in response.
     static func succeedUpdateAudience(
         state: NotebookModel,
         environment: AppEnvironment,
@@ -792,6 +806,22 @@ struct NotebookModel: ModelProtocol {
             state: state,
             actions: [
                 .detailStack(.succeedUpdateAudience(receipt)),
+                .refreshLists
+            ],
+            environment: environment
+        )
+    }
+    
+    static func succeedAssignNoteColor(
+        state: NotebookModel,
+        environment: AppEnvironment,
+        address: Slashlink,
+        color: NoteColor
+    ) -> Update<NotebookModel> {
+        return update(
+            state: state,
+            actions: [
+                .detailStack(.succeedAssignNoteColor(address, color)),
                 .refreshLists
             ],
             environment: environment

--- a/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
@@ -155,8 +155,8 @@ enum NotebookAction: Hashable {
     case succeedMergeEntry(parent: Slashlink, child: Slashlink)
     case requestUpdateAudience(_ address: Slashlink, _ audience: Audience)
     case succeedUpdateAudience(_ receipt: MoveReceipt)
-    case requestAssignNoteColor(_ address: Slashlink, _ color: NoteColor)
-    case succeedAssignNoteColor(_ address: Slashlink, _ color: NoteColor)
+    case requestAssignNoteColor(_ address: Slashlink, _ color: ThemeColor)
+    case succeedAssignNoteColor(_ address: Slashlink, _ color: ThemeColor)
     
     //  Search
     /// Hit submit ("go") while focused on search field
@@ -816,7 +816,7 @@ struct NotebookModel: ModelProtocol {
         state: NotebookModel,
         environment: AppEnvironment,
         address: Slashlink,
-        color: NoteColor
+        color: ThemeColor
     ) -> Update<NotebookModel> {
         return update(
             state: state,

--- a/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
@@ -163,13 +163,11 @@ extension EntryStub: DummyData {
         let slashlink = Slashlink("@\(petname)/entry-\(Int.random(in: 0..<99))")!
         let address = slashlink
         let excerpt = Subtext(markup: String.dummyDataLong())
-        let modified = Date().addingTimeInterval(TimeInterval(-86400 * Int.random(in: 0..<5)))
         
         return EntryStub(
             did: Did.dummyData(),
             address: address,
             excerpt: excerpt,
-            modified: modified,
             headers: .emptySubtext
         )
     }
@@ -184,7 +182,6 @@ extension EntryStub: DummyData {
             did: Did.dummyData(),
             address: address,
             excerpt: excerpt,
-            modified: modified,
             headers: .emptySubtext
         )
     }

--- a/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
@@ -194,7 +194,7 @@ extension Memo: DummyData {
             created: Date.now,
             modified: Date.now,
             fileExtension: "subtext",
-            color: NoteColor.allCases.randomElement(),
+            themeColor: ThemeColor.allCases.randomElement(),
             additionalHeaders: Headers(),
             body: String.dummyDataMedium()
         )

--- a/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/DummyDataUtilities.swift
@@ -169,7 +169,8 @@ extension EntryStub: DummyData {
             did: Did.dummyData(),
             address: address,
             excerpt: excerpt,
-            modified: modified
+            modified: modified,
+            headers: .emptySubtext
         )
     }
     
@@ -183,7 +184,8 @@ extension EntryStub: DummyData {
             did: Did.dummyData(),
             address: address,
             excerpt: excerpt,
-            modified: modified
+            modified: modified,
+            headers: .emptySubtext
         )
     }
 }
@@ -195,6 +197,7 @@ extension Memo: DummyData {
             created: Date.now,
             modified: Date.now,
             fileExtension: "subtext",
+            color: NoteColor.allCases.randomElement(),
             additionalHeaders: Headers(),
             body: String.dummyDataMedium()
         )

--- a/xcode/Subconscious/Shared/Models/Entry.swift
+++ b/xcode/Subconscious/Shared/Models/Entry.swift
@@ -34,7 +34,6 @@ extension EntryStub {
         
         self.address = entry.address
         self.excerpt = Subtext(markup: entry.contents.excerpt())
-        self.modified = entry.contents.modified
         self.did = did
         self.headers = entry.contents.wellKnownHeaders()
     }

--- a/xcode/Subconscious/Shared/Models/Entry.swift
+++ b/xcode/Subconscious/Shared/Models/Entry.swift
@@ -36,5 +36,6 @@ extension EntryStub {
         self.excerpt = Subtext(markup: entry.contents.excerpt())
         self.modified = entry.contents.modified
         self.did = did
+        self.headers = entry.contents.wellKnownHeaders()
     }
 }

--- a/xcode/Subconscious/Shared/Models/EntryStub.swift
+++ b/xcode/Subconscious/Shared/Models/EntryStub.swift
@@ -19,7 +19,7 @@ struct EntryStub:
     let address: Slashlink
     let excerpt: Subtext
     let modified: Date
-    var color: NoteColor? = nil
+    let headers: WellKnownHeaders
 
     var id: Slashlink { address }
     var debugDescription: String {
@@ -31,7 +31,8 @@ struct EntryStub:
             did: did,
             address: address,
             excerpt: excerpt,
-            modified: modified
+            modified: modified,
+            headers: headers
         )
     }
     

--- a/xcode/Subconscious/Shared/Models/EntryStub.swift
+++ b/xcode/Subconscious/Shared/Models/EntryStub.swift
@@ -19,6 +19,7 @@ struct EntryStub:
     let address: Slashlink
     let excerpt: Subtext
     let modified: Date
+    var color: NoteColor? = nil
 
     var id: Slashlink { address }
     var debugDescription: String {

--- a/xcode/Subconscious/Shared/Models/EntryStub.swift
+++ b/xcode/Subconscious/Shared/Models/EntryStub.swift
@@ -18,7 +18,6 @@ struct EntryStub:
     let did: Did
     let address: Slashlink
     let excerpt: Subtext
-    let modified: Date
     let headers: WellKnownHeaders
 
     var id: Slashlink { address }
@@ -31,7 +30,6 @@ struct EntryStub:
             did: did,
             address: address,
             excerpt: excerpt,
-            modified: modified,
             headers: headers
         )
     }

--- a/xcode/Subconscious/Shared/Models/HeaderSubtext.swift
+++ b/xcode/Subconscious/Shared/Models/HeaderSubtext.swift
@@ -56,7 +56,7 @@ extension HeaderSubtext {
             created: wellKnownHeaders.created,
             modified: wellKnownHeaders.modified,
             fileExtension: wellKnownHeaders.fileExtension,
-            color: wellKnownHeaders.color,
+            themeColor: wellKnownHeaders.themeColor,
             additionalHeaders: headers,
             body: body
         )

--- a/xcode/Subconscious/Shared/Models/HeaderSubtext.swift
+++ b/xcode/Subconscious/Shared/Models/HeaderSubtext.swift
@@ -56,6 +56,7 @@ extension HeaderSubtext {
             created: wellKnownHeaders.created,
             modified: wellKnownHeaders.modified,
             fileExtension: wellKnownHeaders.fileExtension,
+            color: wellKnownHeaders.color,
             additionalHeaders: headers,
             body: body
         )

--- a/xcode/Subconscious/Shared/Models/Memo.swift
+++ b/xcode/Subconscious/Shared/Models/Memo.swift
@@ -169,6 +169,9 @@ extension MemoRecord {
         memo: Memo,
         size: Int? = nil
     ) throws {
+        var headers = memo.headers
+        headers.append(contentsOf: memo.additionalHeaders)
+        
         try self.init(
             did: did,
             petname: petname,
@@ -178,7 +181,7 @@ extension MemoRecord {
             modified: memo.modified,
             title: memo.title(),
             fileExtension: memo.fileExtension,
-            headers: memo.headers,
+            headers: headers,
             body: memo.body,
             description: memo.plain(),
             excerpt: memo.excerpt(),

--- a/xcode/Subconscious/Shared/Models/Memo.swift
+++ b/xcode/Subconscious/Shared/Models/Memo.swift
@@ -155,7 +155,7 @@ extension MemoData {
             created: headers.created,
             modified: headers.modified,
             fileExtension: headers.fileExtension,
-            additionalHeaders: [],
+            additionalHeaders: self.additionalHeaders,
             body: body
         )
     }

--- a/xcode/Subconscious/Shared/Models/Memo.swift
+++ b/xcode/Subconscious/Shared/Models/Memo.swift
@@ -15,7 +15,7 @@ struct Memo: Hashable, CustomStringConvertible {
     var created: Date
     var modified: Date
     var fileExtension: String
-    // TODO: lift color to here?
+    var color: NoteColor?
     var additionalHeaders: Headers
     var body: String
     
@@ -27,7 +27,8 @@ struct Memo: Hashable, CustomStringConvertible {
             contentType: contentType,
             created: created,
             modified: modified,
-            fileExtension: fileExtension
+            fileExtension: fileExtension,
+            color: color
         )
         .getAdditionalHeaders()
         .merge(additionalHeaders)
@@ -95,7 +96,8 @@ struct Memo: Hashable, CustomStringConvertible {
             contentType: contentType,
             created: created,
             modified: modified,
-            fileExtension: fileExtension
+            fileExtension: fileExtension,
+            color: color
         )
     }
     
@@ -156,6 +158,7 @@ extension MemoData {
             created: headers.created,
             modified: headers.modified,
             fileExtension: headers.fileExtension,
+            color: headers.color,
             additionalHeaders: self.additionalHeaders,
             body: body
         )
@@ -170,9 +173,6 @@ extension MemoRecord {
         memo: Memo,
         size: Int? = nil
     ) throws {
-        var headers = memo.headers
-        headers.append(contentsOf: memo.additionalHeaders)
-        
         try self.init(
             did: did,
             petname: petname,
@@ -182,7 +182,7 @@ extension MemoRecord {
             modified: memo.modified,
             title: memo.title(),
             fileExtension: memo.fileExtension,
-            headers: headers,
+            headers: memo.headers,
             body: memo.body,
             description: memo.plain(),
             excerpt: memo.excerpt(),

--- a/xcode/Subconscious/Shared/Models/Memo.swift
+++ b/xcode/Subconscious/Shared/Models/Memo.swift
@@ -15,6 +15,7 @@ struct Memo: Hashable, CustomStringConvertible {
     var created: Date
     var modified: Date
     var fileExtension: String
+    // TODO: lift color to here?
     var additionalHeaders: Headers
     var body: String
     

--- a/xcode/Subconscious/Shared/Models/Memo.swift
+++ b/xcode/Subconscious/Shared/Models/Memo.swift
@@ -15,7 +15,7 @@ struct Memo: Hashable, CustomStringConvertible {
     var created: Date
     var modified: Date
     var fileExtension: String
-    var color: NoteColor?
+    var themeColor: ThemeColor?
     var additionalHeaders: Headers
     var body: String
     
@@ -28,7 +28,7 @@ struct Memo: Hashable, CustomStringConvertible {
             created: created,
             modified: modified,
             fileExtension: fileExtension,
-            color: color
+            themeColor: themeColor
         )
         .getAdditionalHeaders()
         .merge(additionalHeaders)
@@ -97,7 +97,7 @@ struct Memo: Hashable, CustomStringConvertible {
             created: created,
             modified: modified,
             fileExtension: fileExtension,
-            color: color
+            themeColor: themeColor
         )
     }
     
@@ -158,7 +158,7 @@ extension MemoData {
             created: headers.created,
             modified: headers.modified,
             fileExtension: headers.fileExtension,
-            color: headers.color,
+            themeColor: headers.themeColor,
             additionalHeaders: [],
             body: body
         )

--- a/xcode/Subconscious/Shared/Models/Memo.swift
+++ b/xcode/Subconscious/Shared/Models/Memo.swift
@@ -159,7 +159,7 @@ extension MemoData {
             modified: headers.modified,
             fileExtension: headers.fileExtension,
             color: headers.color,
-            additionalHeaders: self.additionalHeaders,
+            additionalHeaders: [],
             body: body
         )
     }

--- a/xcode/Subconscious/Shared/Parsers/Header.swift
+++ b/xcode/Subconscious/Shared/Parsers/Header.swift
@@ -68,7 +68,7 @@ extension WellKnownHeaders {
             let colorString = additionalHeaders.get(
                 first: HeaderName.subconsciousTheme.rawValue
             ),
-            let color = ThemeColor(rawValue: colorString)
+            let color = Int(colorString).map({ v in ThemeColor(rawValue: v)})
         {
             this.themeColor = color
         }
@@ -98,7 +98,7 @@ extension WellKnownHeaders {
             headers.append(
                 Header(
                     name: HeaderName.subconsciousTheme.rawValue,
-                    value: color.rawValue
+                    value: String(color.rawValue)
                 )
             )
         }

--- a/xcode/Subconscious/Shared/Parsers/Header.swift
+++ b/xcode/Subconscious/Shared/Parsers/Header.swift
@@ -14,7 +14,7 @@ enum HeaderName: String {
     case created = "Created"
     case modified = "Modified"
     case fileExtension = "File-Extension"
-    case color = "Color"
+    case themeColor = "Theme-Color"
 }
 
 /// A struct containing well-known headers
@@ -23,7 +23,7 @@ struct WellKnownHeaders: Hashable {
     var created: Date
     var modified: Date
     var fileExtension: String
-    var color: NoteColor?
+    var themeColor: NoteColor?
     
     static let emptySubtext = WellKnownHeaders(
         contentType: ContentType.subtext.rawValue,
@@ -66,11 +66,11 @@ extension WellKnownHeaders {
         
         if
             let colorString = additionalHeaders.get(
-                first: HeaderName.color.rawValue
+                first: HeaderName.themeColor.rawValue
             ),
             let color = NoteColor(rawValue: colorString)
         {
-            this.color = color
+            this.themeColor = color
         }
         
         return this
@@ -94,10 +94,10 @@ extension WellKnownHeaders {
             )
         ]
         
-        if let color = color {
+        if let color = themeColor {
             headers.append(
                 Header(
-                    name: HeaderName.color.rawValue,
+                    name: HeaderName.themeColor.rawValue,
                     value: color.rawValue
                 )
             )

--- a/xcode/Subconscious/Shared/Parsers/Header.swift
+++ b/xcode/Subconscious/Shared/Parsers/Header.swift
@@ -23,7 +23,7 @@ struct WellKnownHeaders: Hashable {
     var created: Date
     var modified: Date
     var fileExtension: String
-    var themeColor: NoteColor?
+    var themeColor: ThemeColor?
     
     static let emptySubtext = WellKnownHeaders(
         contentType: ContentType.subtext.rawValue,
@@ -68,7 +68,7 @@ extension WellKnownHeaders {
             let colorString = additionalHeaders.get(
                 first: HeaderName.themeColor.rawValue
             ),
-            let color = NoteColor(rawValue: colorString)
+            let color = ThemeColor(rawValue: colorString)
         {
             this.themeColor = color
         }

--- a/xcode/Subconscious/Shared/Parsers/Header.swift
+++ b/xcode/Subconscious/Shared/Parsers/Header.swift
@@ -14,6 +14,7 @@ enum HeaderName: String {
     case created = "Created"
     case modified = "Modified"
     case fileExtension = "File-Extension"
+    case color = "Color"
 }
 
 /// A struct containing well-known headers
@@ -22,6 +23,14 @@ struct WellKnownHeaders: Hashable {
     var created: Date
     var modified: Date
     var fileExtension: String
+    var color: NoteColor?
+    
+    static let emptySubtext = WellKnownHeaders(
+        contentType: ContentType.subtext.rawValue,
+        created: Date(),
+        modified: Date(),
+        fileExtension: ContentType.subtext.fileExtension
+    )
 }
 
 extension WellKnownHeaders {
@@ -55,13 +64,22 @@ extension WellKnownHeaders {
             this.modified = modified
         }
         
+        if
+            let colorString = additionalHeaders.get(
+                first: HeaderName.color.rawValue
+            ),
+            let color = NoteColor(rawValue: colorString)
+        {
+            this.color = color
+        }
+        
         return this
     }
     
     /// Get "additional" headers as an array.
     /// Does not include `Content-Type`.
     func getAdditionalHeaders() -> [Header] {
-        [
+        var headers = [
             Header(
                 name: HeaderName.fileExtension.rawValue,
                 value: fileExtension
@@ -75,6 +93,17 @@ extension WellKnownHeaders {
                 value: modified.ISO8601Format()
             )
         ]
+        
+        if let color = color {
+            headers.append(
+                Header(
+                    name: HeaderName.color.rawValue,
+                    value: color.rawValue
+                )
+            )
+        }
+        
+        return headers
     }
 }
 

--- a/xcode/Subconscious/Shared/Parsers/Header.swift
+++ b/xcode/Subconscious/Shared/Parsers/Header.swift
@@ -14,7 +14,7 @@ enum HeaderName: String {
     case created = "Created"
     case modified = "Modified"
     case fileExtension = "File-Extension"
-    case themeColor = "Theme-Color"
+    case subconsciousTheme = "Subconscious-Theme"
 }
 
 /// A struct containing well-known headers
@@ -66,7 +66,7 @@ extension WellKnownHeaders {
         
         if
             let colorString = additionalHeaders.get(
-                first: HeaderName.themeColor.rawValue
+                first: HeaderName.subconsciousTheme.rawValue
             ),
             let color = ThemeColor(rawValue: colorString)
         {
@@ -97,7 +97,7 @@ extension WellKnownHeaders {
         if let color = themeColor {
             headers.append(
                 Header(
-                    name: HeaderName.themeColor.rawValue,
+                    name: HeaderName.subconsciousTheme.rawValue,
                     value: color.rawValue
                 )
             )

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -594,10 +594,10 @@ actor DataService {
     
     func assignNoteColor(
         address: Slashlink,
-        color: NoteColor
+        color: ThemeColor
     ) async throws {
         var memo = try await readMemo(address: address)
-        memo.color = color
+        memo.themeColor = color
         
         try await writeMemo(address: address, memo: memo)
     }

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -597,12 +597,7 @@ actor DataService {
         color: NoteColor
     ) async throws {
         var memo = try await readMemo(address: address)
-        memo.additionalHeaders = [
-            Header(
-                name: "Color",
-                value: color.rawValue
-            )
-        ]
+        memo.color = color
         
         try await writeMemo(address: address, memo: memo)
     }

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -592,6 +592,21 @@ actor DataService {
         }
     }
     
+    func assignNoteColor(
+        address: Slashlink,
+        color: NoteColor
+    ) async throws {
+        var memo = try await readMemo(address: address)
+        memo.additionalHeaders = [
+            Header(
+                name: "Color",
+                value: color.rawValue
+            )
+        ]
+        
+        try await writeMemo(address: address, memo: memo)
+    }
+    
     func writeEntry(_ entry: MemoEntry) async throws {
         try await writeMemo(address: entry.address, memo: entry.contents)
     }

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -613,6 +613,7 @@ final class DatabaseService {
         let results = try database.execute(
             sql: """
             SELECT did, id, modified, excerpt
+            SELECT did, id, modified, excerpt, headers
             FROM memo
             WHERE did IN (SELECT value FROM json_each(?))
                 AND substr(slug, 1, 1) != '_'
@@ -638,11 +639,32 @@ final class DatabaseService {
             
             let excerpt = Subtext(markup: row.col(3)?.toString() ?? "")
             
+            var headersDict = [String: String]()
+            if let headersJSON = row.col(4)?.toString() {
+                do {
+                    let jsonData = Data(headersJSON.utf8)
+                    let headersArray = try JSONDecoder().decode([[String: String]].self, from: jsonData)
+
+                    for header in headersArray {
+                        if let name = header["name"], let value = header["value"] {
+                            headersDict[name] = value
+                        }
+                    }
+
+                    // Now headersDict contains your headers as a dictionary
+                } catch {
+                    print("Error parsing JSON: \(error)")
+                }
+            }
+            
+            let color = NoteColor(rawValue: headersDict["Color"] ?? "")
+            
             return EntryStub(
                 did: did,
                 address: address,
                 excerpt: excerpt,
-                modified: modified
+                modified: modified,
+                color: color
             )
         })
     }

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -596,6 +596,24 @@ final class DatabaseService {
         })
     }
     
+    func parseHeadersJson(json: String) throws -> [String: String] {
+        var headersDict: [String: String] = [:]
+        let jsonData = Data(json.utf8)
+        let headersArray = try JSONDecoder().decode(
+            [[String: String]].self,
+            from: jsonData
+        )
+
+        for header in headersArray {
+            if let name = header["name"],
+               let value = header["value"] {
+                headersDict[name] = value
+            }
+        }
+        
+        return headersDict
+    }
+    
     /// List recent entries
     func listRecentMemos(owner: Did?, includeDrafts: Bool = false) throws -> [EntryStub] {
         guard self.state == .ready else {
@@ -624,7 +642,7 @@ final class DatabaseService {
                 .json(dids, or: "[]")
             ]
         )
-        return results.compactMap({ row in
+        return try results.compactMap({ row in
             guard
                 let did = row.col(0)?.toString()?.toDid(),
                 let address = row.col(1)?
@@ -639,24 +657,7 @@ final class DatabaseService {
             
             let excerpt = Subtext(markup: row.col(3)?.toString() ?? "")
             
-            var headersDict = [String: String]()
-            if let headersJSON = row.col(4)?.toString() {
-                do {
-                    let jsonData = Data(headersJSON.utf8)
-                    let headersArray = try JSONDecoder().decode([[String: String]].self, from: jsonData)
-
-                    for header in headersArray {
-                        if let name = header["name"], let value = header["value"] {
-                            headersDict[name] = value
-                        }
-                    }
-
-                    // Now headersDict contains your headers as a dictionary
-                } catch {
-                    print("Error parsing JSON: \(error)")
-                }
-            }
-            
+            let headersDict = try parseHeadersJson(json: row.col(4)?.toString() ?? "")
             let color = NoteColor(rawValue: headersDict["Color"] ?? "")
             
             return EntryStub(

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -504,7 +504,8 @@ final class DatabaseService {
             ]
         )
 
-        return try results.compactMap({ row in
+        return try results.compactMap({
+            row in
             guard
                 let address = row.col(0)?
                     .toString()?
@@ -515,16 +516,14 @@ final class DatabaseService {
             }
             
             let excerpt = Subtext(markup: row.col(2)?.toString() ?? "")
-            
-            let headersDict = try parseHeadersJson(json: row.col(3)?.toString() ?? "")
-            let color = NoteColor(rawValue: headersDict["Color"] ?? "")
+            let headers = try parseHeadersJson(json: row.col(3)?.toString() ?? "")
             
             return EntryStub(
                 did: did,
                 address: address,
                 excerpt: excerpt,
                 modified: modified,
-                color: color
+                headers: headers
             )
         })
         .first
@@ -590,36 +589,39 @@ final class DatabaseService {
             }
             
             let excerpt = Subtext(markup: row.col(3)?.toString() ?? "")
-            
-            let headersDict = try parseHeadersJson(json: row.col(4)?.toString() ?? "")
-            let color = NoteColor(rawValue: headersDict["Color"] ?? "")
+            let headers = try parseHeadersJson(json: row.col(4)?.toString() ?? "")
             
             return EntryStub(
                 did: did,
                 address: slashlink,
                 excerpt: excerpt,
                 modified: modified,
-                color: color
+                headers: headers
             )
         })
     }
     
-    func parseHeadersJson(json: String) throws -> [String: String] {
-        var headersDict: [String: String] = [:]
+    func parseHeadersJson(json: String) throws -> WellKnownHeaders {
+        var headers: [Header] = []
         let jsonData = Data(json.utf8)
         let headersArray = try JSONDecoder().decode(
             [[String: String]].self,
             from: jsonData
         )
-
+        
         for header in headersArray {
             if let name = header["name"],
                let value = header["value"] {
-                headersDict[name] = value
+                headers.append(Header(name: name, value: value))
             }
         }
         
-        return headersDict
+        return WellKnownHeaders(
+            contentType: ContentType.subtext.rawValue,
+            created: Date.now,
+            modified: Date.now,
+            fileExtension: ContentType.subtext.fileExtension
+        ).updating(headers)
     }
     
     /// List recent entries
@@ -664,16 +666,14 @@ final class DatabaseService {
             }
             
             let excerpt = Subtext(markup: row.col(3)?.toString() ?? "")
-            
-            let headersDict = try parseHeadersJson(json: row.col(4)?.toString() ?? "")
-            let color = NoteColor(rawValue: headersDict["Color"] ?? "")
+            let headers = try parseHeadersJson(json: row.col(4)?.toString() ?? "")
             
             return EntryStub(
                 did: did,
                 address: address,
                 excerpt: excerpt,
                 modified: modified,
-                color: color
+                headers: headers
             )
         })
     }
@@ -1228,16 +1228,14 @@ final class DatabaseService {
             }
             
             let excerpt = Subtext(markup: row.col(3)?.toString() ?? "")
-            
-            let headersDict = try parseHeadersJson(json: row.col(4)?.toString() ?? "")
-            let color = NoteColor(rawValue: headersDict["Color"] ?? "")
+            let headers = try parseHeadersJson(json: row.col(4)?.toString() ?? "")
             
             return EntryStub(
                 did: did,
                 address: address,
                 excerpt: excerpt,
                 modified: modified,
-                color: color
+                headers: headers
             )
         })
         .first
@@ -1272,16 +1270,14 @@ final class DatabaseService {
             }
             
             let excerpt = Subtext(markup: row.col(3)?.toString() ?? "")
-            
-            let headersDict = try parseHeadersJson(json: row.col(4)?.toString() ?? "")
-            let color = NoteColor(rawValue: headersDict["Color"] ?? "")
+            let headers = try parseHeadersJson(json: row.col(4)?.toString() ?? "")
             
             return EntryStub(
                 did: did,
                 address: address,
                 excerpt: excerpt,
                 modified: modified,
-                color: color
+                headers: headers
             )
         })
         .first
@@ -1314,16 +1310,14 @@ final class DatabaseService {
             }
             
             let excerpt = Subtext(markup: row.col(3)?.toString() ?? "")
-            
-            let headersDict = try parseHeadersJson(json: row.col(4)?.toString() ?? "")
-            let color = NoteColor(rawValue: headersDict["Color"] ?? "")
+            let headers = try parseHeadersJson(json: row.col(4)?.toString() ?? "")
             
             return EntryStub(
                 did: did,
                 address: address,
                 excerpt: excerpt,
                 modified: modified,
-                color: color
+                headers: headers
             )
         })
         .first
@@ -1365,16 +1359,14 @@ final class DatabaseService {
             }
             
             let excerpt = Subtext(markup: row.col(3)?.toString() ?? "")
-            
-            let headersDict = try parseHeadersJson(json: row.col(4)?.toString() ?? "")
-            let color = NoteColor(rawValue: headersDict["Color"] ?? "")
+            let headers = try parseHeadersJson(json: row.col(4)?.toString() ?? "")
             
             return EntryStub(
                 did: did,
                 address: address,
                 excerpt: excerpt,
                 modified: modified,
-                color: color
+                headers: headers
             )
         })
         .first

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -491,7 +491,7 @@ final class DatabaseService {
 
         let results = try database.execute(
             sql: """
-            SELECT slashlink, modified, excerpt, headers
+            SELECT slashlink, excerpt, headers
             FROM memo
             WHERE did = ?
                 AND slug = ?
@@ -509,14 +509,13 @@ final class DatabaseService {
             guard
                 let address = row.col(0)?
                     .toString()?
-                    .toSlashlink(),
-                let modified = row.col(1)?.toDate()
+                    .toSlashlink()
             else {
                 return nil
             }
             
-            let excerpt = Subtext(markup: row.col(2)?.toString() ?? "")
-            let headers = try parseHeadersJson(json: row.col(3)?.toString() ?? "")
+            let excerpt = Subtext(markup: row.col(1)?.toString() ?? "")
+            let headers = try parseHeadersJson(json: row.col(2)?.toString() ?? "")
             
             return EntryStub(
                 did: did,
@@ -564,7 +563,7 @@ final class DatabaseService {
         
         let results = try database.execute(
             sql: """
-            SELECT did, slashlink, modified, excerpt, headers
+            SELECT did, slashlink, excerpt, headers
             FROM memo
             WHERE did NOT IN (SELECT value FROM json_each(?))
                 AND substr(slug, 1, 1) != '_'
@@ -581,14 +580,13 @@ final class DatabaseService {
                 let slashlink = row.col(1)?
                     .toString()?
                     .toSlashlink()?
-                    .relativizeIfNeeded(did: owner),
-                let modified = row.col(2)?.toDate()
+                    .relativizeIfNeeded(did: owner)
             else {
                 return nil
             }
             
-            let excerpt = Subtext(markup: row.col(3)?.toString() ?? "")
-            let headers = try parseHeadersJson(json: row.col(4)?.toString() ?? "")
+            let excerpt = Subtext(markup: row.col(2)?.toString() ?? "")
+            let headers = try parseHeadersJson(json: row.col(3)?.toString() ?? "")
             
             return EntryStub(
                 did: did,
@@ -638,7 +636,6 @@ final class DatabaseService {
         
         let results = try database.execute(
             sql: """
-            SELECT did, id, modified, excerpt
             SELECT did, id, modified, excerpt, headers
             FROM memo
             WHERE did IN (SELECT value FROM json_each(?))
@@ -657,14 +654,13 @@ final class DatabaseService {
                     .toString()?
                     .toLink()?
                     .toSlashlink()?
-                    .relativizeIfNeeded(did: owner),
-                let modified = row.col(2)?.toDate()
+                    .relativizeIfNeeded(did: owner)
             else {
                 return nil
             }
             
-            let excerpt = Subtext(markup: row.col(3)?.toString() ?? "")
-            let headers = try parseHeadersJson(json: row.col(4)?.toString() ?? "")
+            let excerpt = Subtext(markup: row.col(2)?.toString() ?? "")
+            let headers = try parseHeadersJson(json: row.col(3)?.toString() ?? "")
             
             return EntryStub(
                 did: did,
@@ -1085,9 +1081,8 @@ final class DatabaseService {
         
         let petname = row.col(1)?.toString()?.toPetname()
         let slug = row.col(2)?.toString()?.toSlug()
-        let modified = row.col(3)?.toDate()
-        let excerpt = Subtext(markup: row.col(4)?.toString() ?? "")
-        let headers = try parseHeadersJson(json: row.col(5)?.toString() ?? "")
+        let excerpt = Subtext(markup: row.col(3)?.toString() ?? "")
+        let headers = try parseHeadersJson(json: row.col(4)?.toString() ?? "")
         switch (petname, slug) {
         case let (.some(petname), .some(slug)):
             return EntryStub(
@@ -1136,7 +1131,6 @@ final class DatabaseService {
             SELECT m.did,
                 peer.petname,
                 m.slug,
-                m.modified,
                 m.excerpt,
                 m.headers
             FROM memo m
@@ -1171,7 +1165,6 @@ final class DatabaseService {
                 memo_search.did,
                 peer.petname,
                 memo_search.slug,
-                memo_search.modified,
                 memo_search.excerpt,
                 memo_search.headers
             FROM memo_search
@@ -1202,7 +1195,7 @@ final class DatabaseService {
         
         return try? database.execute(
             sql: """
-            SELECT did, id, modified, excerpt, headers
+            SELECT did, id, excerpt, headers
             FROM memo_search
             WHERE memo_search.modified BETWEEN ? AND ?
                 AND substr(memo_search.slug, 1, 1) != '_'
@@ -1220,14 +1213,13 @@ final class DatabaseService {
                 let address = row.col(1)?
                     .toString()?
                     .toSlashlink()?
-                    .relativizeIfNeeded(did: owner),
-                let modified = row.col(2)?.toDate()
+                    .relativizeIfNeeded(did: owner)
             else {
                 return nil
             }
             
-            let excerpt = Subtext(markup: row.col(3)?.toString() ?? "")
-            let headers = try parseHeadersJson(json: row.col(4)?.toString() ?? "")
+            let excerpt = Subtext(markup: row.col(2)?.toString() ?? "")
+            let headers = try parseHeadersJson(json: row.col(3)?.toString() ?? "")
             
             return EntryStub(
                 did: did,
@@ -1246,7 +1238,7 @@ final class DatabaseService {
 
         return try? database.execute(
             sql: """
-            SELECT did, slashlink, modified, excerpt, headers
+            SELECT did, slashlink, excerpt, headers
             FROM memo
             WHERE substr(memo.slug, 1, 1) != '_'
             AND length(excerpt) > 64
@@ -1261,14 +1253,13 @@ final class DatabaseService {
                 let did = row.col(0)?.toString()?.toDid(),
                 let address = row.col(1)?
                     .toString()?
-                    .toSlashlink(),
-                let modified = row.col(2)?.toDate()
+                    .toSlashlink()
             else {
                 return nil
             }
             
-            let excerpt = Subtext(markup: row.col(3)?.toString() ?? "")
-            let headers = try parseHeadersJson(json: row.col(4)?.toString() ?? "")
+            let excerpt = Subtext(markup: row.col(2)?.toString() ?? "")
+            let headers = try parseHeadersJson(json: row.col(3)?.toString() ?? "")
             
             return EntryStub(
                 did: did,
@@ -1288,7 +1279,7 @@ final class DatabaseService {
 
         return try? database.execute(
             sql: """
-            SELECT did, slashlink, modified, excerpt, headers
+            SELECT did, slashlink, excerpt, headers
             FROM memo
             WHERE substr(memo.slug, 1, 1) != '_'
             ORDER BY RANDOM()
@@ -1300,14 +1291,13 @@ final class DatabaseService {
                 let did = row.col(0)?.toString()?.toDid(),
                 let address = row.col(1)?
                     .toString()?
-                    .toSlashlink(),
-                let modified = row.col(2)?.toDate()
+                    .toSlashlink()
             else {
                 return nil
             }
             
-            let excerpt = Subtext(markup: row.col(3)?.toString() ?? "")
-            let headers = try parseHeadersJson(json: row.col(4)?.toString() ?? "")
+            let excerpt = Subtext(markup: row.col(2)?.toString() ?? "")
+            let headers = try parseHeadersJson(json: row.col(3)?.toString() ?? "")
             
             return EntryStub(
                 did: did,
@@ -1330,7 +1320,7 @@ final class DatabaseService {
         
         return try? database.execute(
             sql: """
-            SELECT did, id, modified, excerpt, headers
+            SELECT did, id, excerpt, headers
             FROM memo_search
             WHERE description MATCH ?
                 AND substr(slug, 1, 1) != '_'
@@ -1348,14 +1338,13 @@ final class DatabaseService {
                     .toString()?
                     .toLink()?
                     .toSlashlink()?
-                    .relativizeIfNeeded(did: owner),
-                let modified = row.col(2)?.toDate()
+                    .relativizeIfNeeded(did: owner)
             else {
                 return nil
             }
             
-            let excerpt = Subtext(markup: row.col(3)?.toString() ?? "")
-            let headers = try parseHeadersJson(json: row.col(4)?.toString() ?? "")
+            let excerpt = Subtext(markup: row.col(2)?.toString() ?? "")
+            let headers = try parseHeadersJson(json: row.col(3)?.toString() ?? "")
             
             return EntryStub(
                 did: did,

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -522,7 +522,6 @@ final class DatabaseService {
                 did: did,
                 address: address,
                 excerpt: excerpt,
-                modified: modified,
                 headers: headers
             )
         })
@@ -595,7 +594,6 @@ final class DatabaseService {
                 did: did,
                 address: slashlink,
                 excerpt: excerpt,
-                modified: modified,
                 headers: headers
             )
         })
@@ -672,7 +670,6 @@ final class DatabaseService {
                 did: did,
                 address: address,
                 excerpt: excerpt,
-                modified: modified,
                 headers: headers
             )
         })
@@ -1234,7 +1231,6 @@ final class DatabaseService {
                 did: did,
                 address: address,
                 excerpt: excerpt,
-                modified: modified,
                 headers: headers
             )
         })
@@ -1276,7 +1272,6 @@ final class DatabaseService {
                 did: did,
                 address: address,
                 excerpt: excerpt,
-                modified: modified,
                 headers: headers
             )
         })
@@ -1316,7 +1311,6 @@ final class DatabaseService {
                 did: did,
                 address: address,
                 excerpt: excerpt,
-                modified: modified,
                 headers: headers
             )
         })
@@ -1365,7 +1359,6 @@ final class DatabaseService {
                 did: did,
                 address: address,
                 excerpt: excerpt,
-                modified: modified,
                 headers: headers
             )
         })

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -636,7 +636,7 @@ final class DatabaseService {
         
         let results = try database.execute(
             sql: """
-            SELECT did, id, modified, excerpt, headers
+            SELECT did, id, excerpt, headers
             FROM memo
             WHERE did IN (SELECT value FROM json_each(?))
                 AND substr(slug, 1, 1) != '_'

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -341,7 +341,7 @@ actor NoosphereService:
             )
         }
     }
-    
+   
     nonisolated func writePublisher(
         slug: Slug,
         contentType: String,

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -341,7 +341,7 @@ actor NoosphereService:
             )
         }
     }
-   
+    
     nonisolated func writePublisher(
         slug: Slug,
         contentType: String,

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -280,8 +280,7 @@ actor UserProfileService {
                         slug: slug
                     ),
                     excerpt: excerpt,
-                    modified: memo.modified,
-                    headers: WellKnownHeaders.emptySubtext
+                    headers: memo.wellKnownHeaders()
                 )
             )
         }
@@ -293,7 +292,7 @@ actor UserProfileService {
     private func sortEntriesByModified(entries: [EntryStub]) -> [EntryStub] {
         var recentEntries = entries
         recentEntries.sort(by: { a, b in
-            a.modified > b.modified
+            a.headers.modified > b.headers.modified
         })
         
         return recentEntries

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -280,7 +280,8 @@ actor UserProfileService {
                         slug: slug
                     ),
                     excerpt: excerpt,
-                    modified: memo.modified
+                    modified: memo.modified,
+                    headers: WellKnownHeaders.emptySubtext
                 )
             )
         }

--- a/xcode/Subconscious/Shared/UIKit/BlockEditor/Appendix/Related/RelatedCell.swift
+++ b/xcode/Subconscious/Shared/UIKit/BlockEditor/Appendix/Related/RelatedCell.swift
@@ -100,21 +100,18 @@ struct BlockEditorRelatedCell_Previews: PreviewProvider {
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/foo")!,
                             excerpt: Subtext(markup: "An [[autopoietic system]] is a network of processes that recursively depend on each other for their own generation and realization."),
-                            modified: Date.now,
                             headers: WellKnownHeaders.emptySubtext
                         ),
                         EntryStub(
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/bar")!,
                             excerpt: Subtext(markup: "Modularity is a form of hierarchy"),
-                            modified: Date.now,
                             headers: WellKnownHeaders.emptySubtext
                         ),
                         EntryStub(
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/baz")!,
                             excerpt: Subtext(markup: "Ashby’s law of requisite variety: If a system is to be stable, the number of states of its control mechanism must be greater than or equal to the number of states in the system being controlled."),
-                            modified: Date.now,
                             headers: WellKnownHeaders.emptySubtext
                         )
                     ]

--- a/xcode/Subconscious/Shared/UIKit/BlockEditor/Appendix/Related/RelatedCell.swift
+++ b/xcode/Subconscious/Shared/UIKit/BlockEditor/Appendix/Related/RelatedCell.swift
@@ -100,19 +100,22 @@ struct BlockEditorRelatedCell_Previews: PreviewProvider {
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/foo")!,
                             excerpt: Subtext(markup: "An [[autopoietic system]] is a network of processes that recursively depend on each other for their own generation and realization."),
-                            modified: Date.now
+                            modified: Date.now,
+                            headers: WellKnownHeaders.emptySubtext
                         ),
                         EntryStub(
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/bar")!,
                             excerpt: Subtext(markup: "Modularity is a form of hierarchy"),
-                            modified: Date.now
+                            modified: Date.now,
+                            headers: WellKnownHeaders.emptySubtext
                         ),
                         EntryStub(
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/baz")!,
                             excerpt: Subtext(markup: "Ashby’s law of requisite variety: If a system is to be stable, the number of states of its control mechanism must be greater than or equal to the number of states in the system being controlled."),
-                            modified: Date.now
+                            modified: Date.now,
+                            headers: WellKnownHeaders.emptySubtext
                         )
                     ]
                 )

--- a/xcode/Subconscious/Shared/UIKit/BlockEditor/Appendix/Related/RelatedCell.swift
+++ b/xcode/Subconscious/Shared/UIKit/BlockEditor/Appendix/Related/RelatedCell.swift
@@ -100,19 +100,19 @@ struct BlockEditorRelatedCell_Previews: PreviewProvider {
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/foo")!,
                             excerpt: Subtext(markup: "An [[autopoietic system]] is a network of processes that recursively depend on each other for their own generation and realization."),
-                            headers: WellKnownHeaders.emptySubtext
+                            headers: .emptySubtext
                         ),
                         EntryStub(
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/bar")!,
                             excerpt: Subtext(markup: "Modularity is a form of hierarchy"),
-                            headers: WellKnownHeaders.emptySubtext
+                            headers: .emptySubtext
                         ),
                         EntryStub(
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/baz")!,
                             excerpt: Subtext(markup: "Ashby’s law of requisite variety: If a system is to be stable, the number of states of its control mechanism must be greater than or equal to the number of states in the system being controlled."),
-                            headers: WellKnownHeaders.emptySubtext
+                            headers: .emptySubtext
                         )
                     ]
                 )

--- a/xcode/Subconscious/Shared/UIKit/BlockEditor/Blocks/ListBlockCell.swift
+++ b/xcode/Subconscious/Shared/UIKit/BlockEditor/Blocks/ListBlockCell.swift
@@ -224,13 +224,15 @@ struct BlockEditorListBlockCell_Previews: PreviewProvider {
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/foo")!,
                             excerpt: Subtext(markup: "An autopoietic system is a network of processes that recursively depend on each other for their own generation and realization."),
-                            modified: Date.now
+                            modified: Date.now,
+                            headers: WellKnownHeaders.emptySubtext
                         ),
                         EntryStub(
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/bar")!,
                             excerpt: Subtext(markup: "Modularity is a form of hierarchy"),
-                            modified: Date.now
+                            modified: Date.now,
+                            headers: WellKnownHeaders.emptySubtext
                         ),
                     ]
                 )

--- a/xcode/Subconscious/Shared/UIKit/BlockEditor/Blocks/ListBlockCell.swift
+++ b/xcode/Subconscious/Shared/UIKit/BlockEditor/Blocks/ListBlockCell.swift
@@ -224,15 +224,13 @@ struct BlockEditorListBlockCell_Previews: PreviewProvider {
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/foo")!,
                             excerpt: Subtext(markup: "An autopoietic system is a network of processes that recursively depend on each other for their own generation and realization."),
-                            modified: Date.now,
-                            headers: WellKnownHeaders.emptySubtext
+                            headers: .emptySubtext
                         ),
                         EntryStub(
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/bar")!,
                             excerpt: Subtext(markup: "Modularity is a form of hierarchy"),
-                            modified: Date.now,
-                            headers: WellKnownHeaders.emptySubtext
+                            headers: .emptySubtext
                         ),
                     ]
                 )

--- a/xcode/Subconscious/Shared/UIKit/BlockEditor/Blocks/QuoteBlockCell.swift
+++ b/xcode/Subconscious/Shared/UIKit/BlockEditor/Blocks/QuoteBlockCell.swift
@@ -203,13 +203,15 @@ struct BlockEditorQuoteBlockCell_Previews: PreviewProvider {
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/foo")!,
                             excerpt: Subtext(markup: "An autopoietic system is a network of processes that recursively depend on each other for their own generation and realization."),
-                            modified: Date.now
+                            modified: Date.now,
+                            headers: WellKnownHeaders.emptySubtext
                         ),
                         EntryStub(
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/bar")!,
                             excerpt: Subtext(markup: "Modularity is a form of hierarchy"),
-                            modified: Date.now
+                            modified: Date.now,
+                            headers: WellKnownHeaders.emptySubtext
                         ),
                     ]
                 )

--- a/xcode/Subconscious/Shared/UIKit/BlockEditor/Blocks/QuoteBlockCell.swift
+++ b/xcode/Subconscious/Shared/UIKit/BlockEditor/Blocks/QuoteBlockCell.swift
@@ -203,13 +203,13 @@ struct BlockEditorQuoteBlockCell_Previews: PreviewProvider {
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/foo")!,
                             excerpt: Subtext(markup: "An autopoietic system is a network of processes that recursively depend on each other for their own generation and realization."),
-                            headers: WellKnownHeaders.emptySubtext
+                            headers: .emptySubtext
                         ),
                         EntryStub(
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/bar")!,
                             excerpt: Subtext(markup: "Modularity is a form of hierarchy"),
-                            headers: WellKnownHeaders.emptySubtext
+                            headers: .emptySubtext
                         ),
                     ]
                 )

--- a/xcode/Subconscious/Shared/UIKit/BlockEditor/Blocks/QuoteBlockCell.swift
+++ b/xcode/Subconscious/Shared/UIKit/BlockEditor/Blocks/QuoteBlockCell.swift
@@ -203,14 +203,12 @@ struct BlockEditorQuoteBlockCell_Previews: PreviewProvider {
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/foo")!,
                             excerpt: Subtext(markup: "An autopoietic system is a network of processes that recursively depend on each other for their own generation and realization."),
-                            modified: Date.now,
                             headers: WellKnownHeaders.emptySubtext
                         ),
                         EntryStub(
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/bar")!,
                             excerpt: Subtext(markup: "Modularity is a form of hierarchy"),
-                            modified: Date.now,
                             headers: WellKnownHeaders.emptySubtext
                         ),
                     ]

--- a/xcode/Subconscious/Shared/UIKit/BlockEditor/Blocks/TextBlockCell.swift
+++ b/xcode/Subconscious/Shared/UIKit/BlockEditor/Blocks/TextBlockCell.swift
@@ -138,14 +138,12 @@ struct BlockEditorTextBlockCell_Previews: PreviewProvider {
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/foo")!,
                             excerpt: Subtext(markup: "An autopoietic system is a network of processes that recursively depend on each other for their own generation and realization."),
-                            modified: Date.now,
                             headers: .emptySubtext
                         ),
                         EntryStub(
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/bar")!,
                             excerpt: Subtext(markup: "Modularity is a form of hierarchy"),
-                            modified: Date.now,
                             headers: .emptySubtext
                         ),
                     ]
@@ -168,14 +166,12 @@ struct BlockEditorTextBlockCell_Previews: PreviewProvider {
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/foo")!,
                             excerpt: Subtext(markup: "An autopoietic system is a network of processes that recursively depend on each other for their own generation and realization."),
-                            modified: Date.now,
                             headers: .emptySubtext
                         ),
                         EntryStub(
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/bar")!,
                             excerpt: Subtext(markup: "Modularity is a form of hierarchy"),
-                            modified: Date.now,
                             headers: .emptySubtext
                         ),
                     ]

--- a/xcode/Subconscious/Shared/UIKit/BlockEditor/Blocks/TextBlockCell.swift
+++ b/xcode/Subconscious/Shared/UIKit/BlockEditor/Blocks/TextBlockCell.swift
@@ -138,13 +138,15 @@ struct BlockEditorTextBlockCell_Previews: PreviewProvider {
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/foo")!,
                             excerpt: Subtext(markup: "An autopoietic system is a network of processes that recursively depend on each other for their own generation and realization."),
-                            modified: Date.now
+                            modified: Date.now,
+                            headers: .emptySubtext
                         ),
                         EntryStub(
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/bar")!,
                             excerpt: Subtext(markup: "Modularity is a form of hierarchy"),
-                            modified: Date.now
+                            modified: Date.now,
+                            headers: .emptySubtext
                         ),
                     ]
                 )
@@ -166,13 +168,15 @@ struct BlockEditorTextBlockCell_Previews: PreviewProvider {
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/foo")!,
                             excerpt: Subtext(markup: "An autopoietic system is a network of processes that recursively depend on each other for their own generation and realization."),
-                            modified: Date.now
+                            modified: Date.now,
+                            headers: .emptySubtext
                         ),
                         EntryStub(
                             did: Did("did:key:abc123")!,
                             address: Slashlink("@example/bar")!,
                             excerpt: Subtext(markup: "Modularity is a form of hierarchy"),
-                            modified: Date.now
+                            modified: Date.now,
+                            headers: .emptySubtext
                         ),
                     ]
                 )

--- a/xcode/Subconscious/Shared/UIKit/BlockEditor/Common/Transclude/BlockEditorTranscludeListView.swift
+++ b/xcode/Subconscious/Shared/UIKit/BlockEditor/Common/Transclude/BlockEditorTranscludeListView.swift
@@ -64,8 +64,7 @@ struct BlockTranscludeListView_Previews: PreviewProvider {
                         did: Did.dummyData(),
                         address: Slashlink("@handle/short")!,
                         excerpt: Subtext(markup: "Short"),
-                        modified: Date.now,
-                        headers: WellKnownHeaders.emptySubtext
+                        headers: .emptySubtext
                     ),
                     EntryStub(
                         did: Did.dummyData(),
@@ -73,8 +72,7 @@ struct BlockTranscludeListView_Previews: PreviewProvider {
                         excerpt: Subtext(
                             markup: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi."
                         ),
-                        modified: Date.now,
-                        headers: WellKnownHeaders.emptySubtext
+                        headers: .emptySubtext
                     ),
                     EntryStub(
                         did: Did.dummyData(),
@@ -82,8 +80,7 @@ struct BlockTranscludeListView_Previews: PreviewProvider {
                         excerpt: Subtext(
                             markup: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi."
                         ),
-                        modified: Date.now,
-                        headers: WellKnownHeaders.emptySubtext
+                        headers: .emptySubtext
                     ),
                 ],
                 send: { action in }

--- a/xcode/Subconscious/Shared/UIKit/BlockEditor/Common/Transclude/BlockEditorTranscludeListView.swift
+++ b/xcode/Subconscious/Shared/UIKit/BlockEditor/Common/Transclude/BlockEditorTranscludeListView.swift
@@ -64,7 +64,8 @@ struct BlockTranscludeListView_Previews: PreviewProvider {
                         did: Did.dummyData(),
                         address: Slashlink("@handle/short")!,
                         excerpt: Subtext(markup: "Short"),
-                        modified: Date.now
+                        modified: Date.now,
+                        headers: WellKnownHeaders.emptySubtext
                     ),
                     EntryStub(
                         did: Did.dummyData(),
@@ -72,7 +73,8 @@ struct BlockTranscludeListView_Previews: PreviewProvider {
                         excerpt: Subtext(
                             markup: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi."
                         ),
-                        modified: Date.now
+                        modified: Date.now,
+                        headers: WellKnownHeaders.emptySubtext
                     ),
                     EntryStub(
                         did: Did.dummyData(),
@@ -80,7 +82,8 @@ struct BlockTranscludeListView_Previews: PreviewProvider {
                         excerpt: Subtext(
                             markup: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi."
                         ),
-                        modified: Date.now
+                        modified: Date.now,
+                        headers: WellKnownHeaders.emptySubtext
                     ),
                 ],
                 send: { action in }

--- a/xcode/Subconscious/SubconsciousTests/Tests_DeckDetailStackCursor.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DeckDetailStackCursor.swift
@@ -62,11 +62,11 @@ final class Tests_DeckDetailStackCursor: XCTestCase {
     
     func testTagRequestAssignNoteColor() throws {
         let action = DeckDetailStackCursor.tag(
-            .requestAssignNoteColor(Slashlink("@bob/foo")!, .tan)
+            .requestAssignNoteColor(Slashlink("@bob/foo")!, .b)
         )
         XCTAssertEqual(
             action,
-            DeckAction.requestAssignNoteColor(Slashlink("@bob/foo")!, .tan)
+            DeckAction.requestAssignNoteColor(Slashlink("@bob/foo")!, .b)
         )
     }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_DeckDetailStackCursor.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DeckDetailStackCursor.swift
@@ -59,5 +59,15 @@ final class Tests_DeckDetailStackCursor: XCTestCase {
             DeckAction.requestUpdateAudience(Slashlink("@bob/foo")!, .public)
         )
     }
+    
+    func testTagRequestAssignNoteColor() throws {
+        let action = DeckDetailStackCursor.tag(
+            .requestAssignNoteColor(Slashlink("@bob/foo")!, .tan)
+        )
+        XCTAssertEqual(
+            action,
+            DeckAction.requestAssignNoteColor(Slashlink("@bob/foo")!, .tan)
+        )
+    }
 }
 

--- a/xcode/Subconscious/SubconsciousTests/Tests_Deck_NotificationActions.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Deck_NotificationActions.swift
@@ -54,7 +54,7 @@ final class Tests_Deck_NotificationActions: XCTestCase {
         let action = AppAction.from(DeckAction.requestAssignNoteColor(Slashlink("@bob/foo")!, .tan))
         XCTAssertEqual(
             action,
-            AppAction.assignColor(addess: Slashlink("@bob/foo")!, color: .tan)
+            AppAction.assignColor(address: Slashlink("@bob/foo")!, color: .tan)
         )
     }
     

--- a/xcode/Subconscious/SubconsciousTests/Tests_Deck_NotificationActions.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Deck_NotificationActions.swift
@@ -50,6 +50,14 @@ final class Tests_Deck_NotificationActions: XCTestCase {
         )
     }
     
+    func testRequestAssignNoteColor() throws {
+        let action = AppAction.from(DeckAction.requestAssignNoteColor(Slashlink("@bob/foo")!, .tan))
+        XCTAssertEqual(
+            action,
+            AppAction.assignColor(addess: Slashlink("@bob/foo")!, color: .tan)
+        )
+    }
+    
     func testSucceedSaveEntry() throws {
         let time = Date.now
         let action = DeckAction.from(.succeedSaveEntry(address: Slashlink("@bob/foo")!, modified: time))
@@ -100,6 +108,22 @@ final class Tests_Deck_NotificationActions: XCTestCase {
         XCTAssertEqual(
             action,
             DeckAction.succeedUpdateAudience(receipt)
+        )
+    }
+    
+    func testSucceedAssignNoteColor() throws {
+        let action = DeckAction.from(
+            .succeedAssignNoteColor(
+                address: Slashlink("@bob/foo")!,
+                color: .tan
+            )
+        )
+        XCTAssertEqual(
+            action,
+            DeckAction.succeedAssignNoteColor(
+                Slashlink("@bob/foo")!,
+                .tan
+            )
         )
     }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_Deck_NotificationActions.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Deck_NotificationActions.swift
@@ -51,10 +51,10 @@ final class Tests_Deck_NotificationActions: XCTestCase {
     }
     
     func testRequestAssignNoteColor() throws {
-        let action = AppAction.from(DeckAction.requestAssignNoteColor(Slashlink("@bob/foo")!, .tan))
+        let action = AppAction.from(DeckAction.requestAssignNoteColor(Slashlink("@bob/foo")!, .d))
         XCTAssertEqual(
             action,
-            AppAction.assignColor(address: Slashlink("@bob/foo")!, color: .tan)
+            AppAction.assignColor(address: Slashlink("@bob/foo")!, color: .d)
         )
     }
     
@@ -115,14 +115,14 @@ final class Tests_Deck_NotificationActions: XCTestCase {
         let action = DeckAction.from(
             .succeedAssignNoteColor(
                 address: Slashlink("@bob/foo")!,
-                color: .tan
+                color: .d
             )
         )
         XCTAssertEqual(
             action,
             DeckAction.succeedAssignNoteColor(
                 Slashlink("@bob/foo")!,
-                .tan
+                .d
             )
         )
     }

--- a/xcode/Subconscious/SubconsciousTests/Tests_HomeProfileDetailStackCursor.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_HomeProfileDetailStackCursor.swift
@@ -62,11 +62,11 @@ final class Tests_HomeProfileDetailStackCursor: XCTestCase {
     
     func testTagRequestAssignNoteColor() throws {
         let action = HomeProfileDetailStackCursor.tag(
-            .requestAssignNoteColor(Slashlink("@bob/foo")!, .tan)
+            .requestAssignNoteColor(Slashlink("@bob/foo")!, .e)
         )
         XCTAssertEqual(
             action,
-            HomeProfileAction.requestAssignNoteColor(Slashlink("@bob/foo")!, .tan)
+            HomeProfileAction.requestAssignNoteColor(Slashlink("@bob/foo")!, .e)
         )
     }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_HomeProfileDetailStackCursor.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_HomeProfileDetailStackCursor.swift
@@ -59,5 +59,15 @@ final class Tests_HomeProfileDetailStackCursor: XCTestCase {
             HomeProfileAction.requestUpdateAudience(Slashlink("@bob/foo")!, .public)
         )
     }
+    
+    func testTagRequestAssignNoteColor() throws {
+        let action = HomeProfileDetailStackCursor.tag(
+            .requestAssignNoteColor(Slashlink("@bob/foo")!, .tan)
+        )
+        XCTAssertEqual(
+            action,
+            HomeProfileAction.requestAssignNoteColor(Slashlink("@bob/foo")!, .tan)
+        )
+    }
 }
 

--- a/xcode/Subconscious/SubconsciousTests/Tests_HomeProfile_NotificationActions.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_HomeProfile_NotificationActions.swift
@@ -50,6 +50,14 @@ final class Tests_HomeProfile_NotificationActions: XCTestCase {
         )
     }
     
+    func testRequestAssignNoteColor() throws {
+        let action = AppAction.from(HomeProfileAction.requestAssignNoteColor(Slashlink("@bob/foo")!, .tan))
+        XCTAssertEqual(
+            action,
+            AppAction.assignColor(addess: Slashlink("@bob/foo")!, color: .tan)
+        )
+    }
+    
     func testSucceedSaveEntry() throws {
         let time = Date.now
         let action = HomeProfileAction.from(.succeedSaveEntry(address: Slashlink("@bob/foo")!, modified: time))
@@ -100,6 +108,22 @@ final class Tests_HomeProfile_NotificationActions: XCTestCase {
         XCTAssertEqual(
             action,
             HomeProfileAction.succeedUpdateAudience(receipt)
+        )
+    }
+    
+    func testSucceedAssignNoteColor() throws {
+        let action = HomeProfileAction.from(
+            .succeedAssignNoteColor(
+                address: Slashlink("@bob/foo")!,
+                color: .tan
+            )
+        )
+        XCTAssertEqual(
+            action,
+            HomeProfileAction.succeedAssignNoteColor(
+                Slashlink("@bob/foo")!,
+                .tan
+            )
         )
     }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_HomeProfile_NotificationActions.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_HomeProfile_NotificationActions.swift
@@ -51,10 +51,10 @@ final class Tests_HomeProfile_NotificationActions: XCTestCase {
     }
     
     func testRequestAssignNoteColor() throws {
-        let action = AppAction.from(HomeProfileAction.requestAssignNoteColor(Slashlink("@bob/foo")!, .tan))
+        let action = AppAction.from(HomeProfileAction.requestAssignNoteColor(Slashlink("@bob/foo")!, .b))
         XCTAssertEqual(
             action,
-            AppAction.assignColor(address: Slashlink("@bob/foo")!, color: .tan)
+            AppAction.assignColor(address: Slashlink("@bob/foo")!, color: .b)
         )
     }
     
@@ -115,14 +115,14 @@ final class Tests_HomeProfile_NotificationActions: XCTestCase {
         let action = HomeProfileAction.from(
             .succeedAssignNoteColor(
                 address: Slashlink("@bob/foo")!,
-                color: .tan
+                color: .b
             )
         )
         XCTAssertEqual(
             action,
             HomeProfileAction.succeedAssignNoteColor(
                 Slashlink("@bob/foo")!,
-                .tan
+                .b
             )
         )
     }

--- a/xcode/Subconscious/SubconsciousTests/Tests_HomeProfile_NotificationActions.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_HomeProfile_NotificationActions.swift
@@ -54,7 +54,7 @@ final class Tests_HomeProfile_NotificationActions: XCTestCase {
         let action = AppAction.from(HomeProfileAction.requestAssignNoteColor(Slashlink("@bob/foo")!, .tan))
         XCTAssertEqual(
             action,
-            AppAction.assignColor(addess: Slashlink("@bob/foo")!, color: .tan)
+            AppAction.assignColor(address: Slashlink("@bob/foo")!, color: .tan)
         )
     }
     

--- a/xcode/Subconscious/SubconsciousTests/Tests_MemoEditorDetailNotification.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_MemoEditorDetailNotification.swift
@@ -39,4 +39,10 @@ final class Tests_MemoEditorDetailNotification: XCTestCase {
         let action = DetailStackAction.tag(notification)
         XCTAssertEqual(action, .requestUpdateAudience(Slashlink("/foo")!, .public))
     }
+    
+    func testForwardRequestAssignNoteColor() throws {
+        let notification = MemoEditorDetailNotification.from(.forwardRequestAssignNoteColor(address: Slashlink("/foo")!, .tan))!
+        let action = DetailStackAction.tag(notification)
+        XCTAssertEqual(action, .requestAssignNoteColor(Slashlink("/foo")!, .tan))
+    }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_MemoEditorDetailNotification.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_MemoEditorDetailNotification.swift
@@ -41,8 +41,8 @@ final class Tests_MemoEditorDetailNotification: XCTestCase {
     }
     
     func testForwardRequestAssignNoteColor() throws {
-        let notification = MemoEditorDetailNotification.from(.forwardRequestAssignNoteColor(address: Slashlink("/foo")!, .tan))!
+        let notification = MemoEditorDetailNotification.from(.forwardRequestAssignNoteColor(address: Slashlink("/foo")!, .a))!
         let action = DetailStackAction.tag(notification)
-        XCTAssertEqual(action, .requestAssignNoteColor(Slashlink("/foo")!, .tan))
+        XCTAssertEqual(action, .requestAssignNoteColor(Slashlink("/foo")!, .a))
     }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_NotebookDetailStackCursor.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_NotebookDetailStackCursor.swift
@@ -59,4 +59,14 @@ final class Tests_NotebookDetailStackCursor: XCTestCase {
             NotebookAction.requestUpdateAudience(Slashlink("@bob/foo")!, .public)
         )
     }
+    
+    func testTagRequestAssignNoteColor() throws {
+        let action = NotebookDetailStackCursor.tag(
+            .requestAssignNoteColor(Slashlink("@bob/foo")!, .tan)
+        )
+        XCTAssertEqual(
+            action,
+            NotebookAction.requestAssignNoteColor(Slashlink("@bob/foo")!, .tan)
+        )
+    }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_NotebookDetailStackCursor.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_NotebookDetailStackCursor.swift
@@ -62,11 +62,11 @@ final class Tests_NotebookDetailStackCursor: XCTestCase {
     
     func testTagRequestAssignNoteColor() throws {
         let action = NotebookDetailStackCursor.tag(
-            .requestAssignNoteColor(Slashlink("@bob/foo")!, .tan)
+            .requestAssignNoteColor(Slashlink("@bob/foo")!, .c)
         )
         XCTAssertEqual(
             action,
-            NotebookAction.requestAssignNoteColor(Slashlink("@bob/foo")!, .tan)
+            NotebookAction.requestAssignNoteColor(Slashlink("@bob/foo")!, .c)
         )
     }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_NotebookUpdate.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_NotebookUpdate.swift
@@ -37,19 +37,19 @@ class Tests_NotebookUpdate: XCTestCase {
                     did: Did.dummyData(),
                     address: a,
                     excerpt: Subtext(markup: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris fermentum orci quis lorem semper porta. Integer sem eros, ultricies et risus id, congue tristique libero."),
-                    modified: Date.now
+                    headers: .emptySubtext
                 ),
                 EntryStub(
                     did: Did.dummyData(),
                     address: b,
                     excerpt: Subtext(markup: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris fermentum orci quis lorem semper porta. Integer sem eros, ultricies et risus id, congue tristique libero."),
-                    modified: Date.now
+                    headers: .emptySubtext
                 ),
                 EntryStub(
                     did: Did.dummyData(),
                     address: c,
                     excerpt: Subtext(markup: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris fermentum orci quis lorem semper porta. Integer sem eros, ultricies et risus id, congue tristique libero."),
-                    modified: Date.now
+                    headers: .emptySubtext
                 )
             ]
         )

--- a/xcode/Subconscious/SubconsciousTests/Tests_Notebook_NotificationActions.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Notebook_NotificationActions.swift
@@ -51,10 +51,10 @@ final class Tests_Notebook_NotificationActions: XCTestCase {
     }
     
     func testRequestAssignNoteColor() throws {
-        let action = AppAction.from(NotebookAction.requestAssignNoteColor(Slashlink("@bob/foo")!, .tan))
+        let action = AppAction.from(NotebookAction.requestAssignNoteColor(Slashlink("@bob/foo")!, .a))
         XCTAssertEqual(
             action,
-            AppAction.assignColor(address: Slashlink("@bob/foo")!, color: .tan)
+            AppAction.assignColor(address: Slashlink("@bob/foo")!, color: .a)
         )
     }
     
@@ -115,14 +115,14 @@ final class Tests_Notebook_NotificationActions: XCTestCase {
         let action = NotebookAction.from(
             .succeedAssignNoteColor(
                 address: Slashlink("@bob/foo")!,
-                color: .tan
+                color: .a
             )
         )
         XCTAssertEqual(
             action,
             NotebookAction.succeedAssignNoteColor(
                 Slashlink("@bob/foo")!,
-                .tan
+                .a
             )
         )
     }

--- a/xcode/Subconscious/SubconsciousTests/Tests_Notebook_NotificationActions.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Notebook_NotificationActions.swift
@@ -50,6 +50,14 @@ final class Tests_Notebook_NotificationActions: XCTestCase {
         )
     }
     
+    func testRequestAssignNoteColor() throws {
+        let action = AppAction.from(NotebookAction.requestAssignNoteColor(Slashlink("@bob/foo")!, .tan))
+        XCTAssertEqual(
+            action,
+            AppAction.assignColor(addess: Slashlink("@bob/foo")!, color: .tan)
+        )
+    }
+    
     func testSucceedSaveEntry() throws {
         let time = Date.now
         let action = NotebookAction.from(.succeedSaveEntry(address: Slashlink("@bob/foo")!, modified: time))
@@ -100,6 +108,22 @@ final class Tests_Notebook_NotificationActions: XCTestCase {
         XCTAssertEqual(
             action,
             NotebookAction.succeedUpdateAudience(receipt)
+        )
+    }
+    
+    func testSucceedAssignNoteColor() throws {
+        let action = NotebookAction.from(
+            .succeedAssignNoteColor(
+                address: Slashlink("@bob/foo")!,
+                color: .tan
+            )
+        )
+        XCTAssertEqual(
+            action,
+            NotebookAction.succeedAssignNoteColor(
+                Slashlink("@bob/foo")!,
+                .tan
+            )
         )
     }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_Notebook_NotificationActions.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Notebook_NotificationActions.swift
@@ -54,7 +54,7 @@ final class Tests_Notebook_NotificationActions: XCTestCase {
         let action = AppAction.from(NotebookAction.requestAssignNoteColor(Slashlink("@bob/foo")!, .tan))
         XCTAssertEqual(
             action,
-            AppAction.assignColor(addess: Slashlink("@bob/foo")!, color: .tan)
+            AppAction.assignColor(address: Slashlink("@bob/foo")!, color: .tan)
         )
     }
     


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/1061

- Store color as header
- Allow updating color from metasheet
- Read headers from DB
- Refresh all views when color changes
- Add color to `WellKnownHeaders`

This change dials back the use of color in the editor/viewer in anticipation of the next chunk of work: designing the mini-editor & full editor using card styles.

https://github.com/subconsciousnetwork/subconscious/assets/5009316/84505a31-78bb-47e1-bfbe-924cfa59d60d