### PR TITLE
Tap tab button again to scroll to top

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListView.swift
@@ -21,7 +21,9 @@ struct EntryListView: View {
         if let entries = entries {
             if entries.count > 0 {
                 List {
-                    ForEach(entries) { entry in
+                    ForEach(entries.indices, id: \.self) { idx in
+                        let entry = entries[idx]
+                        
                         Button(
                             action: {
                                 onEntryPress(entry)
@@ -35,6 +37,7 @@ struct EntryListView: View {
                                 onLink: onLink
                             )
                         }
+                        .id(idx)
                         .buttonStyle(
                             EntryListRowButtonStyle(
                                 color: entry.color(

--- a/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListView.swift
@@ -16,11 +16,15 @@ struct EntryListView: View {
     var onLink: (EntryLink) -> Void
     
     @Environment(\.colorScheme) var colorScheme
+    static let resetScrollTargetId: Int = 0
 
     var body: some View {
         if let entries = entries {
             if entries.count > 0 {
                 List {
+                    // invisible marker to scroll back to
+                    EmptyView().id(Self.resetScrollTargetId)
+                    
                     ForEach(entries.indices, id: \.self) { idx in
                         let entry = entries[idx]
                         
@@ -37,7 +41,6 @@ struct EntryListView: View {
                                 onLink: onLink
                             )
                         }
-                        .id(idx)
                         .buttonStyle(
                             EntryListRowButtonStyle(
                                 color: entry.color(

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -176,6 +176,7 @@ struct UserProfileView: View {
                                 )
                             }
                         )
+                        .id(0)
                         .disabled(state.loadingState != .loaded)
                         .padding(
                             .init([.top, .horizontal]),

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -115,6 +115,8 @@ struct UserProfileView: View {
     @ObservedObject var app: Store<AppModel>
     @ObservedObject var store: Store<UserProfileDetailModel>
     
+    static let resetScrollTargetId: Int = 0
+    
     private var state: UserProfileDetailModel {
         store.state
     }
@@ -176,7 +178,7 @@ struct UserProfileView: View {
                                 )
                             }
                         )
-                        .id(0)
+                        .id(Self.resetScrollTargetId)
                         .disabled(state.loadingState != .loaded)
                         .padding(
                             .init([.top, .horizontal]),

--- a/xcode/Subconscious/Shared/Components/Deck/CardStackView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/CardStackView.swift
@@ -207,10 +207,6 @@ struct CardStack: View {
         }
     }
     
-    var enumeratedDeck: [EnumeratedSequence<[CardModel]>.Element] {
-        Array(deck.enumerated())
-    }
-    
     func effects(card: CardModel, stackFactor: CGFloat, focused: Bool) -> CardEffectModifier {
         CardEffectModifier(
             stackFactor: stackFactor,
@@ -287,8 +283,9 @@ struct CardStack: View {
             Spacer()
             GeometryReader { geo in
                 ZStack {
-                    ForEach(enumeratedDeck, id: \.element.id) {
-                        index, card in
+                    ForEach(deck.indices, id: \.self) { index in
+                        let card = deck[index]
+                        
                         if (index >= current - 1 && index < current + 4) {
                             innerCard(size: geo.size, index: index, card: card)
                         }

--- a/xcode/Subconscious/Shared/Components/Deck/DeckView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/DeckView.swift
@@ -78,6 +78,7 @@ struct DeckView: View {
 // MARK: Actions
 enum DeckAction: Hashable {
     case requestDeckRoot
+    case requestDiscardDeck
     case detailStack(DetailStackAction)
     
     case setSearchPresented(Bool)
@@ -290,8 +291,8 @@ struct DeckModel: ModelProtocol {
             )
         case .appear:
             return appear(state: state, environment: environment)
-        case .refreshDeck:
-            return refreshDeck(state: state, environment: environment)
+        case .refreshDeck, .requestDiscardDeck:
+            return discardAndRedrawDeck(state: state, environment: environment)
         case .topupDeck:
             return topupDeck(state: state, environment: environment)
         case let .setDeck(deck, startIndex):
@@ -404,7 +405,7 @@ struct DeckModel: ModelProtocol {
             return Update(state: state)
         }
         
-        func refreshDeck(
+        func discardAndRedrawDeck(
             state: Self,
             environment: Environment
         ) -> Update<Self> {
@@ -412,6 +413,8 @@ struct DeckModel: ModelProtocol {
             model.loadingStatus = .loading
             
             let fx: Fx<DeckAction> = Future.detached {
+                try? await Task.sleep(for: .seconds(Duration.loading))
+                
                 let us = try await environment.noosphere.identity()
                 let recent = try environment.database.listFeed(owner: us)
                 
@@ -447,7 +450,7 @@ struct DeckModel: ModelProtocol {
             .recover({ error in .setDeck([]) })
             .eraseToAnyPublisher()
             
-            return Update(state: model, fx: fx)
+            return Update(state: model, fx: fx).animation(.easeOutCubic())
         }
         
         func refreshUpcomingCards(
@@ -719,6 +722,11 @@ struct DeckModel: ModelProtocol {
             state: Self,
             environment: AppEnvironment
         ) -> Update<Self> {
+            if state.detailStack.details.isEmpty {
+                let fx: Fx<DeckAction> = Just(.requestDiscardDeck).eraseToAnyPublisher()
+                return Update(state: state, fx: fx)
+            }
+            
             return DeckDetailStackCursor.update(
                 state: state,
                 action: .setDetails([]),

--- a/xcode/Subconscious/Shared/Components/HomeProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/HomeProfileView.swift
@@ -43,7 +43,7 @@ struct HomeProfileNavigationView: View {
                 .onReceive(store.actions) { action in
                     switch action {
                     case .requestScrollToTop:
-                        withAnimation(.easeInOut(duration: Duration.normal)) {
+                        withAnimation(.resetScroll) {
                             proxy.scrollTo(0, anchor: .top)
                         }
                     default:

--- a/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
@@ -847,7 +847,6 @@ struct NotebookModel: ModelProtocol {
     ) -> Update<NotebookModel> {
         if state.details.isEmpty {
             let fx: Fx<NotebookAction> = Just(.requestScrollToTop).eraseToAnyPublisher()
-            
             return Update(state: state, fx: fx)
         }
         

--- a/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
@@ -165,6 +165,7 @@ enum NotebookAction: Hashable {
     case activatedSuggestion(Suggestion)
     
     case requestNotebookRoot
+    case requestScrollToTop
     
     /// Set search query
     static func setSearch(_ query: String) -> NotebookAction {
@@ -502,7 +503,7 @@ struct NotebookModel: ModelProtocol {
                 environment: environment
             )
         case .requestDeleteEntry, .requestSaveEntry, .requestMoveEntry,
-                .requestMergeEntry, .requestUpdateAudience:
+                .requestMergeEntry, .requestUpdateAudience, .requestScrollToTop:
             return Update(state: state)
         }
     }
@@ -844,6 +845,12 @@ struct NotebookModel: ModelProtocol {
         state: NotebookModel,
         environment: AppEnvironment
     ) -> Update<NotebookModel> {
+        if state.details.isEmpty {
+            let fx: Fx<NotebookAction> = Just(.requestScrollToTop).eraseToAnyPublisher()
+            
+            return Update(state: state, fx: fx)
+        }
+        
         return NotebookDetailStackCursor.update(
             state: state,
             action: .setDetails([]),

--- a/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
@@ -92,7 +92,7 @@ struct NotebookNavigationView: View {
                     : DeckTheme.lightBgStart,
                     for: .navigationBar
                 )
-                .onReceive(store.actions, perform: { action in
+                .onReceive(store.actions) { action in
                     switch action {
                     case .requestScrollToTop:
                         withAnimation(.easeInOut(duration: Duration.normal)) {
@@ -101,7 +101,7 @@ struct NotebookNavigationView: View {
                     default:
                         return
                     }
-                })
+                }
             }
         }
     }

--- a/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
@@ -96,7 +96,7 @@ struct NotebookNavigationView: View {
                     switch action {
                     case .requestScrollToTop:
                         withAnimation(.resetScroll) {
-                            proxy.scrollTo(0, anchor: .top)
+                            proxy.scrollTo(EntryListView.resetScrollTargetId, anchor: .top)
                         }
                     default:
                         return

--- a/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
@@ -21,76 +21,88 @@ struct NotebookNavigationView: View {
                 tag: NotebookDetailStackCursor.tag
             )
         ) {
-            VStack(spacing: 0) {
-                EntryListView(
-                    entries: store.state.recent,
-                    onEntryPress: {
-                        entry in
-                        store.send(
-                            .pushDetail(
-                                MemoEditorDetailDescription(
-                                    address: entry.address,
-                                    fallback: entry.excerpt.description
+            ScrollViewReader { proxy in
+                VStack(spacing: 0) {
+                    EntryListView(
+                        entries: store.state.recent,
+                        onEntryPress: {
+                            entry in
+                            store.send(
+                                .pushDetail(
+                                    MemoEditorDetailDescription(
+                                        address: entry.address,
+                                        fallback: entry.excerpt.description
+                                    )
                                 )
                             )
-                        )
-                    },
-                    onEntryDelete: { address in
-                        store.send(.confirmDelete(address))
-                    },
-                    onRefresh: {
-                        app.send(.syncAll)
-                    },
-                    onLink: { link in
-                        store.send(
-                            .detailStack(.findAndPushLinkDetail(link))
-                        )
-                    }
-                )
-                .ignoresSafeArea(.keyboard, edges: .bottom)
-                .confirmationDialog(
-                    "Are you sure you want to delete this note?",
-                    isPresented: Binding(
-                        get: { store.state.isConfirmDeleteShowing },
-                        send: store.send,
-                        tag: NotebookAction.setConfirmDeleteShowing
-                    ),
-                    titleVisibility: .visible,
-                    presenting: store.state.entryToDelete
-                ) { slug in
-                    Button(
-                        role: .destructive,
-                        action: {
-                            store.send(.stageDeleteEntry(slug))
+                        },
+                        onEntryDelete: { address in
+                            store.send(.confirmDelete(address))
+                        },
+                        onRefresh: {
+                            app.send(.syncAll)
+                        },
+                        onLink: { link in
+                            store.send(
+                                .detailStack(.findAndPushLinkDetail(link))
+                            )
                         }
-                    ) {
-                        Text("Delete")
+                    )
+                    .ignoresSafeArea(.keyboard, edges: .bottom)
+                    .confirmationDialog(
+                        "Are you sure you want to delete this note?",
+                        isPresented: Binding(
+                            get: { store.state.isConfirmDeleteShowing },
+                            send: store.send,
+                            tag: NotebookAction.setConfirmDeleteShowing
+                        ),
+                        titleVisibility: .visible,
+                        presenting: store.state.entryToDelete
+                    ) { slug in
+                        Button(
+                            role: .destructive,
+                            action: {
+                                store.send(.stageDeleteEntry(slug))
+                            }
+                        ) {
+                            Text("Delete")
+                        }
                     }
                 }
-            }
-            .navigationTitle("Notes")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                MainToolbar(app: app)
-                
-                ToolbarItemGroup(placement: .principal) {
-                    HStack {
-                        Text("Notes").bold()
-                        CountChip(count: store.state.entryCount)
+                .navigationTitle("Notes")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    MainToolbar(app: app)
+                    
+                    ToolbarItemGroup(placement: .principal) {
+                        HStack {
+                            Text("Notes").bold()
+                            CountChip(count: store.state.entryCount)
+                        }
                     }
                 }
-            }
-            .background(
-                colorScheme == .dark 
+                .background(
+                    colorScheme == .dark
                     ? DeckTheme.darkBg
                     : DeckTheme.lightBg
-            )
-            .toolbarBackground(
-                colorScheme == .dark
+                )
+                .toolbarBackground(
+                    colorScheme == .dark
                     ? DeckTheme.darkBgStart
                     : DeckTheme.lightBgStart,
-                for: .navigationBar
-            )
+                    for: .navigationBar
+                )
+                .onReceive(store.actions, perform: { action in
+                    switch action {
+                    case .requestScrollToTop:
+                        withAnimation(.easeInOut(duration: Duration.normal)) {
+                            proxy.scrollTo(0, anchor: .top)
+                        }
+                    default:
+                        return
+                    }
+                })
+            }
         }
     }
 }

--- a/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
@@ -95,7 +95,7 @@ struct NotebookNavigationView: View {
                 .onReceive(store.actions) { action in
                     switch action {
                     case .requestScrollToTop:
-                        withAnimation(.easeInOut(duration: Duration.normal)) {
+                        withAnimation(.resetScroll) {
                             proxy.scrollTo(0, anchor: .top)
                         }
                     default:

--- a/xcode/Subconscious/Shared/Library/AnimationUtilities.swift
+++ b/xcode/Subconscious/Shared/Library/AnimationUtilities.swift
@@ -34,6 +34,8 @@ extension Duration {
 extension Animation {
     //  Penner curves sourced from
     //  https://matthewlein.com/tools/ceaser
+    
+    static let resetScroll = Animation.easeInOut(duration: Duration.normal)
 
     /// Penner easeOutCubic curve
     static func easeOutCubic(duration: Double = Duration.normal) -> Animation {


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/991

Pretty simple, using `ScrollReaderView` for iOS 16 support but we could clean this up a little using the newer iOS 17 APIs down the line.

- Tap tab button again to scroll to top of lists
- Move away from .enumerated()

https://github.com/subconsciousnetwork/subconscious/assets/5009316/ef31c136-a8f5-4465-ac4f-6c0c5b392140


https://github.com/subconsciousnetwork/subconscious/assets/5009316/0443cf7b-693e-4b6f-bd8d-d071e1f50c3e


