### PR TITLE
Reduce app startup time

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -77,6 +77,7 @@ struct AppView: View {
             )
         }
         .onAppear {
+            SentryIntegration.start()
             store.send(.appear)
         }
         // Track changes to scene phase so we know when app gets

--- a/xcode/Subconscious/Shared/Components/Deck/DeckView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/DeckView.swift
@@ -518,20 +518,15 @@ struct DeckModel: ModelProtocol {
                 try? await Task.sleep(for: .seconds(Duration.loading))
                 
                 let us = try await environment.noosphere.identity()
-                let recent = try environment.database.listFeed(owner: us)
+                let recent = try environment.database.listAll(owner: us, limit: 5)
                 let likes = try await environment.userLikes.readOurLikes()
                 
                 var initialDraw = Array(recent
-                    .prefix(10) // take the 10 most recent posts
+                    .prefix(5) // take the 10 most recent posts
                     .shuffled() // shuffle
-                    .prefix(3)) // take 3
-                
-                // Draw 2 random cards to keep it surprising
-                for _ in 0..<2 {
-                    guard let entry = environment.database.readRandomEntry(owner: us) else {
-                        continue
-                    }
-                    
+                    .prefix(2))
+            
+                if let entry = environment.database.readRandomEntry(owner: us) {
                     initialDraw.append(entry)
                 }
                 

--- a/xcode/Subconscious/Shared/Components/Deck/DeckView.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/DeckView.swift
@@ -521,10 +521,12 @@ struct DeckModel: ModelProtocol {
                 let recent = try environment.database.listAll(owner: us, limit: 5)
                 let likes = try await environment.userLikes.readOurLikes()
                 
-                var initialDraw = Array(recent
-                    .prefix(5) // take the 10 most recent posts
-                    .shuffled() // shuffle
-                    .prefix(2))
+                var initialDraw = Array(
+                    recent
+                        .prefix(5)
+                        .shuffled()
+                        .prefix(2)
+                )
             
                 if let entry = environment.database.readRandomEntry(owner: us) {
                     initialDraw.append(entry)

--- a/xcode/Subconscious/Shared/Library/Sentry.swift
+++ b/xcode/Subconscious/Shared/Library/Sentry.swift
@@ -48,9 +48,6 @@ extension SentryIntegration {
             // per https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization this is fine to be public, unless it's abused (e.g. someone sending us /extra/ errors.
             options.dsn = "https://72ea1a54aeb04f60880d75fcffe705ed@o4505393671569408.ingest.sentry.io/4505393756438528"
             options.environment = Config.default.debug ? "development" : "production"
-            options.tracesSampleRate = 1.0
-            options.profilesSampleRate = 1.0
-            options.attachViewHierarchy = true
             
             options.beforeSend = { event in
                 let ev = event

--- a/xcode/Subconscious/Shared/Services/DatabaseService.swift
+++ b/xcode/Subconscious/Shared/Services/DatabaseService.swift
@@ -553,7 +553,7 @@ final class DatabaseService {
         return excerpt.data(using: .utf8)
     }
     
-    func listFeed(owner: Did) throws -> [EntryStub] {
+    func listAll(owner: Did, limit: Int = 1000) throws -> [EntryStub] {
         guard self.state == .ready else {
             throw DatabaseServiceError.notReady
         }
@@ -568,10 +568,11 @@ final class DatabaseService {
             WHERE did NOT IN (SELECT value FROM json_each(?))
                 AND substr(slug, 1, 1) != '_'
             ORDER BY modified DESC
-            LIMIT 1000
+            LIMIT ?
             """,
             parameters: [
-                .json(ignoredDids, or: "[]")
+                .json(ignoredDids, or: "[]"),
+                .integer(limit)
             ]
         )
         return try results.compactMap({ row in

--- a/xcode/Subconscious/Shared/SubconsciousApp.swift
+++ b/xcode/Subconscious/Shared/SubconsciousApp.swift
@@ -12,7 +12,6 @@ import OSLog
 @main
 struct SubconsciousApp: App {
     init() {
-        SentryIntegration.start()
         NoosphereLogProxy.connect()
     }
 

--- a/xcode/Subconscious/SubconsciousTests/Tests_DataService.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_DataService.swift
@@ -526,7 +526,7 @@ final class Tests_DataService: XCTestCase {
             body: "Hello world!"
         )))
 
-        let list = try await environment.data.listFeed()
+        let list = try await environment.data.listAll()
         
         XCTAssertEqual(list.count, 3)
         XCTAssertEqual(list.filter({ entry in entry.address.isOurs }).count, 2)


### PR DESCRIPTION
While testing 0.0.18 I noticed the app seemed slow to boot & laggy at times. I profiled it using the App Startup profiling, as well as SwiftUI and good old fashioned CPU profiling, found the main bottlenecks and removed them:

- Limit the number of rows read from the DB to populate the deck
- Remove Sentry profiling integration
    - Turns out we have to pay more money for this and we can profile the app locally just fine for now
- Defer SentryIntegration.start()

For me this seems to cut down launch time by nearly a second in the simulator. Hopefully that carries over to a real device!