### PR TITLE
Add, remove and render likes in list views

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -3387,7 +3387,8 @@ struct AppEnvironment {
             database: database,
             local: local,
             addressBook: addressBook,
-            userProfile: userProfile
+            userProfile: userProfile,
+            userLikes: userLikes
         )
         
         self.gatewayProvisioningService = GatewayProvisioningService()

--- a/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListView.swift
@@ -86,7 +86,7 @@ struct EntryListView: View {
                                     },
                                     label: {
                                         Label(
-                                            "Remove from likes",
+                                            "Unlike",
                                             systemImage: "heart.slash"
                                         )
                                     }
@@ -98,7 +98,7 @@ struct EntryListView: View {
                                     },
                                     label: {
                                         Label(
-                                            "Add to likes",
+                                            "Like",
                                             systemImage: "heart"
                                         )
                                     }
@@ -111,7 +111,7 @@ struct EntryListView: View {
                                 },
                                 label: {
                                     Label(
-                                        "Quote in new note",
+                                        "Quote",
                                         systemImage: "quote.opening"
                                     )
                                 }

--- a/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListView.swift
@@ -52,6 +52,7 @@ struct EntryListView: View {
                         ) {
                             EntryRow(
                                 entry: entry,
+                                liked: liked(entry),
                                 highlight: entry.highlightColor,
                                 onLink: { link in notify(.linkTapped(link)) }
                             )

--- a/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryList/EntryListView.swift
@@ -8,11 +8,11 @@
 import SwiftUI
 
 enum EntryNotification {
-    case tapped(EntryStub)
+    case requestDetail(EntryStub)
     case like(Slashlink)
     case unlike(Slashlink)
     case delete(Slashlink)
-    case linkTapped(EntryLink)
+    case requestLinkDetail(EntryLink)
     case quote(Slashlink)
 }
 
@@ -47,14 +47,14 @@ struct EntryListView: View {
                         
                         Button(
                             action: {
-                                notify(.tapped(entry))
+                                notify(.requestDetail(entry))
                             }
                         ) {
                             EntryRow(
                                 entry: entry,
                                 liked: liked(entry),
                                 highlight: entry.highlightColor,
-                                onLink: { link in notify(.linkTapped(link)) }
+                                onLink: { link in notify(.requestLinkDetail(link)) }
                             )
                         }
                         .buttonStyle(

--- a/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct EntryRow: View {
     @Environment (\.colorScheme) var colorScheme
     var entry: EntryStub
+    var liked: Bool
     var emptyExcerpt = "Empty"
     var highlight: Color = .secondary
     var onLink: (EntryLink) -> Void = { _ in }
@@ -35,6 +36,12 @@ struct EntryRow: View {
                     .theme(base: highlight, slug: highlight)
 
                 Spacer()
+                
+                if liked {
+                    Image(systemName: "heart.fill")
+                        .font(.caption)
+                        .foregroundColor(highlight)
+                }
 
                 Text(
                     NiceDateFormatter.shared.string(
@@ -72,7 +79,8 @@ struct EntryRow_Previews: PreviewProvider {
                               """
                     ),
                     headers: .emptySubtext
-                )
+                ),
+                liked: false
             )
             EntryRow(
                 entry: EntryStub(
@@ -84,7 +92,8 @@ struct EntryRow_Previews: PreviewProvider {
                         markup: "Anything that can be derived should be derived. Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply."
                     ),
                     headers: .emptySubtext
-                )
+                ),
+                liked: false
             )
             EntryRow(
                 entry: EntryStub(
@@ -96,7 +105,8 @@ struct EntryRow_Previews: PreviewProvider {
                         markup: "Anything that can be derived should be derived. Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply."
                     ),
                     headers: .emptySubtext
-                )
+                ),
+                liked: false
             )
             EntryRow(
                 entry: EntryStub(
@@ -108,7 +118,8 @@ struct EntryRow_Previews: PreviewProvider {
                         markup: "Anything that can be derived should be derived. Insight from Rich Hickey. Practical example: all information in Git is derived. At Git's core, it is simply a linked list of annotated diffs. All commands are derived via diff/patch/apply."
                     ),
                     headers: .emptySubtext
-                )
+                ),
+                liked: false
             )
         }
         .padding(AppTheme.unit2)

--- a/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
+++ b/xcode/Subconscious/Shared/Components/Common/EntryRow.swift
@@ -36,12 +36,6 @@ struct EntryRow: View {
                     .theme(base: highlight, slug: highlight)
 
                 Spacer()
-                
-                if liked {
-                    Image(systemName: "heart.fill")
-                        .font(.caption)
-                        .foregroundColor(highlight)
-                }
 
                 Text(
                     NiceDateFormatter.shared.string(
@@ -51,6 +45,12 @@ struct EntryRow: View {
                 )
                 .font(.subheadline)
                 .foregroundColor(highlight)
+                
+                if liked {
+                    Image(systemName: "heart.fill")
+                        .font(.caption)
+                        .foregroundColor(highlight)
+                }
             }
             .font(.callout)
             .lineLimit(1)

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -25,31 +25,6 @@ struct ProfileStatisticView: View {
     }
 }
 
-extension UserProfileDetailNotification {
-    static func from(_ notification: EntryNotification) -> UserProfileDetailNotification? {
-        switch notification {
-        case let .tapped(entry):
-            return .requestDetail(
-                .from(
-                    address: entry.address,
-                    fallback: entry.excerpt.description
-                )
-            )
-        case let .linkTapped(link):
-            return .requestFindLinkDetail(link)
-        case let .quote(address):
-            return .requestQuoteInNewNote(address)
-        case let .like(address):
-            return .requestUpdateLikeStatus(address, liked: true)
-        case let .unlike(address):
-            return .requestUpdateLikeStatus(address, liked: false)
-        // Not currently possible from this view
-        case .delete:
-            return nil
-        }
-    }
-}
-
 struct RecentTabView: View {
     @ObservedObject var store: Store<UserProfileDetailModel>
     var notify: (UserProfileDetailNotification) -> Void

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -39,7 +39,12 @@ extension UserProfileDetailNotification {
             return .requestFindLinkDetail(link)
         case let .quote(address):
             return .requestQuoteInNewNote(address)
-        default:
+        case let .like(address):
+            return .requestUpdateLikeStatus(address, liked: true)
+        case let .unlike(address):
+            return .requestUpdateLikeStatus(address, liked: false)
+        // Not currently possible from this view
+        case .delete:
             return nil
         }
     }
@@ -58,9 +63,12 @@ struct RecentTabView: View {
                         story: StoryEntry(
                             entry: entry,
                             author: user,
-                            liked: false
+                            liked: store.state.ourLikes.contains(where: {
+                                like in entry.address == like
+                            })
                         ),
-                        notify: { notification in
+                        notify: {
+                            notification in
                             UserProfileDetailNotification.from(notification).flatMap(notify)
                         }
                     )
@@ -137,7 +145,9 @@ struct LikesTabView: View {
                         story: StoryEntry(
                             entry: like,
                             author: user,
-                            liked: false
+                            liked: store.state.ourLikes.contains(where: {
+                                ourLike in like.address == ourLike
+                            })
                         ),
                         notify: { notification in
                             UserProfileDetailNotification.from(notification).flatMap(notify)

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -42,8 +42,7 @@ struct RecentTabView: View {
                                 like in entry.address == like
                             })
                         ),
-                        notify: {
-                            notification in
+                        notify: { notification in
                             UserProfileDetailNotification.from(notification).flatMap(notify)
                         }
                     )

--- a/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Profile/UserProfileView.swift
@@ -25,6 +25,26 @@ struct ProfileStatisticView: View {
     }
 }
 
+extension UserProfileDetailNotification {
+    static func from(_ notification: EntryNotification) -> UserProfileDetailNotification? {
+        switch notification {
+        case let .tapped(entry):
+            return .requestDetail(
+                .from(
+                    address: entry.address,
+                    fallback: entry.excerpt.description
+                )
+            )
+        case let .linkTapped(link):
+            return .requestFindLinkDetail(link)
+        case let .quote(address):
+            return .requestQuoteInNewNote(address)
+        default:
+            return nil
+        }
+    }
+}
+
 struct RecentTabView: View {
     @ObservedObject var store: Store<UserProfileDetailModel>
     var notify: (UserProfileDetailNotification) -> Void
@@ -37,23 +57,11 @@ struct RecentTabView: View {
                     StoryEntryView(
                         story: StoryEntry(
                             entry: entry,
-                            author: user
+                            author: user,
+                            liked: false
                         ),
-                        onRequestDetail: { address, excerpt in
-                            notify(
-                                .requestDetail(
-                                    .from(
-                                        address: address,
-                                        fallback: excerpt
-                                    )
-                                )
-                            )
-                        },
-                        onLink: { link in
-                            notify(.requestFindLinkDetail(link))
-                        },
-                        onQuote: { address in
-                            notify(.requestQuoteInNewNote(address))
+                        notify: { notification in
+                            UserProfileDetailNotification.from(notification).flatMap(notify)
                         }
                     )
                 }
@@ -128,23 +136,11 @@ struct LikesTabView: View {
                     StoryEntryView(
                         story: StoryEntry(
                             entry: like,
-                            author: user
+                            author: user,
+                            liked: false
                         ),
-                        onRequestDetail: { address, excerpt in
-                            notify(
-                                .requestDetail(
-                                    .from(
-                                        address: address,
-                                        fallback: excerpt
-                                    )
-                                )
-                            )
-                        },
-                        onLink: { link in
-                            notify(.requestFindLinkDetail(link))
-                        },
-                        onQuote: { address in
-                            notify(.requestQuoteInNewNote(address))
+                        notify: { notification in
+                            UserProfileDetailNotification.from(notification).flatMap(notify)
                         }
                     )
                 }

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
@@ -25,9 +25,8 @@ struct StoryEntryView: View {
     @Environment(\.colorScheme) var colorScheme
     
     var story: StoryEntry
-    var onRequestDetail: (Slashlink, String) -> Void
-    var onLink: (EntryLink) -> Void
-    var onQuote: (Slashlink) -> Void
+    var notify: (EntryNotification) -> Void
+    
     var sharedNote: String {
         """
         \(story.entry.excerpt)
@@ -51,10 +50,7 @@ struct StoryEntryView: View {
     var body: some View {
         Button(
             action: {
-                onRequestDetail(
-                    story.entry.address,
-                    story.entry.excerpt.description
-                )
+                notify(.tapped(story.entry))
             },
             label: {
                 VStack(alignment: .leading, spacing: AppTheme.tightPadding) {
@@ -68,7 +64,7 @@ struct StoryEntryView: View {
                             SubtextView(
                                 peer: story.entry.toPeer(),
                                 subtext: story.entry.excerpt,
-                                onLink: onLink
+                                onLink: { link in notify(.linkTapped(link)) }
                             )
                             .multilineTextAlignment(.leading)
                             .foregroundColor(.primary)
@@ -88,9 +84,35 @@ struct StoryEntryView: View {
         .contextMenu {
             ShareLink(item: sharedNote)
             
+            if story.liked {
+                Button(
+                    action: {
+                        notify(.unlike(story.entry.address))
+                    },
+                    label: {
+                        Label(
+                            "Remove from likes",
+                            systemImage: "heart.slash"
+                        )
+                    }
+                )
+            } else {
+                Button(
+                    action: {
+                        notify(.like(story.entry.address))
+                    },
+                    label: {
+                        Label(
+                            "Add to likes",
+                            systemImage: "heart"
+                        )
+                    }
+                )
+            }
+            
             Button(
                 action: {
-                    onQuote(story.entry.address)
+                    notify(.quote(story.entry.address))
                 },
                 label: {
                     Label(
@@ -125,11 +147,10 @@ struct StoryPlainView_Previews: PreviewProvider {
                     ),
                     did: Did.dummyData()
                 ),
-                author: UserProfile.dummyData()
+                author: UserProfile.dummyData(),
+                liked: false
             ),
-            onRequestDetail: { _, _ in },
-            onLink: { _ in },
-            onQuote: { _ in }
+            notify: { _ in }
         )
     }
 }

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
@@ -105,7 +105,7 @@ struct StoryEntryView: View {
                     },
                     label: {
                         Label(
-                            "Remove from likes",
+                            "Unlike",
                             systemImage: "heart.slash"
                         )
                     }
@@ -117,7 +117,7 @@ struct StoryEntryView: View {
                     },
                     label: {
                         Label(
-                            "Add to likes",
+                            "Like",
                             systemImage: "heart"
                         )
                     }
@@ -130,7 +130,7 @@ struct StoryEntryView: View {
                 },
                 label: {
                     Label(
-                        "Quote in new note",
+                        "Quote",
                         systemImage: "quote.opening"
                     )
                 }

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
@@ -50,7 +50,7 @@ struct StoryEntryView: View {
     var body: some View {
         Button(
             action: {
-                notify(.tapped(story.entry))
+                notify(.requestDetail(story.entry))
             },
             label: {
                 VStack(alignment: .leading, spacing: AppTheme.tightPadding) {
@@ -64,7 +64,7 @@ struct StoryEntryView: View {
                         SubtextView(
                             peer: story.entry.toPeer(),
                             subtext: story.entry.excerpt,
-                            onLink: { link in notify(.linkTapped(link)) }
+                            onLink: { link in notify(.requestLinkDetail(link)) }
                         )
                         .multilineTextAlignment(.leading)
                         .foregroundColor(.primary)

--- a/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Story/StoryEntryView.swift
@@ -54,25 +54,39 @@ struct StoryEntryView: View {
             },
             label: {
                 VStack(alignment: .leading, spacing: AppTheme.tightPadding) {
-                        VStack(alignment: .leading, spacing: AppTheme.unit2) {
-                            BylineSmView(
-                                pfp: .generated(story.entry.did),
-                                slashlink: story.entry.address,
-                                highlight: highlight
-                            )
-                            
-                            SubtextView(
-                                peer: story.entry.toPeer(),
-                                subtext: story.entry.excerpt,
-                                onLink: { link in notify(.linkTapped(link)) }
-                            )
-                            .multilineTextAlignment(.leading)
-                            .foregroundColor(.primary)
-                        }
-                        .tint(highlight)
-                        .truncateWithGradient(maxHeight: AppTheme.maxTranscludeHeight)
+                    VStack(alignment: .leading, spacing: AppTheme.unit2) {
+                        BylineSmView(
+                            pfp: .generated(story.entry.did),
+                            slashlink: story.entry.address,
+                            highlight: highlight
+                        )
+                        
+                        SubtextView(
+                            peer: story.entry.toPeer(),
+                            subtext: story.entry.excerpt,
+                            onLink: { link in notify(.linkTapped(link)) }
+                        )
+                        .multilineTextAlignment(.leading)
+                        .foregroundColor(.primary)
+                    }
+                    .truncateWithGradient(maxHeight: AppTheme.maxTranscludeHeight)
                 }
+                .tint(highlight)
                 .contentShape(Rectangle())
+                .overlay(VStack {
+                    Spacer()
+                        HStack {
+                            Spacer()
+                            
+                            if story.liked {
+                                Image(systemName: "heart.fill")
+                                    .font(.caption)
+                                    .foregroundColor(highlight)
+                            }
+                        }
+                    }
+                    .allowsHitTesting(false)
+                )
             }
         )
         .contentShape(.interaction, RectangleCroppedTopRightCorner())

--- a/xcode/Subconscious/Shared/Components/Deck/CardStackView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/CardStackView.swift
@@ -133,11 +133,8 @@ enum CardStackNotification {
     case swipeLeft(CardModel)
     case swipeStarted
     case swipeAbandoned
-    case cardTapped(CardModel)
-    case linkTapped(EntryLink)
-    case cardQuoted(Slashlink)
-    case cardLiked(Slashlink)
-    case cardUnliked(Slashlink)
+    
+    case entry(EntryNotification)
 }
 
 struct CardStack: View {
@@ -229,7 +226,11 @@ struct CardStack: View {
     func gestures(card: CardModel) -> CardGestureModifier {
         CardGestureModifier(
             offsets: $offsets,
-            onTapped: { notify(.cardTapped(card)) },
+            onTapped: {
+                if let entry = card.entry {
+                    notify(.entry(.requestDetail(entry)))
+                }
+            },
             onSwipeStart: { notify(.swipeStarted) },
             onSwipeChanged: { translation in
                 dragChanged(card: card, translation: translation)
@@ -248,24 +249,7 @@ struct CardStack: View {
             CardView(
                 card: card,
                 notify: { notification in
-                    switch notification {
-                    case let .like(address):
-                        notify(.cardLiked(address))
-                        break
-                    case let .unlike(address):
-                        notify(.cardUnliked(address))
-                        break
-                    case let .quote(address):
-                        notify(.cardQuoted(address))
-                        break
-                    case let .linkTapped(link):
-                        notify(.linkTapped(link))
-                        break
-                    case .tapped:
-                        notify(.cardTapped(card))
-                    case .delete:
-                        break
-                    }
+                    notify(.entry(notification))
                 }
             )
             // Size card based on available space

--- a/xcode/Subconscious/Shared/Components/Deck/CardStackView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/CardStackView.swift
@@ -261,6 +261,10 @@ struct CardStack: View {
                     case let .linkTapped(link):
                         notify(.linkTapped(link))
                         break
+                    case .tapped:
+                        notify(.cardTapped(card))
+                    case .delete:
+                        break
                     }
                 }
             )

--- a/xcode/Subconscious/Shared/Components/Deck/Cards/CardContentView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/Cards/CardContentView.swift
@@ -50,7 +50,7 @@ struct CardContentView: View {
     var entry: EntryStub
     var liked: Bool
     var related: Set<EntryStub>
-    var notify: (CardNotification) -> Void
+    var notify: (EntryNotification) -> Void
     
     var highlight: Color {
         entry.highlightColor

--- a/xcode/Subconscious/Shared/Components/Deck/Cards/CardContentView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/Cards/CardContentView.swift
@@ -64,7 +64,7 @@ struct CardContentView: View {
         SubtextView(
             peer: entry.toPeer(),
             subtext: entry.excerpt,
-            onLink: { link in notify(.linkTapped(link)) }
+            onLink: { link in notify(.requestLinkDetail(link)) }
         )
         // Opacity allows blendMode to show through
         .foregroundStyle(.primary.opacity(0.8))

--- a/xcode/Subconscious/Shared/Components/Deck/Cards/CardView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/Cards/CardView.swift
@@ -8,18 +8,11 @@
 import Foundation
 import SwiftUI
 
-enum CardNotification {
-    case linkTapped(EntryLink)
-    case like(Slashlink)
-    case unlike(Slashlink)
-    case quote(Slashlink)
-}
-
 struct CardView: View {
     @Environment(\.colorScheme) private var colorScheme
     
     var card: CardModel
-    var notify: (CardNotification) -> Void
+    var notify: (EntryNotification) -> Void
     
     var color: Color {
         switch card.card {

--- a/xcode/Subconscious/Shared/Components/Deck/Cards/EntryCardView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/Cards/EntryCardView.swift
@@ -14,7 +14,7 @@ struct EntryCardView: View {
     var entry: EntryStub
     var liked: Bool
     var related: Set<EntryStub>
-    var notify: (CardNotification) -> Void
+    var notify: (EntryNotification) -> Void
     
     var background: Color {
         entry.color

--- a/xcode/Subconscious/Shared/Components/Deck/Cards/PromptCardView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/Cards/PromptCardView.swift
@@ -15,7 +15,7 @@ struct PromptCardView: View {
     var entry: EntryStub
     var liked: Bool
     var related: Set<EntryStub>
-    var notify: (CardNotification) -> Void
+    var notify: (EntryNotification) -> Void
     
     var background: Color {
         entry.color
@@ -62,6 +62,32 @@ struct PromptCardView: View {
         .cornerRadius(DeckTheme.cornerRadius)
         .contextMenu {
             ShareLink(item: entry.sharedText)
+            
+            if liked {
+                Button(
+                    action: {
+                        notify(.unlike(entry.address))
+                    },
+                    label: {
+                        Label(
+                            "Remove from likes",
+                            systemImage: "heart.slash"
+                        )
+                    }
+                )
+            } else {
+                Button(
+                    action: {
+                        notify(.like(entry.address))
+                    },
+                    label: {
+                        Label(
+                            "Add to likes",
+                            systemImage: "heart"
+                        )
+                    }
+                )
+            }
             
             Button(
                 action: {

--- a/xcode/Subconscious/Shared/Components/Deck/Cards/PromptCardView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/Cards/PromptCardView.swift
@@ -70,7 +70,7 @@ struct PromptCardView: View {
                     },
                     label: {
                         Label(
-                            "Remove from likes",
+                            "Unlike",
                             systemImage: "heart.slash"
                         )
                     }
@@ -82,7 +82,7 @@ struct PromptCardView: View {
                     },
                     label: {
                         Label(
-                            "Add to likes",
+                            "Like",
                             systemImage: "heart"
                         )
                     }
@@ -95,7 +95,7 @@ struct PromptCardView: View {
                 },
                 label: {
                     Label(
-                        "Quote in new note",
+                        "Quote",
                         systemImage: "quote.opening"
                     )
                 }

--- a/xcode/Subconscious/Shared/Components/Deck/DeckNavigationView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/DeckNavigationView.swift
@@ -31,18 +31,23 @@ struct DeckNavigationView: View {
             store.send(.cardPickedUp)
         case .swipeAbandoned:
             store.send(.cardReleased)
-        case let .cardTapped(card):
-            store.send(.cardTapped(card))
-        case let .linkTapped(link):
-            store.send(
-                .detailStack(.findAndPushLinkDetail(link))
-            )
-        case let .cardQuoted(address):
-            store.send(.detailStack(.pushQuoteInNewDetail(address)))
-        case let .cardLiked(address):
-            store.send(.requestUpdateLikeStatus(address, liked: true))
-        case let .cardUnliked(address):
-            store.send(.requestUpdateLikeStatus(address, liked: false))
+        case let .entry(entryNotification):
+            switch entryNotification {
+            case let .requestDetail(entry):
+                store.send(.cardDetailRequested(entry))
+            case let .requestLinkDetail(link):
+                store.send(
+                    .detailStack(.findAndPushLinkDetail(link))
+                )
+            case let .quote(address):
+                store.send(.detailStack(.pushQuoteInNewDetail(address)))
+            case let .like(address):
+                store.send(.requestUpdateLikeStatus(address, liked: true))
+            case let .unlike(address):
+                store.send(.requestUpdateLikeStatus(address, liked: false))
+            case .delete:
+                break
+            }
         }
     }
     

--- a/xcode/Subconscious/Shared/Components/Deck/DeckView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/DeckView.swift
@@ -90,7 +90,7 @@ enum DeckAction: Hashable {
     
     case cardPickedUp
     case cardReleased
-    case cardTapped(CardModel)
+    case cardDetailRequested(EntryStub)
     
     case chooseCard(CardModel)
     case skipCard(CardModel)
@@ -341,10 +341,10 @@ struct DeckModel: ModelProtocol {
             return cardPickedUp(state: state)
         case .cardReleased:
             return cardReleased(state: state)
-        case let .cardTapped(card):
-            return cardTapped(
+        case let .cardDetailRequested(entry):
+            return cardDetailRequested(
                 state: state,
-                card: card,
+                entry: entry,
                 environment: environment
             )
         case let .chooseCard(card):
@@ -753,26 +753,22 @@ struct DeckModel: ModelProtocol {
             return Update(state: state)
         }
 
-        func cardTapped(state: Self, card: CardModel, environment: Environment) -> Update<Self> {
+        func cardDetailRequested(state: Self, entry: EntryStub, environment: Environment) -> Update<Self> {
             state.feedback.prepare()
             state.feedback.impactOccurred()
-            
-            if let entry = card.entry {
-                return update(
-                    state: state,
-                    action: .detailStack(
-                        .pushDetail(
-                            MemoDetailDescription.from(
-                                address: entry.address,
-                                fallback: entry.excerpt.description
-                            )
+        
+            return update(
+                state: state,
+                action: .detailStack(
+                    .pushDetail(
+                        MemoDetailDescription.from(
+                            address: entry.address,
+                            fallback: entry.excerpt.description
                         )
-                    ),
-                    environment: environment
-                )
-            }
-            
-            return Update(state: state)
+                    )
+                ),
+                environment: environment
+            )
         }
        
         

--- a/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
@@ -753,6 +753,8 @@ extension DetailStackAction {
             ))
         case let .requestQuoteInNewNote(address, comment):
             return .pushQuoteInNewDetail(address, comment: comment)
+        case let .requestUpdateLikeStatus(address, liked):
+            return .requestUpdateLikeStatus(address, liked: liked)
         }
     }
 }

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -73,6 +73,30 @@ enum UserProfileDetailNotification: Hashable {
     case requestUpdateLikeStatus(Slashlink, liked: Bool)
 }
 
+extension UserProfileDetailNotification {
+    static func from(_ notification: EntryNotification) -> UserProfileDetailNotification? {
+        switch notification {
+        case let .requestDetail(entry):
+            return .requestDetail( .from(
+                    address: entry.address,
+                    fallback: entry.excerpt.description
+                )
+            )
+        case let .requestLinkDetail(link):
+            return .requestFindLinkDetail(link)
+        case let .quote(address):
+            return .requestQuoteInNewNote(address)
+        case let .like(address):
+            return .requestUpdateLikeStatus(address, liked: true)
+        case let .unlike(address):
+            return .requestUpdateLikeStatus(address, liked: false)
+        // Not currently possible from this view
+        case .delete:
+            return nil
+        }
+    }
+}
+
 extension UserProfileDetailAction {
     static func toAppAction(_ action: Self) -> AppAction? {
         switch action {
@@ -88,30 +112,7 @@ extension UserProfileDetailAction {
             return nil
         }
     }
-    
-    static func from(_ notification: EntryNotification) -> UserProfileDetailNotification? {
-        switch notification {
-        case let .tapped(entry):
-            return .requestDetail( .from(
-                    address: entry.address,
-                    fallback: entry.excerpt.description
-                )
-            )
-        case let .linkTapped(link):
-            return .requestFindLinkDetail(link)
-        case let .quote(address):
-            return .requestQuoteInNewNote(address)
-        case let .like(address):
-            return .requestUpdateLikeStatus(address, liked: true)
-        case let .unlike(address):
-            return .requestUpdateLikeStatus(address, liked: false)
-        // Not currently possible from this view
-        case .delete:
-            return nil
-        }
-    }
 }
-
 
 extension UserProfileDetailAction {
     static func from(_ action: AppAction) -> Self? {

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -88,7 +88,30 @@ extension UserProfileDetailAction {
             return nil
         }
     }
+    
+    static func from(_ notification: EntryNotification) -> UserProfileDetailNotification? {
+        switch notification {
+        case let .tapped(entry):
+            return .requestDetail( .from(
+                    address: entry.address,
+                    fallback: entry.excerpt.description
+                )
+            )
+        case let .linkTapped(link):
+            return .requestFindLinkDetail(link)
+        case let .quote(address):
+            return .requestQuoteInNewNote(address)
+        case let .like(address):
+            return .requestUpdateLikeStatus(address, liked: true)
+        case let .unlike(address):
+            return .requestUpdateLikeStatus(address, liked: false)
+        // Not currently possible from this view
+        case .delete:
+            return nil
+        }
+    }
 }
+
 
 extension UserProfileDetailAction {
     static func from(_ action: AppAction) -> Self? {

--- a/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
@@ -138,6 +138,8 @@ enum NotebookAction: Hashable {
     /// from the list before requesting delete for the animation to work.
     case stageDeleteEntry(Slashlink)
     
+    /// Fetch like status
+    /// This could be removed if we instead index liked status in SQLite
     case refreshLikes
     case succeedRefreshLikes(_ likes: [Slashlink])
     case failRefreshLikes(_ error: String)

--- a/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/Notebook.swift
@@ -984,6 +984,6 @@ struct NotebookModel: ModelProtocol {
     ) -> Update<NotebookModel> {
         var model = state
         model.likes = likes
-        return Update(state: model)
+        return Update(state: model).animation(.easeOutCubic())
     }
 }

--- a/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
@@ -12,6 +12,56 @@ struct NotebookNavigationView: View {
     @ObservedObject var store: Store<NotebookModel>
     
     @Environment (\.colorScheme) var colorScheme
+    
+    func notify(_ notification: EntryNotification) -> Void {
+        switch notification {
+        case let .tapped(entry):
+            store.send(
+                .pushDetail(
+                    MemoEditorDetailDescription(
+                        address: entry.address,
+                        fallback: entry.excerpt.description
+                    )
+                )
+            )
+        case let .delete(address):
+            store.send(
+                .confirmDelete(
+                    address
+                )
+            )
+        case let .linkTapped(link):
+            store.send(
+                .detailStack(
+                    .findAndPushLinkDetail(
+                        link
+                    )
+                )
+            )
+        case let .quote(address):
+            store.send(
+                .detailStack(
+                    .pushQuoteInNewDetail(
+                        address
+                    )
+                )
+            )
+        case let .like(address):
+            store.send(
+                .requestUpdateLikeStatus(
+                    address,
+                    liked: true
+                )
+            )
+        case let .unlike(address):
+            store.send(
+                .requestUpdateLikeStatus(
+                    address,
+                    liked: false
+                )
+            )
+        }
+    }
 
     var body: some View {
         DetailStackView(
@@ -25,31 +75,11 @@ struct NotebookNavigationView: View {
                 VStack(spacing: 0) {
                     EntryListView(
                         entries: store.state.recent,
-                        onEntryPress: {
-                            entry in
-                            store.send(
-                                .pushDetail(
-                                    MemoEditorDetailDescription(
-                                        address: entry.address,
-                                        fallback: entry.excerpt.description
-                                    )
-                                )
-                            )
-                        },
-                        onEntryDelete: { address in
-                            store.send(.confirmDelete(address))
-                        },
+                        likes: store.state.likes,
                         onRefresh: {
                             app.send(.syncAll)
                         },
-                        onLink: { link in
-                            store.send(
-                                .detailStack(.findAndPushLinkDetail(link))
-                            )
-                        },
-                        onQuote: { address in
-                            store.send(.detailStack(.pushQuoteInNewDetail(address)))
-                        }
+                        notify: self.notify
                     )
                     .ignoresSafeArea(.keyboard, edges: .bottom)
                     .confirmationDialog(

--- a/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
+++ b/xcode/Subconscious/Shared/Components/Notebook/NotebookNavigationView.swift
@@ -15,7 +15,7 @@ struct NotebookNavigationView: View {
     
     func notify(_ notification: EntryNotification) -> Void {
         switch notification {
-        case let .tapped(entry):
+        case let .requestDetail(entry):
             store.send(
                 .pushDetail(
                     MemoEditorDetailDescription(
@@ -30,7 +30,7 @@ struct NotebookNavigationView: View {
                     address
                 )
             )
-        case let .linkTapped(link):
+        case let .requestLinkDetail(link):
             store.send(
                 .detailStack(
                     .findAndPushLinkDetail(

--- a/xcode/Subconscious/Shared/Models/StoryEntry.swift
+++ b/xcode/Subconscious/Shared/Models/StoryEntry.swift
@@ -16,6 +16,7 @@ struct StoryEntry:
     var id: String { entry.id.description }
     var entry: EntryStub
     var author: UserProfile
+    var liked: Bool
 
     var description: String {
         """

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -756,7 +756,13 @@ actor DataService {
             for entry in entries {
                 // Have we already found the author for this post?
                 if let author = authors[entry.did] {
-                    stories.append(StoryEntry(entry: entry, author: author))
+                    stories.append(
+                        StoryEntry(
+                            entry: entry,
+                            author: author,
+                            liked: false
+                        )
+                    )
                     continue
                 }
                 
@@ -767,7 +773,13 @@ actor DataService {
                 )
                 
                 authors.updateValue(user, forKey: entry.did)
-                stories.append(StoryEntry(entry: entry, author: user))
+                stories.append(
+                    StoryEntry(
+                        entry: entry,
+                        author: user,
+                        liked: false
+                    )
+                )
             }
             
             return stories

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -49,6 +49,7 @@ actor DataService {
     private var noosphere: NoosphereService
     private var database: DatabaseService
     private var userProfile: UserProfileService
+    private var userLikes: UserLikesService
     private var local: HeaderSubtextMemoStore
     private var logger: Logger = logger
 
@@ -57,13 +58,15 @@ actor DataService {
         database: DatabaseService,
         local: HeaderSubtextMemoStore,
         addressBook: AddressBookService,
-        userProfile: UserProfileService
+        userProfile: UserProfileService,
+        userLikes: UserLikesService
     ) {
         self.database = database
         self.noosphere = noosphere
         self.local = local
         self.addressBook = addressBook
         self.userProfile = userProfile
+        self.userLikes = userLikes
     }
     
     /// Create a default sphere for user if needed, and persist sphere details.
@@ -750,17 +753,19 @@ actor DataService {
     nonisolated func listFeedPublisher() -> AnyPublisher<[StoryEntry], Error> {
         Future.detached {
             let entries = try await self.listFeed()
+            let likes = try await self.userLikes.readOurLikes()
             var authors: [Did:UserProfile] = [:]
             var stories: [StoryEntry] = []
             
             for entry in entries {
+                let liked = likes.contains(where: { like in like == entry.address })
                 // Have we already found the author for this post?
                 if let author = authors[entry.did] {
                     stories.append(
                         StoryEntry(
                             entry: entry,
                             author: author,
-                            liked: false
+                            liked: liked
                         )
                     )
                     continue
@@ -777,7 +782,7 @@ actor DataService {
                     StoryEntry(
                         entry: entry,
                         author: user,
-                        liked: false
+                        liked: liked
                     )
                 )
             }

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -568,6 +568,11 @@ actor UserProfileService {
         // on how many degrees away from this peer we are
         // we might need to load likes as a seperate background task
         for link in likedLinks.collection.reversed() {
+            // This user may have liked their own draft notes, but we can't fetch these
+            if link.isLocal {
+                continue
+            }
+            
             let did = try await sphere.resolve(peer: link.peer)
             let memo = try await sphere.read(slashlink: link)
             

--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -98,6 +98,7 @@ struct UserProfileContentResponse: Equatable, Hashable {
     var following: [StoryUser]
     var followingStatus: UserProfileFollowStatus
     var likes: [EntryStub]
+    var ourLikes: [Slashlink]
 }
 
 struct UserProfileEntry: Codable, Equatable, Hashable {
@@ -557,7 +558,8 @@ actor UserProfileService {
                 slugs: notes
             )
         }
-        let likedLinks = await userLikes.readLikesMemo(sphere: sphere) ?? UserLikesEntry(likes: [])
+        let ourLikes = try await userLikes.readOurLikes()
+        let likedLinks = await userLikes.readLikesMemo(sphere: sphere) ?? UserLikesEntry()
         var likes: [EntryStub] = []
         
         // iterate backwards for reverse chronological feed
@@ -601,7 +603,8 @@ actor UserProfileService {
             recentEntries: recentEntries,
             following: following,
             followingStatus: followingStatus,
-            likes: likes
+            likes: likes,
+            ourLikes: ourLikes
         )
     }
     

--- a/xcode/Subconscious/SubconsciousTests/TestUtilities.swift
+++ b/xcode/Subconscious/SubconsciousTests/TestUtilities.swift
@@ -95,7 +95,8 @@ struct TestUtilities {
             database: database,
             local: local,
             addressBook: addressBook,
-            userProfile: userProfile
+            userProfile: userProfile,
+            userLikes: likes
         )
         
         let transclude = TranscludeService(

--- a/xcode/Subconscious/SubconsciousTests/Tests_DataService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DataService.swift
@@ -223,7 +223,8 @@ final class Tests_DataService: XCTestCase {
                 database: database,
                 local: local,
                 addressBook: addressBook,
-                userProfile: userProfile
+                userProfile: userProfile,
+                userLikes: userLikes
             )
             
             versionX = try await noosphere.version()
@@ -276,7 +277,8 @@ final class Tests_DataService: XCTestCase {
             database: database,
             local: local,
             addressBook: addressBook,
-            userProfile: userProfile
+            userProfile: userProfile,
+            userLikes: userLikes
         )
         let versionY = try await noosphere.version()
         
@@ -586,7 +588,8 @@ final class Tests_DataService: XCTestCase {
             database: database,
             local: local,
             addressBook: addressBook,
-            userProfile: userProfile
+            userProfile: userProfile,
+            userLikes: userLikes
         )
                 
         try await data.writeMemo(

--- a/xcode/Subconscious/SubconsciousTests/Tests_Slashlink.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Slashlink.swift
@@ -23,6 +23,8 @@ final class Tests_Slashlink: XCTestCase {
         XCTAssertNotNil(Slashlink("@bob-foo.alice-foo"))
         XCTAssertNotNil(Slashlink("@bob_foo.alice_foo"))
         XCTAssertNotNil(Slashlink("@bob_foo.alice_foo/foo/bar/baz"))
+        XCTAssertNotNil(Slashlink("did:subconscious:local/k-elo-orfkjwldkfssfsdkkdsdfkkfkssdfaskasfa"))
+        XCTAssertNotNil(Slashlink("did:key:abc123/a-slug"))
     }
     
     func testNotValid() throws {

--- a/xcode/Subconscious/SubconsciousTests/Tests_UserLikesService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_UserLikesService.swift
@@ -87,7 +87,7 @@ final class Tests_UserLikesService: XCTestCase {
         
         let likes3 = try await data.userLikes.readOurLikes()
         
-        XCTAssert(likes3.count == 1)
+        XCTAssert(likes3.count == 2)
     }
     
     func testIsLiked() async throws {


### PR DESCRIPTION
Follow on from https://github.com/subconsciousnetwork/subconscious/pull/1106

Introduces:
- Show liked status with a small heart in list views (notebook & profile)
- Add / remove likes from the list view context menu
- A new `EntryNotification` abstraction to encode the core set of actions that can be taken on a note

# Demo

https://github.com/subconsciousnetwork/subconscious/assets/5009316/b4cc4bda-049f-4f62-9dcb-ae4ab8858be2

