### PR TITLE
Editor performance improvements

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
@@ -128,45 +128,45 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
                 )
             )
         }
-        
-        // This allows us to intercept touches on embedded transclude blocks
-        override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-            guard let touch = touches.first else {
-                super.touchesBegan(touches, with: event)
-                return
-            }
-
-            let tapPoint = touch.location(in: self)
-            
-            guard let textLayoutManager = self.textLayoutManager else {
-                SubtextTextViewRepresentable.logger.warning("Could not access textLayoutManager")
-                super.touchesBegan(touches, with: event)
-                return
-            }
-            
-            guard let textContentStorage = textLayoutManager
-                .textContentManager as? NSTextContentStorage
-            else {
-                SubtextTextViewRepresentable.logger.warning("Could not access textContentStorage")
-                super.touchesBegan(touches, with: event)
-                return
-            }
-            
-            // Did tap a text element?
-            if let textElement = textLayoutManager
-                .textLayoutFragment(for: tapPoint)?
-                .textElement
-            {
-                let content = textContentStorage.attributedString(
-                    for: textElement
-                )
-                
-                // TODO: check for whether this tap should navigate to a link
-                SubtextTextViewRepresentable.logger.debug("Tapped: \(String(describing: content?.string))")
-                // Calling super preserves default behaviour
-                super.touchesBegan(touches, with: event)
-            }
-        }
+//        
+//        // This allows us to intercept touches on embedded transclude blocks
+//        override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+//            guard let touch = touches.first else {
+//                super.touchesBegan(touches, with: event)
+//                return
+//            }
+//
+//            let tapPoint = touch.location(in: self)
+//            
+//            guard let textLayoutManager = self.textLayoutManager else {
+//                SubtextTextViewRepresentable.logger.warning("Could not access textLayoutManager")
+//                super.touchesBegan(touches, with: event)
+//                return
+//            }
+//            
+//            guard let textContentStorage = textLayoutManager
+//                .textContentManager as? NSTextContentStorage
+//            else {
+//                SubtextTextViewRepresentable.logger.warning("Could not access textContentStorage")
+//                super.touchesBegan(touches, with: event)
+//                return
+//            }
+//            
+//            // Did tap a text element?
+//            if let textElement = textLayoutManager
+//                .textLayoutFragment(for: tapPoint)?
+//                .textElement
+//            {
+//                let content = textContentStorage.attributedString(
+//                    for: textElement
+//                )
+//                
+//                // TODO: check for whether this tap should navigate to a link
+//                SubtextTextViewRepresentable.logger.debug("Tapped: \(String(describing: content?.string))")
+//                // Calling super preserves default behaviour
+//                super.touchesBegan(touches, with: event)
+//            }
+//        }
     }
 
     // MARK: Coordinator
@@ -188,6 +188,7 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
         /// Subtext renderer instance
         var renderer: SubtextAttributedStringRenderer
         var subtext: Subtext? = nil
+        var lastText: String? = nil
 
         init(
             representable: SubtextTextViewRepresentable
@@ -290,41 +291,41 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
         
         // MARK: - NSTextLayoutManagerDelegate
                                 
-        func textLayoutManager(
-            _ textLayoutManager: NSTextLayoutManager,
-            textLayoutFragmentFor location: NSTextLocation,
-            in textElement: NSTextElement
-        ) -> NSTextLayoutFragment {
-            let baseLayoutFragment = NSTextLayoutFragment(
-                textElement: textElement,
-                range: textElement.elementRange
-            )
- 
-            guard renderTranscludeBlocks else {
-                return baseLayoutFragment
-            }
-
-            guard let paragraph = textElement as? NSTextParagraph else {
-                return baseLayoutFragment
-            }
-
-            // Only render transcludes for a single slashlink in a single block
-            guard let _ = subtext?
-                .block(forParagraph: paragraph)?
-                .slashlinks
-                .get(0)?
-                .toSlashlink()
-            else {
-                return baseLayoutFragment
-            }
-
-            let layoutFragment = TranscludeBlockLayoutFragment(
-                textElement: paragraph,
-                range: paragraph.elementRange
-            )
-
-            return layoutFragment
-        }
+//        func textLayoutManager(
+//            _ textLayoutManager: NSTextLayoutManager,
+//            textLayoutFragmentFor location: NSTextLocation,
+//            in textElement: NSTextElement
+//        ) -> NSTextLayoutFragment {
+//            let baseLayoutFragment = NSTextLayoutFragment(
+//                textElement: textElement,
+//                range: textElement.elementRange
+//            )
+// 
+//            guard renderTranscludeBlocks else {
+//                return baseLayoutFragment
+//            }
+//
+//            guard let paragraph = textElement as? NSTextParagraph else {
+//                return baseLayoutFragment
+//            }
+//
+//            // Only render transcludes for a single slashlink in a single block
+//            guard let _ = subtext?
+//                .block(forParagraph: paragraph)?
+//                .slashlinks
+//                .get(0)?
+//                .toSlashlink()
+//            else {
+//                return baseLayoutFragment
+//            }
+//
+//            let layoutFragment = TranscludeBlockLayoutFragment(
+//                textElement: paragraph,
+//                range: paragraph.elementRange
+//            )
+//
+//            return layoutFragment
+//        }
     }
 
     static var logger = Logger(

--- a/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
@@ -403,10 +403,12 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
             context.coordinator.isUIViewUpdating = false
         }
 
-        if (view.text != state.text) {
+        let txt = view.text
+        if (txt != state.text && context.coordinator.lastText != state.text) {
             SubtextTextViewRepresentable.logger.debug("updateUIView: set text")
             view.text = state.text
         }
+        context.coordinator.lastText = view.text
 
         // Update width
         if view.fixedWidth != self.frame.width {

--- a/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
+++ b/xcode/Subconscious/Shared/Components/Common/SubtextTextViewRepresentable.swift
@@ -128,45 +128,6 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
                 )
             )
         }
-//        
-//        // This allows us to intercept touches on embedded transclude blocks
-//        override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-//            guard let touch = touches.first else {
-//                super.touchesBegan(touches, with: event)
-//                return
-//            }
-//
-//            let tapPoint = touch.location(in: self)
-//            
-//            guard let textLayoutManager = self.textLayoutManager else {
-//                SubtextTextViewRepresentable.logger.warning("Could not access textLayoutManager")
-//                super.touchesBegan(touches, with: event)
-//                return
-//            }
-//            
-//            guard let textContentStorage = textLayoutManager
-//                .textContentManager as? NSTextContentStorage
-//            else {
-//                SubtextTextViewRepresentable.logger.warning("Could not access textContentStorage")
-//                super.touchesBegan(touches, with: event)
-//                return
-//            }
-//            
-//            // Did tap a text element?
-//            if let textElement = textLayoutManager
-//                .textLayoutFragment(for: tapPoint)?
-//                .textElement
-//            {
-//                let content = textContentStorage.attributedString(
-//                    for: textElement
-//                )
-//                
-//                // TODO: check for whether this tap should navigate to a link
-//                SubtextTextViewRepresentable.logger.debug("Tapped: \(String(describing: content?.string))")
-//                // Calling super preserves default behaviour
-//                super.touchesBegan(touches, with: event)
-//            }
-//        }
     }
 
     // MARK: Coordinator
@@ -175,8 +136,7 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
         UITextViewDelegate,
         NSTextContentStorageDelegate,
         NSTextStorageDelegate,
-        NSTextContentManagerDelegate,
-        NSTextLayoutManagerDelegate
+        NSTextContentManagerDelegate
     {
         /// Is event happening during updateUIView?
         /// Used to avoid setting properties in events during view updates, as
@@ -290,44 +250,6 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
                 )
             )
         }
-        
-        // MARK: - NSTextLayoutManagerDelegate
-                                
-//        func textLayoutManager(
-//            _ textLayoutManager: NSTextLayoutManager,
-//            textLayoutFragmentFor location: NSTextLocation,
-//            in textElement: NSTextElement
-//        ) -> NSTextLayoutFragment {
-//            let baseLayoutFragment = NSTextLayoutFragment(
-//                textElement: textElement,
-//                range: textElement.elementRange
-//            )
-// 
-//            guard renderTranscludeBlocks else {
-//                return baseLayoutFragment
-//            }
-//
-//            guard let paragraph = textElement as? NSTextParagraph else {
-//                return baseLayoutFragment
-//            }
-//
-//            // Only render transcludes for a single slashlink in a single block
-//            guard let _ = subtext?
-//                .block(forParagraph: paragraph)?
-//                .slashlinks
-//                .get(0)?
-//                .toSlashlink()
-//            else {
-//                return baseLayoutFragment
-//            }
-//
-//            let layoutFragment = TranscludeBlockLayoutFragment(
-//                textElement: paragraph,
-//                range: paragraph.elementRange
-//            )
-//
-//            return layoutFragment
-//        }
     }
 
     static var logger = Logger(
@@ -357,10 +279,7 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
         let textContentStorage = NSTextContentStorage()
         let textContainer = NSTextContainer()
         textContentStorage.delegate = context.coordinator
-        textLayoutManager.delegate = context.coordinator
-        
         textContentStorage.addTextLayoutManager(textLayoutManager)
-        
         textLayoutManager.textContainer = textContainer
         
         let view = SubtextTextView(frame: self.frame, textContainer: textContainer)
@@ -420,7 +339,7 @@ struct SubtextTextViewRepresentable: UIViewRepresentable {
         // THEN state.text updates to "abcd"
         // updateUIVIew() called again
         // we set view.text = state.text
-        // view.text == "abcd"
+        // view.text = "abcd"
         
         // so we set view.text TWICE when we could set it zero times
         // caching the last known rendered value allows us to detect and sidestep this scenario

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -196,7 +196,7 @@ struct MemoEditorDetailView: View {
     var highlight: Color? {
         store.state.themeColor?.toHighlightColor()
             ?? store.state.address?.themeColor.toHighlightColor()
-            ?? ThemeColor.a.toColor()
+            ?? ThemeColor.a.toHighlightColor()
     }
     
     var background: Color? {

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -73,16 +73,21 @@ struct MemoEditorDetailView: View {
     }
     
     var body: some View {
-        VStack {
-            if app.state.isBlockEditorEnabled {
-                blockEditor()
-            } else {
-                plainEditor()
+        ZStack {
+            VStack { }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .modifier(AppThemeBackgroundViewModifier())
+            
+            VStack {
+                if app.state.isBlockEditorEnabled {
+                    blockEditor()
+                } else {
+                    plainEditor()
+                }
             }
         }
         .navigationTitle(navigationTitle)
         .navigationBarTitleDisplayMode(.inline)
-        .modifier(AppThemeBackgroundViewModifier())
         .modifier(AppThemeToolbarViewModifier())
         .toolbar(content: {
             DetailToolbarContent(
@@ -211,7 +216,7 @@ struct MemoEditorDetailView: View {
             VStack(spacing: 0) {
                 ScrollView(.vertical) {
                     VStack(spacing: 0) {
-                        SubtextTextViewRepresentable( state: store.state.editor, send: Address.forward(
+                        SubtextTextViewRepresentable(state: store.state.editor, send: Address.forward(
                                 send: store.send,
                                 tag: MemoEditorDetailSubtextTextCursor.tag
                             ),


### PR DESCRIPTION
While investigating https://github.com/subconsciousnetwork/subconscious/issues/1108 I profiled the `plainEditor()` and found it was extremely expensive on each keystroke. It's incredibly expensive to set the `.text` property on the underlying view and doing so can result in cursor desync. 

I suspect this is also responsible for https://github.com/subconsciousnetwork/subconscious/issues/566.

Setting `.text` frequently causes `updateUIView()` to take a LONG time (up to 400ms in debug mode) which means `isUIViewUpdating` stays true for a long time and we start dropping input events if the user is typing rapidly. This is what is responsible for the autocorrect cursor desync issue linked above and can be replicated by typing very fast into the simulator. It's harder to trigger in release, on-device, but it happens there too.

In brief: there's a pathological update cycle happening that results in setting `.text` twice when we can set it 0 times. I've documented the specifics in the code.

I made two changes:

1. enhance the change detection logic so we can trust `view.text` more often instead of resetting it
1. split the rendering of the new gradient BG into another layer from the editor itself (minor, but helpful) 

The difference is more exaggerated on simulator, but it's night and day.

# Before

https://github.com/subconsciousnetwork/subconscious/assets/5009316/1eec6b50-8abf-4ddb-ab9e-ce0504597587

# After


https://github.com/subconsciousnetwork/subconscious/assets/5009316/39af615e-3802-48da-82a0-af04265b8df2

