### PR TITLE
Narrow trigger condition to re-check provisioning status

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -2165,7 +2165,8 @@ struct AppModel: ModelProtocol {
             )
         ]
         
-        // If we have a gateway ID but sync failed then provisioning may have failed / timed out.
+        // If we have a gateway ID but sync failed and we are using the default gateway,
+        // then provisioning may have failed / timed out.
         // Let's retry in-case it suddenly resolves the issue.
         if let _ = state.gatewayId,
            state.gatewayURL == AppDefaults.defaultGatewayURL,

--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -2168,6 +2168,7 @@ struct AppModel: ModelProtocol {
         // If we have a gateway ID but sync failed then provisioning may have failed / timed out.
         // Let's retry in-case it suddenly resolves the issue.
         if let _ = state.gatewayId,
+           state.gatewayURL == AppDefaults.defaultGatewayURL,
            state.gatewayProvisioningStatus != .succeeded {
             actions.append(.requestGatewayProvisioningStatus)
         }

--- a/xcode/Subconscious/Shared/Services/AppDefaults.swift
+++ b/xcode/Subconscious/Shared/Services/AppDefaults.swift
@@ -17,8 +17,9 @@ struct AppDefaults {
     @UserDefaultsProperty(forKey: "firstRunComplete")
     var firstRunComplete = false
     
+    static let defaultGatewayURL = "http://127.0.0.1:4433"
     @UserDefaultsProperty(forKey: "gatewayURL")
-    var gatewayURL = "http://127.0.0.1:4433"
+    var gatewayURL = Self.defaultGatewayURL
     
     @UserDefaultsProperty(forKey: "gatewayId")
     var gatewayId: String? = nil


### PR DESCRIPTION
The fix I implemented in https://github.com/subconsciousnetwork/subconscious/pull/1094 works but it's triggered in scenarios it shouldn't be. There's no ill effect of running this too often but I'd rather be precise.