### PR TITLE
Render names in authorization list

### DIFF
--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -524,9 +524,15 @@ actor NoosphereService:
         }
     }
     
-    func listAuthorizations() async throws -> [Authorization] {
+    func listAuthorizations() async throws -> [NamedAuthorization] {
         try await errorLoggingService.capturing {
             try await sphere().listAuthorizations()
+        }
+    }
+    
+    func authorizationName(authorization: Authorization) async throws -> String {
+        try await errorLoggingService.capturing {
+            try await sphere().authorizationName(authorization: authorization)
         }
     }
     

--- a/xcode/Subconscious/SubconsciousTests/Tests_Sphere.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Sphere.swift
@@ -552,6 +552,9 @@ final class Tests_Sphere: XCTestCase {
             })
         )
         
+        let name = try await sphere.authorizationName(authorization: authorization)
+        XCTAssertEqual(name, "ben")
+        
         let verified = try await sphere.verify(authorization: authorization)
         XCTAssertTrue(verified)
         

--- a/xcode/Subconscious/SubconsciousTests/Tests_Sphere.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Sphere.swift
@@ -546,7 +546,11 @@ final class Tests_Sphere: XCTestCase {
         
         let authorizations = try await sphere.listAuthorizations()
         XCTAssertEqual(authorizations.count, 2)
-        XCTAssertTrue(authorizations.contains(where: { auth in auth == authorization }))
+        XCTAssertTrue(
+            authorizations.contains(where: {
+                auth in auth.authorization == authorization && auth.name == "ben"
+            })
+        )
         
         let verified = try await sphere.verify(authorization: authorization)
         XCTAssertTrue(verified)
@@ -560,7 +564,7 @@ final class Tests_Sphere: XCTestCase {
         
         let authorizations2 = try await sphere.listAuthorizations()
         XCTAssertEqual(authorizations2.count, 1)
-        XCTAssertFalse(authorizations2.contains(where: { auth in auth == authorization }))
+        XCTAssertFalse(authorizations2.contains(where: { auth in auth.authorization == authorization }))
         
     }
 }


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/1060

- Fetch name of authorizations
- Render in list view
- Move to `.contextMenu` for revocation and sharing

https://github.com/subconsciousnetwork/subconscious/assets/5009316/ddb7206d-45b1-40bb-9cec-d891a41a55a8


