### PR TITLE
Experiment: TraceryDisambiguator

### DIFF
--- a/xcode/Subconscious/Shared/Library/NaturalLanguage/Tracery.swift
+++ b/xcode/Subconscious/Shared/Library/NaturalLanguage/Tracery.swift
@@ -79,3 +79,32 @@ public struct Tracery {
         flatten(depth: 0, grammar: grammar, start: start)
     }
 }
+
+extension Grammar {
+    /// Merge one or more grammars into this grammar, appending new values to
+    /// old keys. If a key does not exist in this grammar yet, it creates it.
+    /// - Returns: merged grammar
+    func mergeGrammar(_ grammars: Grammar...) -> Self {
+        var merged = self
+        for grammar in grammars {
+            for (key, values) in grammar {
+                var mergedValues = merged[key] ?? []
+                mergedValues.append(contentsOf: values)
+                merged[key] = mergedValues
+            }
+        }
+        return merged
+    }
+
+    /// Patch a grammar, overwriting old keys.
+    /// - Returns patched grammar
+    func patchGrammar(_ grammars: Grammar...) -> Self {
+        var patched = self
+        for grammar in grammars {
+            for (key, values) in grammar {
+                patched[key] = values
+            }
+        }
+        return patched
+    }
+}

--- a/xcode/Subconscious/Shared/Library/NaturalLanguage/TraceryDisambiguator.swift
+++ b/xcode/Subconscious/Shared/Library/NaturalLanguage/TraceryDisambiguator.swift
@@ -13,12 +13,12 @@ struct TraceryContext: Hashable {
 }
 
 protocol TraceryDisambiguatorRoute {
-    func match(_ input: String) -> TraceryContext?
+    func match(_ input: String) async -> TraceryContext?
 }
 
 struct RegexRoute<Output>: TraceryDisambiguatorRoute {
     let pattern: Regex<Output>
-    let route: (Regex<Output>.Match, String) -> TraceryContext?
+    let route: (Regex<Output>.Match, String) async -> TraceryContext?
 
     init(
         _ pattern: Regex<Output>,
@@ -28,11 +28,11 @@ struct RegexRoute<Output>: TraceryDisambiguatorRoute {
         self.route = route
     }
 
-    func match(_ input: String) -> TraceryContext? {
+    func match(_ input: String) async -> TraceryContext? {
         guard let match = try? pattern.firstMatch(in: input) else {
             return nil
         }
-        return self.route(match, input)
+        return await self.route(match, input)
     }
 }
 
@@ -50,10 +50,13 @@ struct TraceryDisambiguator {
 
     /// Match input against disambiguators, returning up to `max` matches
     /// for input.
-    func match(_ input: String, max maxResults: Int = 5) -> [TraceryContext] {
+    func match(
+        _ input: String,
+        max maxResults: Int = 5
+    ) async -> [TraceryContext] {
         var results: [TraceryContext] = []
         for route in routes {
-            if let result = route.match(input) {
+            if let result = await route.match(input) {
                 results.append(result)
                 if results.count >= maxResults {
                     return results

--- a/xcode/Subconscious/Shared/Library/NaturalLanguage/TraceryDisambiguator.swift
+++ b/xcode/Subconscious/Shared/Library/NaturalLanguage/TraceryDisambiguator.swift
@@ -1,0 +1,65 @@
+//
+//  TraceryDisambiguator.swift
+//  Subconscious
+//
+//  Created by Gordon Brander on 2/5/24.
+//
+
+import Foundation
+
+struct TraceryContext: Hashable {
+    var start: String = "#start#"
+    var grammar: Grammar = [:]
+}
+
+protocol TraceryDisambiguatorRoute {
+    func match(_ input: String) -> TraceryContext?
+}
+
+struct RegexRoute<Output>: TraceryDisambiguatorRoute {
+    let pattern: Regex<Output>
+    let route: (Regex<Output>.Match, String) -> TraceryContext?
+
+    init(
+        _ pattern: Regex<Output>,
+        route: @escaping (Regex<Output>.Match, String) -> TraceryContext?
+    ) {
+        self.pattern = pattern.ignoresCase()
+        self.route = route
+    }
+
+    func match(_ input: String) -> TraceryContext? {
+        guard let match = try? pattern.firstMatch(in: input) else {
+            return nil
+        }
+        return self.route(match, input)
+    }
+}
+
+/// A router for Tracery Grammars
+struct TraceryDisambiguator {
+    var routes: [TraceryDisambiguatorRoute]
+
+    init(routes: [TraceryDisambiguatorRoute] = []) {
+        self.routes = routes
+    }
+
+    mutating func route(_ route: TraceryDisambiguatorRoute) {
+        self.routes.append(route)
+    }
+
+    /// Match input against disambiguators, returning up to `max` matches
+    /// for input.
+    func match(_ input: String, max maxResults: Int = 5) -> [TraceryContext] {
+        var results: [TraceryContext] = []
+        for route in routes {
+            if let result = route.match(input) {
+                results.append(result)
+                if results.count >= maxResults {
+                    return results
+                }
+            }
+        }
+        return results
+    }
+}

--- a/xcode/Subconscious/Shared/Services/PromptService.swift
+++ b/xcode/Subconscious/Shared/Services/PromptService.swift
@@ -40,7 +40,7 @@ actor PromptService {
         /// Patch our base grammar with the returned grammar (if any) and
         /// use the returned start string to begin flattening.
         return tracery.flatten(
-            grammar: PromptService.prompts.patchGrammar(match.grammar),
+            grammar: grammar.patchGrammar(match.grammar),
             start: match.start
         )
     }

--- a/xcode/Subconscious/Shared/Services/PromptService.swift
+++ b/xcode/Subconscious/Shared/Services/PromptService.swift
@@ -26,14 +26,16 @@ actor PromptService {
         self.disambiguator = disambiguator
     }
 
-    func generate(start: String = "#start#") -> String {
+    func generate(start: String = "#start#") async -> String {
         tracery.flatten(grammar: grammar, start: start)
     }
 
     /// Generate a prompt given an input string
-    func generate(input: String) -> String {
-        guard let match = disambiguator.match(input).randomElement() else {
-            return generate()
+    func generate(input: String) async -> String {
+        guard
+            let match = await disambiguator.match(input).randomElement()
+        else {
+            return await generate()
         }
         /// Patch our base grammar with the returned grammar (if any) and
         /// use the returned start string to begin flattening.

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -175,6 +175,8 @@
 		B8109C2927A8879C00CD2B6D /* AppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8109C2727A8879C00CD2B6D /* AppTheme.swift */; };
 		B8133AEB29B8FD1300B38760 /* SubtextAttributedStringRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8133AEA29B8FD1300B38760 /* SubtextAttributedStringRenderer.swift */; };
 		B8133AEC29B8FD1300B38760 /* SubtextAttributedStringRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8133AEA29B8FD1300B38760 /* SubtextAttributedStringRenderer.swift */; };
+		B81719992B713904008367D5 /* TraceryDisambiguator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81719982B713904008367D5 /* TraceryDisambiguator.swift */; };
+		B817199A2B713904008367D5 /* TraceryDisambiguator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81719982B713904008367D5 /* TraceryDisambiguator.swift */; };
 		B81A1A6D29DF267200B4CD1C /* LoadingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81A1A6C29DF267200B4CD1C /* LoadingState.swift */; };
 		B81A1A6F29DF29BF00B4CD1C /* MemoViewerDetailMetaSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81A1A6E29DF29BF00B4CD1C /* MemoViewerDetailMetaSheetView.swift */; };
 		B81A535C27275138001A6268 /* Tape.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81A535B27275138001A6268 /* Tape.swift */; };
@@ -695,6 +697,7 @@
 		B80CC806299D4DF000C4D7C0 /* Tests_SQLite3Database.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_SQLite3Database.swift; sourceTree = "<group>"; };
 		B8109C2727A8879C00CD2B6D /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
 		B8133AEA29B8FD1300B38760 /* SubtextAttributedStringRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubtextAttributedStringRenderer.swift; sourceTree = "<group>"; };
+		B81719982B713904008367D5 /* TraceryDisambiguator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceryDisambiguator.swift; sourceTree = "<group>"; };
 		B81A1A6C29DF267200B4CD1C /* LoadingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingState.swift; sourceTree = "<group>"; };
 		B81A1A6E29DF29BF00B4CD1C /* MemoViewerDetailMetaSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoViewerDetailMetaSheetView.swift; sourceTree = "<group>"; };
 		B81A535B27275138001A6268 /* Tape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tape.swift; sourceTree = "<group>"; };
@@ -1209,6 +1212,15 @@
 			path = SubconsciousTests;
 			sourceTree = "<group>";
 		};
+		B81719972B7138DE008367D5 /* NaturalLanguage */ = {
+			isa = PBXGroup;
+			children = (
+				B8B9640D2B692EBB00A96165 /* Tracery.swift */,
+				B81719982B713904008367D5 /* TraceryDisambiguator.swift */,
+			);
+			path = NaturalLanguage;
+			sourceTree = "<group>";
+		};
 		B828F0AC2B029F6F00FDE4AE /* Transclude */ = {
 			isa = PBXGroup;
 			children = (
@@ -1688,6 +1700,7 @@
 				B8B4251128FDE7780081B8D5 /* Mapping.swift */,
 				B56B80932B05AEA800AABF08 /* MathUtilities.swift */,
 				B89E30762911B51A00A4721F /* Migration.swift */,
+				B81719972B7138DE008367D5 /* NaturalLanguage */,
 				B59850B42B328E6800FF8E65 /* NoosphereLogProxy.swift */,
 				B866868027AC4EF100A03A55 /* NSRangeUtilities.swift */,
 				B82C3A6426F5796300833CC8 /* OptionalUtilities.swift */,
@@ -1706,7 +1719,6 @@
 				B8E00A2C299294A0003B40C1 /* UserDefaultsProperty.swift */,
 				B8B3EE7C297B1A1000779B7F /* ViewDebugUtilities.swift */,
 				B8249DA227E2753800BCDFBA /* ViewUtilities.swift */,
-				B8B9640D2B692EBB00A96165 /* Tracery.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -2125,6 +2137,7 @@
 				B569971729B6A0DF003204FC /* DidQrCodeView.swift in Sources */,
 				B542EF672AF48F2100BE29F1 /* StoreUtilities.swift in Sources */,
 				B8EA3EE82915C23200B92C2E /* HeaderSubtext.swift in Sources */,
+				B81719992B713904008367D5 /* TraceryDisambiguator.swift in Sources */,
 				B58C73A729DBB3B500B00EA1 /* UserProfileView.swift in Sources */,
 				B8EF986E29034ADF0029363D /* Pathlike.swift in Sources */,
 				B83B19A32A005C6B007657D9 /* Did+SubconsciousLocal.swift in Sources */,
@@ -2404,6 +2417,7 @@
 			files = (
 				B82C3A6626F5796300833CC8 /* OptionalUtilities.swift in Sources */,
 				B8AC6490278F7E7B0099E96B /* BackLabelStyle.swift in Sources */,
+				B817199A2B713904008367D5 /* TraceryDisambiguator.swift in Sources */,
 				B866868227AC4EF100A03A55 /* NSRangeUtilities.swift in Sources */,
 				B59E9E1B2AB8FA29008E3543 /* HomeProfileView.swift in Sources */,
 				B8B9640F2B692EBB00A96165 /* Tracery.swift in Sources */,


### PR DESCRIPTION
This gives us a basic way to customize prompts based on inputs.

- TraceryDisambiguator is essentially a router
  - Tries a succession of routes
  - Collects up to `n` matches
- A route is a protocol that implements `match(:) async -> TraceryContext?`
  - `RegexRoute` is a concrete implementation of the protocol and allows regular-expression-based matching.
- TraceryContext contains a grammar and a start string
  - The start string is used to begin flattening
  - The grammar is used in PromptService to overwrite keys on our base grammar. This allows us to save "state" extracted from the input to the grammar.

RegexRoute should allow us to do simple keyword-based dispatch of prompts.

Future improvements:

- Could be expanded to tokenize, lemmatize, or otherwise preprocess text before handing to routes
- Could be expanded support other kinds of router, including on-device ML classifier, or even LLM.