### PR TITLE
Make "Quote" action available from everywhere

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListView.swift
@@ -14,6 +14,7 @@ struct EntryListView: View {
     var onEntryDelete: (Slashlink) -> Void
     var onRefresh: () -> Void
     var onLink: (EntryLink) -> Void
+    var onQuote: (Slashlink) -> Void
     
     @Environment(\.colorScheme) var colorScheme
     static let resetScrollTargetId: Int = 0
@@ -61,6 +62,35 @@ struct EntryListView: View {
                                 Text("Delete")
                             }
                             .tint(.red)
+                        }
+                        .contextMenu {
+                            ShareLink(item: entry.sharedText)
+                            
+                            Button(
+                                action: {
+                                    onQuote(entry.address)
+                                },
+                                label: {
+                                    Label(
+                                        "Quote in new note",
+                                        systemImage: "quote.opening"
+                                    )
+                                }
+                            )
+                            
+                            Divider()
+                            
+                            Button(
+                                role: .destructive,
+                                action: {
+                                    onEntryDelete(entry.address)
+                                }
+                            ) {
+                                Label(
+                                    "Delete",
+                                    systemImage: "trash"
+                                )
+                            }
                         }
                     }
                     
@@ -111,7 +141,8 @@ struct EntryListView_Previews: PreviewProvider {
             onEntryPress: { entry in },
             onEntryDelete: { slug in },
             onRefresh: {},
-            onLink: { _ in }
+            onLink: { _ in },
+            onQuote: { _ in }
         )
     }
 }

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -51,6 +51,9 @@ struct RecentTabView: View {
                         },
                         onLink: { link in
                             notify(.requestFindLinkDetail(link))
+                        },
+                        onQuote: { address in
+                            notify(.requestQuoteInNewNote(address))
                         }
                     )
                 }

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
@@ -27,6 +27,7 @@ struct StoryEntryView: View {
     var story: StoryEntry
     var onRequestDetail: (Slashlink, String) -> Void
     var onLink: (EntryLink) -> Void
+    var onQuote: (Slashlink) -> Void
     var sharedNote: String {
         """
         \(story.entry.excerpt)
@@ -90,6 +91,18 @@ struct StoryEntryView: View {
         )
         .contextMenu {
             ShareLink(item: sharedNote)
+            
+            Button(
+                action: {
+                    onQuote(story.entry.address)
+                },
+                label: {
+                    Label(
+                        "Quote in new note",
+                        systemImage: "quote.opening"
+                    )
+                }
+            )
         }
     }
 }
@@ -119,7 +132,8 @@ struct StoryPlainView_Previews: PreviewProvider {
                 author: UserProfile.dummyData()
             ),
             onRequestDetail: { _, _ in },
-            onLink: { _ in }
+            onLink: { _ in },
+            onQuote: { _ in }
         )
     }
 }

--- a/xcode/Subconscious/Shared/Components/Deck/Cards/CardView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/Cards/CardView.swift
@@ -13,6 +13,7 @@ struct CardView: View {
     
     var entry: CardModel
     var onLink: (EntryLink) -> Void
+    var onQuote: (Slashlink) -> Void
     
     var color: Color {
         switch entry.card {
@@ -56,29 +57,29 @@ struct CardView: View {
                     message: message,
                     entry: entry,
                     related: related,
-                    onLink: onLink
+                    onLink: onLink,
+                    onQuote: onQuote
                 )
-                
             case let .action(message):
                 ActionCardView(message: message)
             }
         }
-        
     }
 }
 
 struct CardView_Previews: PreviewProvider {
     static var previews: some View {
-        CardView(entry: CardModel(
-            card: .prompt(
-                message: "Hello",
-                entry: EntryStub.dummyData(),
-                author: UserProfile.dummyData(),
-                related: []
-            )
-        ),
-                 onLink: {
-            _ in
-        })
+        CardView(
+            entry: CardModel(
+                card: .prompt(
+                    message: "Hello",
+                    entry: EntryStub.dummyData(),
+                    author: UserProfile.dummyData(),
+                    related: []
+                )
+            ),
+            onLink: { _ in },
+            onQuote: { _ in }
+        )
     }
 }

--- a/xcode/Subconscious/Shared/Components/Deck/Cards/PromptCardView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/Cards/PromptCardView.swift
@@ -15,6 +15,7 @@ struct PromptCardView: View {
     var entry: EntryStub
     var related: Set<EntryStub>
     var onLink: (EntryLink) -> Void
+    var onQuote: (Slashlink) -> Void
     
     var background: Color {
         entry.color(colorScheme: colorScheme)
@@ -53,6 +54,21 @@ struct PromptCardView: View {
         .allowsHitTesting(false)
         .background(background)
         .cornerRadius(DeckTheme.cornerRadius)
+        .contextMenu {
+            ShareLink(item: entry.sharedText)
+            
+            Button(
+                action: {
+                    onQuote(entry.address)
+                },
+                label: {
+                    Label(
+                        "Quote in new note",
+                        systemImage: "quote.opening"
+                    )
+                }
+            )
+        }
     }
 }
 

--- a/xcode/Subconscious/Shared/Components/Deck/DeckNavigationView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/DeckNavigationView.swift
@@ -21,6 +21,27 @@ struct DeckNavigationView: View {
         )
     }
     
+    func notify(notification: CardNotification) {
+        switch notification {
+        case let .swipeLeft(card):
+            store.send(.skipCard(card))
+        case let .swipeRight(card):
+            store.send(.chooseCard(card))
+        case .swipeStarted:
+            store.send(.cardPickedUp)
+        case .swipeAbandoned:
+            store.send(.cardReleased)
+        case let .cardTapped(card):
+            store.send(.cardTapped(card))
+        case let .linkTapped(link):
+            store.send(
+                .detailStack(.findAndPushLinkDetail(link))
+            )
+        case let .quoteCard(address):
+            store.send(.detailStack(.pushQuoteInNewDetail(address)))
+        }
+    }
+    
     var body: some View {
         DetailStackView(app: app, store: detailStack) {
             VStack(alignment: .leading) {
@@ -76,34 +97,7 @@ struct DeckNavigationView: View {
                     CardStack(
                         deck: store.state.deck,
                         current: store.state.pointer,
-                        onSwipeRight: { card in
-                            store.send(
-                                .chooseCard(
-                                    card
-                                )
-                            )
-                        },
-                        onSwipeLeft: { card in
-                            store.send(
-                                .skipCard(
-                                    card
-                                )
-                            )
-                        },
-                        onSwipeStart: {
-                            store.send(.cardPickedUp)
-                        },
-                        onSwipeAbandoned: {
-                            store.send(.cardReleased)
-                        },
-                        onCardTapped: { card in
-                            store.send(.cardTapped(card))
-                        },
-                        onLink: { link in
-                            store.send(
-                                .detailStack(.findAndPushLinkDetail(link))
-                            )
-                        }
+                        notify: notify
                     )
                     .offset(y: -AppTheme.unit * 8)
                     

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -70,6 +70,7 @@ enum UserProfileDetailNotification: Hashable {
     case requestNavigateToProfile(_ address: Slashlink)
     case requestDetail(MemoDetailDescription)
     case requestFindLinkDetail(EntryLink)
+    case requestQuoteInNewNote(_ address: Slashlink)
 }
 
 extension UserProfileDetailAction {

--- a/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
@@ -46,6 +46,9 @@ struct NotebookNavigationView: View {
                             store.send(
                                 .detailStack(.findAndPushLinkDetail(link))
                             )
+                        },
+                        onQuote: { address in
+                            store.send(.detailStack(.pushQuoteInNewDetail(address)))
                         }
                     )
                     .ignoresSafeArea(.keyboard, edges: .bottom)

--- a/xcode/Subconscious/Shared/Models/EntryStub.swift
+++ b/xcode/Subconscious/Shared/Models/EntryStub.swift
@@ -25,6 +25,14 @@ struct EntryStub:
         "Subconscious.EntryStub(\(address))"
     }
     
+    var sharedText: String {
+        """
+        \(excerpt)
+        
+        \(address)
+        """
+    }
+    
     func withAddress(_ address: Slashlink) -> Self {
         return Self(
             did: did,


### PR DESCRIPTION
Add a `.contextMenu` to all the major views to allow Quoting from everywhere.

<img width="378" alt="image" src="https://github.com/subconsciousnetwork/subconscious/assets/5009316/a00a81b3-b0a1-4b6a-a359-4221e9600cf5">

<img width="373" alt="image" src="https://github.com/subconsciousnetwork/subconscious/assets/5009316/879606b3-122c-4aa6-a943-b981566201ae">

<img width="368" alt="image" src="https://github.com/subconsciousnetwork/subconscious/assets/5009316/868ba444-0c78-44da-85fa-e63aaf4c2187">
