### PR TITLE
Log key activities in SQLite

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -531,10 +531,6 @@ enum FirstRunStep: Hashable {
     case done
 }
 
-enum SystemActivityEventType: String {
-    case succeedIndexPeer = "succeed_index_peer"
-}
-
 // MARK: Model
 struct AppModel: ModelProtocol {
     /// Has first run completed?
@@ -3001,6 +2997,11 @@ struct AppModel: ModelProtocol {
         return Update(state: state, fx: fx)
     }
     
+    struct SucceedSaveEntryActivityEvent: Codable {
+        public static let event = "save_entry"
+        public let address: String
+    }
+    
     static func succeedSaveEntry(
         state: Self,
         environment: AppEnvironment,
@@ -3010,12 +3011,10 @@ struct AppModel: ModelProtocol {
         let fx: Fx<AppAction> = Future.detached {
             try environment.database.writeActivity(
                 event: ActivityEvent(
-                    category: .note,
-                    event: "save_note",
+                    category: .system,
+                    event: SucceedSaveEntryActivityEvent.event,
                     message: "",
-                    metadata: DeckActivityEvent(
-                        address: address.description
-                    )
+                    metadata: SucceedSaveEntryActivityEvent(address: address.description)
                 )
             )
             

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -531,6 +531,10 @@ enum FirstRunStep: Hashable {
     case done
 }
 
+enum SystemActivityEventType: String {
+    case succeedIndexPeer = "succeed_index_peer"
+}
+
 // MARK: Model
 struct AppModel: ModelProtocol {
     /// Has first run completed?

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -2084,23 +2084,6 @@ struct AppModel: ModelProtocol {
         var model = state
         model.lastGatewaySyncStatus = .failed(error)
         
-        let fx: Fx<AppAction> = Future.detached {
-            try environment.database.writeActivity(
-                event: ActivityEvent(
-                    category: .system,
-                    event: "sync_failed",
-                    message: error,
-                    metadata: ""
-                )
-            )
-            
-            return .succeedLogActivity
-        }
-        .recover { error in
-            .failLogActivity(error.localizedDescription)
-        }
-        .eraseToAnyPublisher()
-        
         return update(
             state: model,
             actions: [
@@ -2113,9 +2096,7 @@ struct AppModel: ModelProtocol {
                 )
             ],
             environment: environment
-        )
-        .animation()
-        .mergeFx(fx)
+        ).animation()
     }
 
     static func indexOurSphere(

--- a/xcode/Subconscious/Shared/Components/Deck/DeckView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/DeckView.swift
@@ -588,8 +588,10 @@ struct DeckModel: ModelProtocol {
         }
        
         
-        enum DeckEventType: String {
-            case chooseCard = "choose_card"
+        struct ChooseCardActivityEvent: Codable {
+            public static let event: String = "choose_card"
+            
+            let address: String
         }
         
         func shuffleInBacklinks(message: String, address: Slashlink, backlinks: Set<EntryStub>) -> Update<Self> {
@@ -599,9 +601,9 @@ struct DeckModel: ModelProtocol {
                 try environment.database.writeActivity(
                     event: ActivityEvent(
                         category: .deck,
-                        event: DeckEventType.chooseCard.rawValue,
+                        event: ChooseCardActivityEvent.event,
                         message: message,
-                        metadata: DeckActivityEvent(
+                        metadata: ChooseCardActivityEvent(
                             address: address.description
                         )
                     )
@@ -834,8 +836,4 @@ struct DeckModel: ModelProtocol {
             return state.deck.contains(where: { entry in entry == entry })
         }
     }
-}
-
-struct DeckActivityEvent: Codable {
-    public let address: String
 }

--- a/xcode/Subconscious/Shared/Models/ActivityEvent.swift
+++ b/xcode/Subconscious/Shared/Models/ActivityEvent.swift
@@ -1,0 +1,22 @@
+//
+//  ActivityEvent.swift
+//  Subconscious (iOS)
+//
+//  Created by Ben Follington on 10/1/2024.
+//
+
+import Foundation
+
+struct ActivityEvent<Metadata: Codable>: Codable {
+    let category: ActivityEventCategory
+    let event: String
+    let message: String
+    let metadata: Metadata?
+}
+
+enum ActivityEventCategory: String, Codable {
+    case system = "system"
+    case deck = "deck"
+    case note = "note"
+    case addressBook = "addressBook"
+}

--- a/xcode/Subconscious/Shared/Services/AddressBookService.swift
+++ b/xcode/Subconscious/Shared/Services/AddressBookService.swift
@@ -29,11 +29,6 @@ enum AddressBookError: Error {
     case other(String)
 }
 
-enum AddressBookActivityEventType: String {
-    case followUser = "follow_user"
-    case unfollowUser = "unfollow_user"
-}
-
 extension AddressBookError: LocalizedError {
     var errorDescription: String? {
         switch self {
@@ -330,6 +325,13 @@ actor AddressBookService {
         .eraseToAnyPublisher()
     }
     
+    struct FollowUserActivityEvent: Codable {
+        public static let event: String = "follow_user"
+        
+        let did: String
+        let petname: String
+    }
+    
     /// Associates the passed DID with the passed petname within the sphere,
     /// saves the changes and updates the database.
     func followUser(
@@ -353,9 +355,9 @@ actor AddressBookService {
         try database.writeActivity(
             event: ActivityEvent(
                 category: .addressBook,
-                event: AddressBookActivityEventType.followUser.rawValue,
-                message: "",
-                metadata: AddressBookActivityEventMetadata(
+                event: FollowUserActivityEvent.event,
+                message: "Followed \(petname.markup)",
+                metadata: FollowUserActivityEvent(
                     did: did.did.description,
                     petname: petname.description
                 )
@@ -438,6 +440,13 @@ actor AddressBookService {
         .eraseToAnyPublisher()
     }
     
+    struct UnfollowUserActivityEvent: Codable {
+        public static let event: String = "unfollow_user"
+        
+        let did: String
+        let petname: String
+    }
+    
     /// Disassociates the passed Petname from any DID within the sphere,
     /// saves the changes and updates the database.
     func unfollowUser(petname: Petname) async throws -> Did {
@@ -448,9 +457,9 @@ actor AddressBookService {
         try database.writeActivity(
             event: ActivityEvent(
                 category: .addressBook,
-                event: AddressBookActivityEventType.unfollowUser.rawValue,
-                message: "",
-                metadata: AddressBookActivityEventMetadata(
+                event: UnfollowUserActivityEvent.event,
+                message: "Unfollowed \(petname.markup)",
+                metadata: UnfollowUserActivityEvent(
                     did: did.description,
                     petname: petname.description
                 )

--- a/xcode/Subconscious/Shared/Services/AddressBookService.swift
+++ b/xcode/Subconscious/Shared/Services/AddressBookService.swift
@@ -29,6 +29,11 @@ enum AddressBookError: Error {
     case other(String)
 }
 
+enum AddressBookActivityEventType: String {
+    case followUser = "follow_user"
+    case unfollowUser = "unfollow_user"
+}
+
 extension AddressBookError: LocalizedError {
     var errorDescription: String? {
         switch self {
@@ -347,10 +352,10 @@ actor AddressBookService {
         
         try database.writeActivity(
             event: ActivityEvent(
-                category: .peer,
-                event: "follow_peer",
+                category: .addressBook,
+                event: AddressBookActivityEventType.followUser.rawValue,
                 message: "",
-                metadata: FollowPeerActivityEvent(
+                metadata: AddressBookActivityEventMetadata(
                     did: did.did.description,
                     petname: petname.description
                 )
@@ -358,7 +363,7 @@ actor AddressBookService {
         )
     }
     
-    struct FollowPeerActivityEvent: Codable {
+    struct AddressBookActivityEventMetadata: Codable {
         let did: String
         let petname: String
     }
@@ -442,10 +447,10 @@ actor AddressBookService {
         
         try database.writeActivity(
             event: ActivityEvent(
-                category: .peer,
-                event: "unfollow_peer",
+                category: .addressBook,
+                event: AddressBookActivityEventType.unfollowUser.rawValue,
                 message: "",
-                metadata: FollowPeerActivityEvent(
+                metadata: AddressBookActivityEventMetadata(
                     did: did.description,
                     petname: petname.description
                 )

--- a/xcode/Subconscious/Shared/Services/AddressBookService.swift
+++ b/xcode/Subconscious/Shared/Services/AddressBookService.swift
@@ -344,6 +344,23 @@ actor AddressBookService {
         
         try await noosphere.setPetname(did: did, petname: petname)
         let _ = try await noosphere.save()
+        
+        try database.writeActivity(
+            event: ActivityEvent(
+                category: .peer,
+                event: "follow_peer",
+                message: "",
+                metadata: FollowPeerActivityEvent(
+                    did: did.did.description,
+                    petname: petname.description
+                )
+            )
+        )
+    }
+    
+    struct FollowPeerActivityEvent: Codable {
+        let did: String
+        let petname: String
     }
     
     func resolutionStatus(petname: Petname) async throws -> ResolutionStatus {
@@ -422,6 +439,19 @@ actor AddressBookService {
         let did = try await self.noosphere.getPetname(petname: petname)
         try await self.addressBook.unsetPetname(petname: petname)
         let _ = try await self.noosphere.save()
+        
+        try database.writeActivity(
+            event: ActivityEvent(
+                category: .peer,
+                event: "unfollow_peer",
+                message: "",
+                metadata: FollowPeerActivityEvent(
+                    did: did.description,
+                    petname: petname.description
+                )
+            )
+        )
+        
         return did
     }
     

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -249,9 +249,9 @@ actor DataService {
                 
                 try database.writeActivity(
                     event: ActivityEvent(
-                        category: .peer,
-                        event: "index_peer",
-                        message: "",
+                        category: .system,
+                        event: SystemActivityEventType.succeedIndexPeer.rawValue,
+                        message: "Found \(changeCount) updates from \(petname.markup)",
                         metadata: PeerIndexActivityEvent(
                             did: peer.identity.description,
                             petname: petname.description,

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -223,7 +223,8 @@ actor DataService {
         )
     }
     
-    struct PeerIndexActivityEvent: Codable {
+    struct SucceedIndexPeerActivityEvent: Codable {
+        public static let event = "succeed_index_peer"
         let did: String
         let petname: String
         let changes: Int
@@ -250,9 +251,9 @@ actor DataService {
                 try database.writeActivity(
                     event: ActivityEvent(
                         category: .system,
-                        event: SystemActivityEventType.succeedIndexPeer.rawValue,
+                        event: SucceedIndexPeerActivityEvent.event,
                         message: "Found \(changeCount) updates from \(petname.markup)",
-                        metadata: PeerIndexActivityEvent(
+                        metadata: SucceedIndexPeerActivityEvent(
                             did: peer.identity.description,
                             petname: petname.description,
                             changes: changeCount

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -118,7 +118,7 @@ actor DataService {
     /// - If sphere has not been indexed, we get everything, and update
     func indexPeer(
         petname: Petname
-    ) async throws -> PeerRecord {
+    ) async throws -> (Int, PeerRecord) {
         let sphere = try await noosphere.traverse(petname: petname)
         let identity = try await sphere.identity()
         logger.log(
@@ -147,6 +147,7 @@ actor DataService {
         
         let savepoint = "index_peer"
         try database.savepoint(savepoint)
+        
         do {
             for change in changes {
                 let slashlink = Slashlink(slug: change)
@@ -212,11 +213,20 @@ actor DataService {
             )
             throw error
         }
-        return PeerRecord(
-            petname: petname,
-            identity: identity,
-            since: version
+        return (
+            changes.count,
+            PeerRecord(
+                petname: petname,
+                identity: identity,
+                since: version
+            )
         )
+    }
+    
+    struct PeerIndexActivityEvent: Codable {
+        let did: String
+        let petname: String
+        let changes: Int
     }
     
     func indexPeers(petnames: [Petname]) async -> [PeerIndexResult] {
@@ -231,11 +241,25 @@ actor DataService {
             )
             
             do {
-                let peer = try await self.indexPeer(
+                let (changeCount, peer) = try await self.indexPeer(
                     petname: petname
                 )
                 
                 results.append(.success(peer))
+                
+                try database.writeActivity(
+                    event: ActivityEvent(
+                        category: .peer,
+                        event: "index_peer",
+                        message: "",
+                        metadata: PeerIndexActivityEvent(
+                            did: peer.identity.description,
+                            petname: petname.description,
+                            changes: changeCount
+                        )
+                    )
+                )
+                
                 // Give other tasks a chance to use noosphere, indexing many peers
                 // can take a long time and potentially block user actions
                 await Task.yield()

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -1391,39 +1391,6 @@ final class DatabaseService {
             ]
         )
     }
-    
-    func writeActivity(category: String, event: String, message: String, metadata: String?) throws {
-        guard self.state == .ready else {
-            return
-        }
-        
-        try database.execute(
-            sql: """
-            INSERT INTO activity (category, event, message, metadata)
-            VALUES (?, ?, ?, ?)
-            """,
-            parameters: [
-                .text(category),
-                .text(event),
-                .text(message),
-                .text(metadata)
-            ]
-        )
-    }
-}
-
-struct ActivityEvent<Data: Codable>: Codable {
-    let category: ActivityEventCategory
-    let event: String
-    let message: String
-    let metadata: Data?
-}
-
-enum ActivityEventCategory: String, Codable {
-    case system = "system"
-    case deck = "deck"
-    case note = "note"
-    case addressBook = "addressBook"
 }
 
 // MARK: Migrations
@@ -1611,6 +1578,7 @@ extension Config {
         SQLMigration(
             version: Int.from(iso8601String: "2024-01-10T11:59:00")!,
             sql: """
+            /* Tracks `ActivityEvent`s in a queryable stream */
             CREATE TABLE activity
             (
                 id       INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -1555,6 +1555,20 @@ extension Config {
                 );
             END;
             """
+        ),
+        SQLMigration(
+            version: Int.from(iso8601String: "2024-01-10T11:59:00")!,
+            sql: """
+            CREATE TABLE activity
+            (
+                id       INTEGER PRIMARY KEY AUTOINCREMENT,
+                category TEXT                           NOT NULL,
+                event    TEXT                           NOT NULL,
+                message  TEXT DEFAULT ''                NOT NULL,
+                metadata TEXT DEFAULT '{}'              NOT NULL,
+                created  TEXT DEFAULT CURRENT_TIMESTAMP NOT NULL
+            );
+            """
         )
     ])
 }

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -1423,7 +1423,7 @@ enum ActivityEventCategory: String, Codable {
     case system = "system"
     case deck = "deck"
     case note = "note"
-    case peer = "peer"
+    case addressBook = "addressBook"
 }
 
 // MARK: Migrations

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		B58FD6732A4E4C0E00826548 /* InviteCodeSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58FD6722A4E4C0E00826548 /* InviteCodeSettingsSection.swift */; };
 		B58FD6752A4E4C8200826548 /* ResourceSyncBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58FD6742A4E4C8200826548 /* ResourceSyncBadge.swift */; };
 		B5908BEB29DAB05B00225B1A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5908BEA29DAB05B00225B1A /* TestUtilities.swift */; };
+		B597C7372B4E34DB003F4342 /* ActivityEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B597C7362B4E34DA003F4342 /* ActivityEvent.swift */; };
 		B59D556329BBFF56007915E2 /* FormField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59D556229BBFF56007915E2 /* FormField.swift */; };
 		B59E4E572B3BA781000A2B49 /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59E4E562B3BA781000A2B49 /* CardView.swift */; };
 		B59E4E592B3BA8E7000A2B49 /* EntryCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59E4E582B3BA8E7000A2B49 /* EntryCardView.swift */; };
@@ -629,6 +630,7 @@
 		B58FD6722A4E4C0E00826548 /* InviteCodeSettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteCodeSettingsSection.swift; sourceTree = "<group>"; };
 		B58FD6742A4E4C8200826548 /* ResourceSyncBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceSyncBadge.swift; sourceTree = "<group>"; };
 		B5908BEA29DAB05B00225B1A /* TestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUtilities.swift; sourceTree = "<group>"; };
+		B597C7362B4E34DA003F4342 /* ActivityEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityEvent.swift; sourceTree = "<group>"; };
 		B59D556229BBFF56007915E2 /* FormField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormField.swift; sourceTree = "<group>"; };
 		B59E4E562B3BA781000A2B49 /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
 		B59E4E582B3BA8E7000A2B49 /* EntryCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryCardView.swift; sourceTree = "<group>"; };
@@ -1441,6 +1443,7 @@
 				B5E816B82AB0458E00C61500 /* RecoveryPhrase.swift */,
 				B51359292AC2723E004385A7 /* GatewayURL.swift */,
 				B5EC3A4E2B297DBA00FDF728 /* Prompt.swift */,
+				B597C7362B4E34DA003F4342 /* ActivityEvent.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -2167,6 +2170,7 @@
 				B542EF772AF495F200BE29F1 /* FollowNewUserSheetModifier.swift in Sources */,
 				B8A617202971D3000054D410 /* Slashlink.swift in Sources */,
 				B81EACD827B724A000B3B8DC /* ThickDividerView.swift in Sources */,
+				B597C7372B4E34DB003F4342 /* ActivityEvent.swift in Sources */,
 				B5F68F602A09F7E200CE4DD7 /* StackedGlowingImage.swift in Sources */,
 				B58862C829F612CE006C2EE4 /* EditProfileSheet.swift in Sources */,
 				B828F0A32AFFF05800FDE4AE /* TranscludeListView.swift in Sources */,

--- a/xcode/Subconscious/SubconsciousTests/Tests_DatabaseService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DatabaseService.swift
@@ -1332,7 +1332,7 @@ class Tests_DatabaseService: XCTestCase {
         let foo: String
     }
     
-    func testWriteActivity() async throws {
+    func testWriteActivity() throws {
         let service = try createDatabaseService()
         _ = try service.migrate()
         
@@ -1347,27 +1347,14 @@ class Tests_DatabaseService: XCTestCase {
             )
         )
         
-        try? await Task.sleep(for: .seconds(0.5))
-        
-        try service.writeActivity(
-            event: ActivityEvent(
-                category: .system,
-                event: "test_event",
-                message: "test_message 2",
-                metadata: TestMetadata(
-                    foo: "bar 2"
-                )
-            )
-        )
-        
         let activities: [ActivityEvent<TestMetadata>] = try service.listActivityEventType(eventType: "test_event")
         
-        XCTAssertEqual(activities.count, 2)
+        XCTAssertEqual(activities.count, 1)
         let lastActivity = activities.first!
         
         XCTAssertEqual(lastActivity.category, .system)
         XCTAssertEqual(lastActivity.event, "test_event")
-        XCTAssertEqual(lastActivity.message, "test_message 2")
-        XCTAssertEqual(lastActivity.metadata, TestMetadata(foo: "bar 2"))
+        XCTAssertEqual(lastActivity.message, "test_message")
+        XCTAssertEqual(lastActivity.metadata, TestMetadata(foo: "bar"))
     }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_DatabaseService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DatabaseService.swift
@@ -1332,7 +1332,7 @@ class Tests_DatabaseService: XCTestCase {
         let foo: String
     }
     
-    func testWriteActivity() throws {
+    func testWriteActivity() async throws {
         let service = try createDatabaseService()
         _ = try service.migrate()
         
@@ -1346,6 +1346,8 @@ class Tests_DatabaseService: XCTestCase {
                 )
             )
         )
+        
+        try? await Task.sleep(for: .seconds(0.5))
         
         try service.writeActivity(
             event: ActivityEvent(

--- a/xcode/Subconscious/SubconsciousTests/Tests_Migrations.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Migrations.swift
@@ -9,6 +9,13 @@ import XCTest
 @testable import Subconscious
 
 final class Tests_Migrations: XCTestCase {
+    func testAppMigrations() throws {
+        let migrations = Config.migrations
+        let db = SQLite3Database(path: ":memory:")
+        let version = try migrations.migrate(db)
+        XCTAssertEqual(version, migrations.migrations.last?.version)
+    }
+    
     func testMigrationMigrate() throws {
         let v1 = SQLMigration(
             version: 1,


### PR DESCRIPTION
Trying not to over engineer anything here.

- Create a new `activity` SQLite table
- Log events we may be interested in responding to / surfacing:
    - Swipe choices in Deck view (step towards https://github.com/subconsciousnetwork/subconscious/issues/1023)
    - Follow / unfollow user actions
    - Index complete + how many changes

As mentioned above, this is a step towards offering more sophisticated behaviour in the Deck view over multiple sessions but it could also let us offer an "activity" view in the app where you can see updates like "`@gordon` published 4 notes".

https://github.com/subconsciousnetwork/subconscious/assets/5009316/c05dbb91-d3fa-47b1-bdff-60081f8761a0