### PR TITLE
Skip unloadable likes and unresolvable peers when reading user likes

### DIFF
--- a/xcode/Subconscious/Shared/Services/UserProfileService.swift
+++ b/xcode/Subconscious/Shared/Services/UserProfileService.swift
@@ -573,10 +573,13 @@ actor UserProfileService {
                 continue
             }
             
-            let did = try await sphere.resolve(peer: link.peer)
-            let memo = try await sphere.read(slashlink: link)
+            // This might fail if the slug has been deleted or peer is unresolvable etc.
+            // We want to skip this like and load the rest.
+            let did = try? await sphere.resolve(peer: link.peer)
+            let memo = try? await sphere.read(slashlink: link)
             
-            guard let memo = memo.toMemo() else {
+            guard let did = did,
+                  let memo = memo?.toMemo() else {
                 continue
             }
             


### PR DESCRIPTION
Liking a note and then deleting it triggered a "Not Found" error on the profile view.

We should skip over unreadable likes rather than throwing.