### PR TITLE
Implement "comments" under notes

### DIFF
--- a/xcode/Subconscious/Shared/Components/AICommentsView.swift
+++ b/xcode/Subconscious/Shared/Components/AICommentsView.swift
@@ -1,5 +1,5 @@
 //
-//  CommentsView.swift
+//  AICommentsView.swift
 //  Subconscious
 //
 //  Created by Ben Follington on 13/2/2024.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct CommentsView: View {
+struct AICommentsView: View {
     var comments: [String]
     var onRefresh: () -> Void
     var onRespond: (_ comment: String) -> Void
@@ -55,10 +55,10 @@ struct CommentsView: View {
     }
 }
 
-struct CommentsView_Previews: PreviewProvider {
+struct AICommentsView_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
-            CommentsView(
+            AICommentsView(
                 comments: [
                     "This is a comment",
                     "This is another comment"

--- a/xcode/Subconscious/Shared/Components/CommentsView.swift
+++ b/xcode/Subconscious/Shared/Components/CommentsView.swift
@@ -1,0 +1,71 @@
+//
+//  CommentsView.swift
+//  Subconscious
+//
+//  Created by Ben Follington on 13/2/2024.
+//
+
+import SwiftUI
+
+struct CommentsView: View {
+    var comments: [String]
+    var onRefresh: () -> Void
+    var onRespond: (_ comment: String) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppTheme.unit2) {
+            Button(
+                action: {
+                    onRefresh()
+                },
+                label: {
+                    HStack {
+                        Text("Comments")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                    }
+                }
+            )
+            
+            if comments.count > 0 {
+                LazyVStack(alignment: .leading, spacing: AppTheme.unit2) {
+                    ForEach(comments, id: \.self) { comment in
+                        Button(
+                            action: { onRespond(comment) },
+                            label: {
+                                Text("\(comment)")
+                                    .italic()
+                                    .multilineTextAlignment(.leading)
+                            }
+                        )
+                        .padding(.horizontal, AppTheme.unit3)
+                        .padding(.vertical, AppTheme.unit2)
+                        .foregroundStyle(.primary)
+                        .background(comment.themeColor.toColor())
+                        .cornerRadius(AppTheme.cornerRadiusLg, corners: .allCorners)
+                        .shadow(style: .transclude)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, AppTheme.unit4)
+        .padding(.vertical, AppTheme.unit2)
+    }
+}
+
+struct CommentsView_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            CommentsView(
+                
+                comments: [
+                    "This is a comment",
+                    "This is another comment"
+                ],
+                onRefresh: { },
+                onRespond: { _ in }
+            )
+        }
+    }
+}

--- a/xcode/Subconscious/Shared/Components/CommentsView.swift
+++ b/xcode/Subconscious/Shared/Components/CommentsView.swift
@@ -59,7 +59,6 @@ struct CommentsView_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
             CommentsView(
-                
                 comments: [
                     "This is a comment",
                     "This is another comment"

--- a/xcode/Subconscious/Shared/Components/CommentsView.swift
+++ b/xcode/Subconscious/Shared/Components/CommentsView.swift
@@ -27,9 +27,10 @@ struct CommentsView: View {
                     }
                 }
             )
+            .foregroundStyle(.secondary)
             
             if comments.count > 0 {
-                LazyVStack(alignment: .leading, spacing: AppTheme.unit2) {
+                LazyVStack(alignment: .leading, spacing: AppTheme.unit) {
                     ForEach(comments, id: \.self) { comment in
                         Button(
                             action: { onRespond(comment) },

--- a/xcode/Subconscious/Shared/Components/Deck/DeckTheme.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/DeckTheme.swift
@@ -132,6 +132,9 @@ public extension ThemeColor {
 extension String {
     var themeColor: ThemeColor {
         let colors = ThemeColor.allCases
+        // fast determimistic hash of the string
+        // the inbuilt Swift Hasher() has a random seed, which changes on each
+        // execution
         let hash = self.utf8.reduce(0) { $0 + Int($1) }
         
         return colors[abs(hash.hashValue) % colors.count]

--- a/xcode/Subconscious/Shared/Components/Deck/DeckTheme.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/DeckTheme.swift
@@ -129,10 +129,12 @@ public extension ThemeColor {
     }
 }
 
-private extension Hashable {
+extension String {
     var themeColor: ThemeColor {
         let colors = ThemeColor.allCases
-        return colors[abs(self.hashValue) % colors.count]
+        let hash = self.utf8.reduce(0) { $0 + Int($1) }
+        
+        return colors[abs(hash.hashValue) % colors.count]
     }
 }
 

--- a/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/DetailStackView.swift
@@ -130,7 +130,7 @@ enum DetailStackAction: Hashable {
     case pushRandomDetail(autofocus: Bool)
     case failPushRandomDetail(String)
     
-    case pushQuoteInNewDetail(Slashlink)
+    case pushQuoteInNewDetail(Slashlink, comment: String? = nil)
 
     /// Note lifecycle events.
     /// `request`s are passed up to the app root
@@ -230,11 +230,12 @@ struct DetailStackModel: Hashable, ModelProtocol {
                 environment: environment,
                 autofocus: autofocus
             )
-        case let .pushQuoteInNewDetail(address):
+        case let .pushQuoteInNewDetail(address, comment):
             return pushQuoteInNewDetail(
                 state: state,
                 environment: environment,
-                address: address
+                address: address,
+                comment: comment
             )
         case let .failPushRandomDetail(error):
             return failPushRandomDetail(
@@ -483,8 +484,23 @@ struct DetailStackModel: Hashable, ModelProtocol {
     static func pushQuoteInNewDetail(
         state: Self,
         environment: Environment,
-        address: Slashlink
+        address: Slashlink,
+        comment: String?
     ) -> Update<Self> {
+        if let comment = comment {
+            return update(
+                state: state,
+                action: .pushDetail(
+                    .editor(
+                        MemoEditorDetailDescription(
+                            fallback: "\n\n\(comment) \(address.markup)"
+                        )
+                    )
+                ),
+                environment: environment
+            )
+        }
+        
         return update(
             state: state,
             action: .pushDetail(
@@ -494,7 +510,8 @@ struct DetailStackModel: Hashable, ModelProtocol {
                     )
                 )
             ),
-            environment: environment)
+            environment: environment
+        )
     }
 
     static func failPushRandomDetail(
@@ -684,8 +701,8 @@ extension DetailStackAction {
             return .requestUpdateAudience(address, audience)
         case let .requestAssignNoteColor(address, color):
             return .requestAssignNoteColor(address, color)
-        case let .requestQuoteInNewDetail(address):
-            return .pushQuoteInNewDetail(address)
+        case let .requestQuoteInNewDetail(address, comment):
+            return .pushQuoteInNewDetail(address, comment: comment)
         case let .requestUpdateLikeStatus(address, liked):
             return .requestUpdateLikeStatus(address, liked: liked)
         case let .selectAppendLinkSearchSuggestion(suggestion):
@@ -713,8 +730,8 @@ extension DetailStackAction {
                     )
                 )
             )
-        case let .requestQuoteInNewDetail(address):
-            return .pushQuoteInNewDetail(address)
+        case let .requestQuoteInNewDetail(address, comment):
+            return .pushQuoteInNewDetail(address, comment: comment)
         case let .requestUpdateLikeStatus(address, liked):
             return .requestUpdateLikeStatus(address, liked: liked)
         case let .selectAppendLinkSearchSuggestion(suggestion):
@@ -734,8 +751,8 @@ extension DetailStackAction {
                     address: address
                 )
             ))
-        case let .requestQuoteInNewNote(address):
-            return .pushQuoteInNewDetail(address)
+        case let .requestQuoteInNewNote(address, comment):
+            return .pushQuoteInNewDetail(address, comment: comment)
         }
     }
 }

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -263,6 +263,18 @@ struct MemoEditorDetailView: View {
                         .padding(.bottom, AppTheme.unit4)
                         .padding(.top, AppTheme.unit2)
                         
+                        CommentsView(
+                            comments: store.state.comments,
+                            onRefresh: {
+                                store.send(.refreshComments)
+                            },
+                            onRespond: { comment in
+                                if let address = store.state.address {
+                                    notify(.requestQuoteInNewDetail(address, comment: comment))
+                                }
+                            }
+                        )
+                        
                         BacklinksView(
                             backlinks: store.state.backlinks,
                             onLink: { link in
@@ -334,7 +346,7 @@ enum MemoEditorDetailNotification: Hashable {
     case requestMergeEntry(parent: Slashlink, child: Slashlink)
     case requestUpdateAudience(address: Slashlink, audience: Audience)
     case requestAssignNoteColor(_ address: Slashlink, _ color: ThemeColor)
-    case requestQuoteInNewDetail(_ address: Slashlink)
+    case requestQuoteInNewDetail(_ address: Slashlink, comment: String? = nil)
     case requestUpdateLikeStatus(_ address: Slashlink, liked: Bool)
     case selectAppendLinkSearchSuggestion(AppendLinkSuggestion)
 }
@@ -354,8 +366,8 @@ extension MemoEditorDetailNotification {
             return .requestUpdateAudience(address: address, audience: audience)
         case let .forwardRequestAssignNoteColor(address, color):
             return .requestAssignNoteColor(address, color)
-        case let .requestQuoteInNewNote(address):
-            return .requestQuoteInNewDetail(address)
+        case let .requestQuoteInNewNote(address, comment):
+            return .requestQuoteInNewDetail(address, comment: comment)
         case let .requestUpdateLikeStatus(address, liked):
             return .requestUpdateLikeStatus(address, liked: liked)
         case let .selectAppendLinkSearchSuggestion(suggestion):
@@ -411,6 +423,10 @@ enum MemoEditorDetailAction: Hashable {
     case refreshBacklinks
     case succeedRefreshBacklinks(_ backlinks: [EntryStub])
     case failRefreshBacklinks(_ error: String)
+    
+    case refreshComments
+    case succeedRefreshComments(_ comments: [String])
+    case failRefreshComments(_ error: String)
     
     /// Unable to load detail
     case failLoadDetail(String)
@@ -520,7 +536,7 @@ enum MemoEditorDetailAction: Hashable {
     /// Refresh after save
     case refreshLists
     
-    case requestQuoteInNewNote(_ address: Slashlink)
+    case requestQuoteInNewNote(_ address: Slashlink, comment: String? = nil)
     case selectAppendLinkSearchSuggestion(AppendLinkSuggestion)
 
     /// Local action for requesting editor focus.
@@ -667,8 +683,8 @@ struct MemoEditorDetailMetaSheetCursor: CursorProtocol {
             return .requestAssignNoteColor(color)
         case .requestDelete(let address):
             return .requestDelete(address)
-        case let .requestQuoteInNewNote(address):
-            return .requestQuoteInNewNote(address)
+        case let .requestQuoteInNewNote(address, comment):
+            return .requestQuoteInNewNote(address, comment: comment)
         case let .requestUpdateLikeStatus(address, liked):
             return .requestUpdateLikeStatus(address, liked: liked)
         case let .selectAppendLinkSearchSuggestion(suggestion):
@@ -706,6 +722,8 @@ struct MemoEditorDetailModel: ModelProtocol {
     /// Additional headers that are not well-known headers.
     var additionalHeaders: Headers = []
     var backlinks: [EntryStub] = []
+    
+    var comments: [String] = []
     
     /// Is editor saved?
     var saveState = SaveState.saved
@@ -1108,6 +1126,20 @@ struct MemoEditorDetailModel: ModelProtocol {
                 ),
                 environment: environment
             )
+        case .refreshComments:
+            return refreshComments(
+                state: state,
+                environment: environment
+            )
+        case let .succeedRefreshComments(comments):
+            return succeedRefreshComments(
+                state: state,
+                environment: environment,
+                comments: comments
+            )
+        case let .failRefreshComments(error):
+            logger.error("Failed to refresh comments: \(error)")
+            return Update(state: state)
         case .forwardRequestSaveEntry, .forwardRequestDelete, .forwardRequestMoveEntry,
                 .forwardRequestMergeEntry, .forwardRequestUpdateAudience,
                 .forwardRequestAssignNoteColor:
@@ -1367,7 +1399,8 @@ struct MemoEditorDetailModel: ModelProtocol {
             state: model,
             actions: [
                 .refreshBacklinks,
-                .refreshLikedStatus
+                .refreshLikedStatus,
+                .refreshComments
             ],
             environment: environment
         ).mergeFx(fx)
@@ -2215,6 +2248,43 @@ struct MemoEditorDetailModel: ModelProtocol {
         .eraseToAnyPublisher()
         
         return Update(state: state, fx: fx)
+    }
+    
+    static func refreshComments(
+        state: Self,
+        environment: Environment
+    ) -> Update<Self> {
+        let fx: Fx<MemoEditorDetailAction> = Future.detached {
+            var comments: [String] = []
+            
+            for _ in 0...2 {
+                let comment = await environment.prompt.generate(
+                    input: state.editor.text
+                )
+                comments.append(comment)
+            }
+            
+            return comments.uniquing()
+        }
+        .map { comments in
+            .succeedRefreshComments(comments)
+        }
+        .recover { error in
+            .failRefreshComments(error.localizedDescription)
+        }
+        .eraseToAnyPublisher()
+        
+        return Update(state: state, fx: fx)
+    }
+    
+    static func succeedRefreshComments(
+        state: Self,
+        environment: Environment,
+        comments: [String]
+    ) -> Update<Self> {
+        var model = state
+        model.comments = comments
+        return Update(state: model).animation(.easeOutCubic())
     }
     
     /// Snapshot editor state in preparation for saving.

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -263,7 +263,7 @@ struct MemoEditorDetailView: View {
                         .padding(.bottom, AppTheme.unit4)
                         .padding(.top, AppTheme.unit2)
                         
-                        CommentsView(
+                        AICommentsView(
                             comments: store.state.comments,
                             onRefresh: {
                                 store.send(.refreshComments)

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetailMetaSheetView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetailMetaSheetView.swift
@@ -237,7 +237,7 @@ enum MemoEditorDetailMetaSheetAction: Hashable {
     /// Request this address be deleted.
     /// Should be handled by parent component.
     case requestDelete(Slashlink?)
-    case requestQuoteInNewNote(_ address: Slashlink)
+    case requestQuoteInNewNote(_ address: Slashlink, comment: String? = nil)
     
     /// Tagged actions for append link search sheet
     case appendLinkSearch(AppendLinkSearchAction)

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailMetaSheetView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailMetaSheetView.swift
@@ -152,7 +152,7 @@ enum MemoViewerDetailMetaSheetAction: Hashable {
     case setLiked(_ liked: Bool)
     case requestDismiss
     case requestAuthorDetail(_ author: UserProfile)
-    case requestQuoteInNewNote(_ address: Slashlink)
+    case requestQuoteInNewNote(_ address: Slashlink, comment: String? = nil)
     case requestUpdateLikeStatus(_ address: Slashlink, liked: Bool)
     
     /// Tagged actions for append link search sheet

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -180,6 +180,7 @@ struct MemoViewerDetailLoadedView: View {
                     .background(store.state.themeColor?.toColor())
                     .cornerRadius(DeckTheme.cornerRadius, corners: .allCorners)
                     .shadow(style: .transclude)
+                    .padding(.bottom, AppTheme.unit4)
                     .padding(.top, AppTheme.unit2)
                     
                     CommentsView(
@@ -188,8 +189,7 @@ struct MemoViewerDetailLoadedView: View {
                             store.send(.refreshComments)
                         },
                         onRespond: { comment in
-                            // TODO: new action for quoting with the comment included
-                            notify(.requestQuoteInNewDetail(address))
+                            notify(.requestQuoteInNewDetail(address, comment: comment))
                         }
                     )
                     
@@ -217,7 +217,7 @@ enum MemoViewerDetailNotification: Hashable {
     )
     case requestFindLinkDetail(EntryLink)
     case requestUserProfileDetail(_ address: Slashlink)
-    case requestQuoteInNewDetail(_ address: Slashlink)
+    case requestQuoteInNewDetail(_ address: Slashlink, comment: String? = nil)
     case requestUpdateLikeStatus(_ address: Slashlink, liked: Bool)
     case selectAppendLinkSearchSuggestion(AppendLinkSuggestion)
 }
@@ -227,8 +227,8 @@ extension MemoViewerDetailNotification {
         switch action {
         case let .requestAuthorDetail(user):
             return .requestUserProfileDetail(user.address)
-        case let .requestQuoteInNewNote(address):
-            return .requestQuoteInNewDetail(address)
+        case let .requestQuoteInNewNote(address, comment):
+            return .requestQuoteInNewDetail(address, comment: comment)
         case let .requestUpdateLikeStatus(address, liked):
             return .requestUpdateLikeStatus(address, liked: liked)
         case let .selectAppendLinkSearchSuggestion(suggestion):
@@ -269,7 +269,7 @@ enum MemoViewerDetailAction: Hashable {
     
     case succeedIndexBackgroundSphere
     case requestAuthorDetail(_ author: UserProfile)
-    case requestQuoteInNewNote(_ address: Slashlink)
+    case requestQuoteInNewNote(_ address: Slashlink, comment: String? = nil)
     case requestUpdateLikeStatus(_ address: Slashlink, liked: Bool)
     
     case refreshLikedStatus
@@ -788,8 +788,8 @@ struct MemoViewerDetailMetaSheetCursor: CursorProtocol {
             return .presentMetaSheet(false)
         case let .requestAuthorDetail(user):
             return .requestAuthorDetail(user)
-        case let .requestQuoteInNewNote(address):
-            return .requestQuoteInNewNote(address)
+        case let .requestQuoteInNewNote(address, comment):
+            return .requestQuoteInNewNote(address, comment: comment)
         case let .requestUpdateLikeStatus(address, liked):
             return .requestUpdateLikeStatus(address, liked: liked)
         case let .selectAppendLinkSearchSuggestion(suggestion):

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -183,7 +183,7 @@ struct MemoViewerDetailLoadedView: View {
                     .padding(.bottom, AppTheme.unit4)
                     .padding(.top, AppTheme.unit2)
                     
-                    CommentsView(
+                    AICommentsView(
                         comments: store.state.comments,
                         onRefresh: {
                             store.send(.refreshComments)

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -69,7 +69,7 @@ enum UserProfileDetailNotification: Hashable {
     case requestNavigateToProfile(_ address: Slashlink)
     case requestDetail(MemoDetailDescription)
     case requestFindLinkDetail(EntryLink)
-    case requestQuoteInNewNote(_ address: Slashlink)
+    case requestQuoteInNewNote(_ address: Slashlink, comment: String? = nil)
 }
 
 extension UserProfileDetailAction {

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -38,8 +38,8 @@
 		B53B60162B47EF77007BF747 /* Tests_HomeProfile_NotificationActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53B60152B47EF77007BF747 /* Tests_HomeProfile_NotificationActions.swift */; };
 		B53B60182B47F51E007BF747 /* Tests_CardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53B60172B47F51E007BF747 /* Tests_CardModel.swift */; };
 		B53B601A2B47FD1C007BF747 /* Tests_MemoEditorDetailNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53B60192B47FD1C007BF747 /* Tests_MemoEditorDetailNotification.swift */; };
-		B53DC5302B7B2B0E00D20CCB /* CommentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53DC52F2B7B2B0E00D20CCB /* CommentsView.swift */; };
-		B53DC5312B7B2B0E00D20CCB /* CommentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53DC52F2B7B2B0E00D20CCB /* CommentsView.swift */; };
+		B53DC5302B7B2B0E00D20CCB /* AICommentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53DC52F2B7B2B0E00D20CCB /* AICommentsView.swift */; };
+		B53DC5312B7B2B0E00D20CCB /* AICommentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53DC52F2B7B2B0E00D20CCB /* AICommentsView.swift */; };
 		B540F8BA2A0C748C00876256 /* Line.swift in Sources */ = {isa = PBXBuildFile; fileRef = B540F8B92A0C748C00876256 /* Line.swift */; };
 		B54187B829EF5CA00056E4A9 /* FollowUserFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54187B729EF5CA00056E4A9 /* FollowUserFormView.swift */; };
 		B542EF672AF48F2100BE29F1 /* StoreUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B542EF662AF48F2100BE29F1 /* StoreUtilities.swift */; };
@@ -603,7 +603,7 @@
 		B53B60152B47EF77007BF747 /* Tests_HomeProfile_NotificationActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_HomeProfile_NotificationActions.swift; sourceTree = "<group>"; };
 		B53B60172B47F51E007BF747 /* Tests_CardModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_CardModel.swift; sourceTree = "<group>"; };
 		B53B60192B47FD1C007BF747 /* Tests_MemoEditorDetailNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_MemoEditorDetailNotification.swift; sourceTree = "<group>"; };
-		B53DC52F2B7B2B0E00D20CCB /* CommentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentsView.swift; sourceTree = "<group>"; };
+		B53DC52F2B7B2B0E00D20CCB /* AICommentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AICommentsView.swift; sourceTree = "<group>"; };
 		B540F8B92A0C748C00876256 /* Line.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Line.swift; sourceTree = "<group>"; };
 		B54187B729EF5CA00056E4A9 /* FollowUserFormView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FollowUserFormView.swift; sourceTree = "<group>"; };
 		B542EF662AF48F2100BE29F1 /* StoreUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreUtilities.swift; sourceTree = "<group>"; };
@@ -1683,13 +1683,13 @@
 		B8EB2A3826F27CD1006E97C3 /* Components */ = {
 			isa = PBXGroup;
 			children = (
-				B58CC8DD2B0C6C26004CFFEA /* Deck */,
+				B53DC52F2B7B2B0E00D20CCB /* AICommentsView.swift */,
 				B82F053628D60EE60025A8B5 /* AppTabView.swift */,
 				B8DA32B429CB999500EA166E /* AppUpgradeView.swift */,
 				B8EB29F526F27794006E97C3 /* AppView.swift */,
 				B8879EA826F93EBF00A0B4FF /* BacklinksView.swift */,
-				B53DC52F2B7B2B0E00D20CCB /* CommentsView.swift */,
 				B8EC568426F41A2C00AC64E5 /* Common */,
+				B58CC8DD2B0C6C26004CFFEA /* Deck */,
 				B87288E2299C02E200EF7E07 /* Detail */,
 				B8B3EE712979DEDF00779B7F /* FirstRun */,
 				B8AE34C4276BF72500777FF0 /* LinkSearchView.swift */,
@@ -2222,7 +2222,7 @@
 				B5D769CB29F770440015385A /* GenerativeProfilePic.swift in Sources */,
 				B828F0AA2B029C9F00FDE4AE /* BlockEditorTranscludeListView.swift in Sources */,
 				B8B4D7EE27EA8AA000633B5F /* DragHandleView.swift in Sources */,
-				B53DC5302B7B2B0E00D20CCB /* CommentsView.swift in Sources */,
+				B53DC5302B7B2B0E00D20CCB /* AICommentsView.swift in Sources */,
 				B8545F0A296F8FB700BC4EA1 /* OmniboxView.swift in Sources */,
 				B5CA6F3F2B5A4E5D00877B0D /* AppendLinkSearchView.swift in Sources */,
 				B5C818D62AF380A7001F65BE /* CardStackView.swift in Sources */,
@@ -2468,7 +2468,7 @@
 				B542EF7B2AF4963700BE29F1 /* UserProfileDetialMetaSheetModifier.swift in Sources */,
 				B8EF986F29034ADF0029363D /* Pathlike.swift in Sources */,
 				B542EF6B2AF493F800BE29F1 /* RenameUserSheet.swift in Sources */,
-				B53DC5312B7B2B0E00D20CCB /* CommentsView.swift in Sources */,
+				B53DC5312B7B2B0E00D20CCB /* AICommentsView.swift in Sources */,
 				B82D145529EF157B009E21FF /* SubtextView.swift in Sources */,
 				B8A1621929B39337008322EB /* ExpandAlignedLeadingViewModifier.swift in Sources */,
 				B8879EAA26F93EBF00A0B4FF /* BacklinksView.swift in Sources */,

--- a/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
+++ b/xcode/Subconscious/Subconscious.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		B53B60162B47EF77007BF747 /* Tests_HomeProfile_NotificationActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53B60152B47EF77007BF747 /* Tests_HomeProfile_NotificationActions.swift */; };
 		B53B60182B47F51E007BF747 /* Tests_CardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53B60172B47F51E007BF747 /* Tests_CardModel.swift */; };
 		B53B601A2B47FD1C007BF747 /* Tests_MemoEditorDetailNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53B60192B47FD1C007BF747 /* Tests_MemoEditorDetailNotification.swift */; };
+		B53DC5302B7B2B0E00D20CCB /* CommentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53DC52F2B7B2B0E00D20CCB /* CommentsView.swift */; };
+		B53DC5312B7B2B0E00D20CCB /* CommentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53DC52F2B7B2B0E00D20CCB /* CommentsView.swift */; };
 		B540F8BA2A0C748C00876256 /* Line.swift in Sources */ = {isa = PBXBuildFile; fileRef = B540F8B92A0C748C00876256 /* Line.swift */; };
 		B54187B829EF5CA00056E4A9 /* FollowUserFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54187B729EF5CA00056E4A9 /* FollowUserFormView.swift */; };
 		B542EF672AF48F2100BE29F1 /* StoreUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B542EF662AF48F2100BE29F1 /* StoreUtilities.swift */; };
@@ -601,6 +603,7 @@
 		B53B60152B47EF77007BF747 /* Tests_HomeProfile_NotificationActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_HomeProfile_NotificationActions.swift; sourceTree = "<group>"; };
 		B53B60172B47F51E007BF747 /* Tests_CardModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_CardModel.swift; sourceTree = "<group>"; };
 		B53B60192B47FD1C007BF747 /* Tests_MemoEditorDetailNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_MemoEditorDetailNotification.swift; sourceTree = "<group>"; };
+		B53DC52F2B7B2B0E00D20CCB /* CommentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentsView.swift; sourceTree = "<group>"; };
 		B540F8B92A0C748C00876256 /* Line.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Line.swift; sourceTree = "<group>"; };
 		B54187B729EF5CA00056E4A9 /* FollowUserFormView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FollowUserFormView.swift; sourceTree = "<group>"; };
 		B542EF662AF48F2100BE29F1 /* StoreUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreUtilities.swift; sourceTree = "<group>"; };
@@ -1685,6 +1688,7 @@
 				B8DA32B429CB999500EA166E /* AppUpgradeView.swift */,
 				B8EB29F526F27794006E97C3 /* AppView.swift */,
 				B8879EA826F93EBF00A0B4FF /* BacklinksView.swift */,
+				B53DC52F2B7B2B0E00D20CCB /* CommentsView.swift */,
 				B8EC568426F41A2C00AC64E5 /* Common */,
 				B87288E2299C02E200EF7E07 /* Detail */,
 				B8B3EE712979DEDF00779B7F /* FirstRun */,
@@ -2218,6 +2222,7 @@
 				B5D769CB29F770440015385A /* GenerativeProfilePic.swift in Sources */,
 				B828F0AA2B029C9F00FDE4AE /* BlockEditorTranscludeListView.swift in Sources */,
 				B8B4D7EE27EA8AA000633B5F /* DragHandleView.swift in Sources */,
+				B53DC5302B7B2B0E00D20CCB /* CommentsView.swift in Sources */,
 				B8545F0A296F8FB700BC4EA1 /* OmniboxView.swift in Sources */,
 				B5CA6F3F2B5A4E5D00877B0D /* AppendLinkSearchView.swift in Sources */,
 				B5C818D62AF380A7001F65BE /* CardStackView.swift in Sources */,
@@ -2463,6 +2468,7 @@
 				B542EF7B2AF4963700BE29F1 /* UserProfileDetialMetaSheetModifier.swift in Sources */,
 				B8EF986F29034ADF0029363D /* Pathlike.swift in Sources */,
 				B542EF6B2AF493F800BE29F1 /* RenameUserSheet.swift in Sources */,
+				B53DC5312B7B2B0E00D20CCB /* CommentsView.swift in Sources */,
 				B82D145529EF157B009E21FF /* SubtextView.swift in Sources */,
 				B8A1621929B39337008322EB /* ExpandAlignedLeadingViewModifier.swift in Sources */,
 				B8879EAA26F93EBF00A0B4FF /* BacklinksView.swift in Sources */,


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/1085

- Implement deterministic hash for color across executions
- Add comments to editor and viewer
- Tapping a comment will open a new editor instance preloaded with the comment + address 

<img src="https://github.com/subconsciousnetwork/subconscious/assets/5009316/98d66c9c-b62f-4203-8d5a-88da574d73c2" width=320>
