### PR TITLE
Re-check gateway provisioning status if sync fails but we DO have a gateway ID

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -2130,17 +2130,27 @@ struct AppModel: ModelProtocol {
         var model = state
         model.lastGatewaySyncStatus = .failed(error)
         
+        
+        var actions: [AppAction] = [
+            .indexOurSphere,
+            .toastStack(
+                .pushToast(
+                    message: "Sync failed",
+                    image: "exclamationmark.arrow.triangle.2.circlepath"
+                )
+            )
+        ]
+        
+        // If we have a gateway ID but sync failed then provisioning may have failed / timed out.
+        // Let's retry in-case it suddenly resolves the issue.
+        if let _ = state.gatewayId,
+           state.gatewayProvisioningStatus != .succeeded {
+            actions.append(.requestGatewayProvisioningStatus)
+        }
+        
         return update(
             state: model,
-            actions: [
-                .indexOurSphere,
-                .toastStack(
-                    .pushToast(
-                        message: "Sync failed",
-                        image: "exclamationmark.arrow.triangle.2.circlepath"
-                    )
-                )
-            ],
+            actions: actions,
             environment: environment
         ).animation()
     }


### PR DESCRIPTION
We ran into an issue where some gateways failed to come online in production and we timed out waiting. We've fixed the backend issue since. The scenario is recoverable by a user opening their gateway settings and hitting the "Check Provisioning Status" button but we can try to auto-detect and resolve the issue too.

If a sync fails but we _do_ have a gateway ID then it means provisioning must have timed out in the past. 

In the MTG future the provisioning time should drop to near-instant hopefully making this even less of an issue.

@gordonbrander can you think of a better condition to detect this situation? The user has redeemed an invite code for a gateway but they _haven't_ received the gateway URL yet. It's still going to be set to `127.0.0.1:4443` for anyone hit by this.