### PR TITLE
Fix: tapping links to drafts could (erroneously) open the viewer instead of the editor

### DIFF
--- a/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
@@ -339,7 +339,7 @@ struct DetailStackModel: Hashable, ModelProtocol {
 
         // If slashlink pointing to our sphere, dispatch findAndPushEditDetail
         // to find in local or sphere content and then push editor detail.
-        guard address.peer != nil else {
+        guard address.peer != nil && !address.isLocal else {
             return update(
                 state: state,
                 action: .findAndPushMemoEditorDetail(

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -49,7 +49,7 @@ extension NoosphereService {
         
         // We _could_ also choose to simply bail out and navigate to the address without
         // traversing, at the expense of the clever redirect.
-        var did: Did? = nil
+        var did = slashlink.toDid()
         if let petname = slashlink.petname {
             did = try? await Func.run {
                 let sphere = try await self.traverse(petname: petname)
@@ -63,7 +63,7 @@ extension NoosphereService {
         }
         
         // Is this address ours? Trim off the peer
-        guard did != ourIdentity else {
+        if did == ourIdentity || did.isLocal {
             return Slashlink(slug: slashlink.slug)
         }
     

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -62,8 +62,13 @@ extension NoosphereService {
             return slashlink
         }
         
+        // Preserve local DID
+        guard !did.isLocal else {
+            return slashlink
+        }
+        
         // Is this address ours? Trim off the peer
-        if did == ourIdentity || did.isLocal {
+        if did == ourIdentity {
             return Slashlink(slug: slashlink.slug)
         }
     

--- a/xcode/Subconscious/SubconsciousTests/Tests_NoosphereService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_NoosphereService.swift
@@ -125,28 +125,13 @@ final class Tests_NoosphereService: XCTestCase {
         XCTAssertEqual(versionC, versionZ)
     }
     
-    func testFindBestLinkAddressNoContext() async throws {
+    func testFindBestLinkAddressUnresolvable() async throws {
         let tmp = try TestUtilities.createTmpDir()
         let data = try await TestUtilities.createDataServiceEnvironment(tmp: tmp)
         
         let _ = try await data.noosphere.createSphere(ownerKeyName: "quick-test")
         
-        try await data.noosphere.write(
-            slug: Slug(
-                "test"
-            )!,
-            contentType: "text/subtext",
-            additionalHeaders: [],
-            body: (
-                "hello"
-            ).toData(
-                encoding: .utf8
-            )!
-        )
-        try await data.noosphere.save()
-        
         let slashlink = Slashlink(petname: Petname("bob.alice")!, slug: Slug("hello")!)
-        let link = SubSlashlinkLink(slashlink: slashlink)
         
         let address = try await data.noosphere.findBestAddressForLink(
             slashlink
@@ -162,27 +147,8 @@ final class Tests_NoosphereService: XCTestCase {
         
         let _ = try await data.noosphere.createSphere(ownerKeyName: "quick-test")
         
-        // Follow a user and attempt to navigate to a link based on them
-        
-        try await data.noosphere.write(
-            slug: Slug(
-                "test"
-            )!,
-            contentType: "text/subtext",
-            additionalHeaders: [],
-            body: (
-                "hello"
-            ).toData(
-                encoding: .utf8
-            )!
-        )
-        try await data.noosphere.save()
-        
-        let friend = Did.dummyData()
         let friendName = Petname("friend")!
-        try await data.addressBook.followUser(did: friend, petname: friendName)
-        
-        let slashlink = Slashlink(slug: Slug("hello")!)
+        let slashlink = Slashlink(peer: .petname(friendName), slug: Slug("hello")!)
         
         let address = try await data.noosphere.findBestAddressForLink(
             slashlink
@@ -190,5 +156,32 @@ final class Tests_NoosphereService: XCTestCase {
        
         XCTAssertEqual(address, slashlink)
     }
-
+    
+    func testFindBestLinkAddressWithDraft() async throws {
+        let tmp = try TestUtilities.createTmpDir()
+        let data = try await TestUtilities.createDataServiceEnvironment(tmp: tmp)
+        
+        let slashlink = Slashlink(peer: .did(.local), slug: Slug("hello")!)
+        
+        let address = try await data.noosphere.findBestAddressForLink(
+            slashlink
+        )
+       
+        XCTAssertEqual(address, Slashlink(slug: Slug("hello")!))
+    }
+    
+    func testFindBestLinkAddressWithOwnNote() async throws {
+        let tmp = try TestUtilities.createTmpDir()
+        let data = try await TestUtilities.createDataServiceEnvironment(tmp: tmp)
+        
+        let did = try await data.noosphere.identity()
+        
+        let slashlink = Slashlink(peer: .did(did), slug: Slug("hello")!)
+        
+        let address = try await data.noosphere.findBestAddressForLink(
+            slashlink
+        )
+       
+        XCTAssertEqual(address, Slashlink(slug: Slug("hello")!))
+    }
 }

--- a/xcode/Subconscious/SubconsciousTests/Tests_NoosphereService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_NoosphereService.swift
@@ -167,7 +167,8 @@ final class Tests_NoosphereService: XCTestCase {
             slashlink
         )
        
-        XCTAssertEqual(address, Slashlink(slug: Slug("hello")!))
+        // Should preserve Did.local
+        XCTAssertEqual(address, slashlink)
     }
     
     func testFindBestLinkAddressWithOwnNote() async throws {
@@ -182,6 +183,7 @@ final class Tests_NoosphereService: XCTestCase {
             slashlink
         )
        
+        // Should drop our DID
         XCTAssertEqual(address, Slashlink(slug: Slug("hello")!))
     }
 }


### PR DESCRIPTION
Our `findBestLink` function was not considering `Did.local` as a possibility. Updated the code + tests to cover these cases.

I found this in-app in two places:
1. tapping a draft in the deck view opens in the viewer (uneditable)
2. tapping a backlink to a draft (in the related notes section) opened the viewer