### PR TITLE
Visual tweaks after playtesting

### DIFF
--- a/xcode/Subconscious/Shared/Components/AICommentsView.swift
+++ b/xcode/Subconscious/Shared/Components/AICommentsView.swift
@@ -11,6 +11,7 @@ struct AICommentsView: View {
     var comments: [String]
     var onRefresh: () -> Void
     var onRespond: (_ comment: String) -> Void
+    var background: Color
 
     var body: some View {
         VStack(alignment: .leading, spacing: AppTheme.unit2) {
@@ -43,7 +44,7 @@ struct AICommentsView: View {
                         .padding(.horizontal, AppTheme.unit3)
                         .padding(.vertical, AppTheme.unit2)
                         .foregroundStyle(.primary)
-                        .background(comment.themeColor.toColor())
+                        .background(background)
                         .cornerRadius(AppTheme.cornerRadiusLg, corners: .allCorners)
                         .shadow(style: .transclude)
                     }
@@ -64,7 +65,8 @@ struct AICommentsView_Previews: PreviewProvider {
                     "This is another comment"
                 ],
                 onRefresh: { },
-                onRespond: { _ in }
+                onRespond: { _ in },
+                background: .red
             )
         }
     }

--- a/xcode/Subconscious/Shared/Components/Deck/DeckTheme.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/DeckTheme.swift
@@ -15,12 +15,12 @@ extension DeckTheme {
         blendDuration: 0
     )
     
-    static let dragTargetSize = CGSize(width: 16, height: 400)
+    static let dragTargetSize = CGSize(width: 16, height: 380)
     
     static let cardPadding = AppTheme.unit * 5
     static let cornerRadius: CGFloat = 32.0
-    static let cardSize = CGSize(width: 374, height: 420)
-    static let cardContentSize = CGSize(width: 374, height: AppTheme.unit * 80)
+    static let cardSize = CGSize(width: 374, height: 380)
+    static let cardContentSize = CGSize(width: 374, height: AppTheme.unit * 70)
     
     static let cardShadow = Color(red: 0.19, green: 0.09, blue: 0.33)
     

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -277,7 +277,8 @@ struct MemoEditorDetailView: View {
                                 if let address = store.state.address {
                                     notify(.requestQuoteInNewDetail(address, comment: comment))
                                 }
-                            }
+                            },
+                            background: background ?? .secondary
                         )
                         
                         BacklinksView(

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -254,7 +254,12 @@ struct MemoEditorDetailView: View {
                                         }
                                     )
                                 }
-                                .padding(AppTheme.padding)
+                                .padding(EdgeInsets(
+                                    top: 0,
+                                    leading: AppTheme.padding,
+                                    bottom: AppTheme.padding,
+                                    trailing: AppTheme.padding
+                                ))
                             }
                         }
                         .background(background)

--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -256,9 +256,9 @@ struct MemoEditorDetailView: View {
                                 }
                                 .padding(EdgeInsets(
                                     top: 0,
-                                    leading: AppTheme.padding,
-                                    bottom: AppTheme.padding,
-                                    trailing: AppTheme.padding
+                                    leading: DeckTheme.cardPadding,
+                                    bottom: DeckTheme.cardPadding,
+                                    trailing: DeckTheme.cardPadding
                                 ))
                             }
                         }

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -524,6 +524,7 @@ struct MemoViewerDetailModel: ModelProtocol {
             // Set meta sheet address as well
             actions: [
                 .setMetaSheetAddress(description.address),
+                .refreshComments,
                 .refreshAll
             ],
             environment: environment
@@ -551,8 +552,7 @@ struct MemoViewerDetailModel: ModelProtocol {
             state: model,
             actions: [
                 .fetchOwnerProfile,
-                .refreshBacklinks,
-                .refreshComments
+                .refreshBacklinks
             ],
             environment: environment
         ).mergeFx(fx)

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -144,7 +144,39 @@ struct MemoViewerDetailLoadedView: View {
     var body: some View {
         GeometryReader { geometry in
             ScrollView {
-                VStack(spacing: 0) {
+                VStack(alignment: .leading, spacing: 0) {
+                    if let author = store.state.owner,
+                       let name = author.toNameVariant() {
+                        Button(
+                            action: {
+                                store.send(.requestAuthorDetail(author))
+                            },
+                            label: {
+                                HStack(
+                                    alignment: .center,
+                                    spacing: AppTheme.unit3
+                                ) {
+                                    ProfilePic(
+                                        pfp: author.pfp,
+                                        size: .large
+                                    )
+                                    
+                                    PetnameView(
+                                        name: name,
+                                        aliases: [],
+                                        showMaybePrefix: false
+                                    )
+                                }
+                                .transition(
+                                    .push(
+                                        from: .bottom
+                                    )
+                                )
+                            }
+                        )
+                        .padding(AppTheme.padding)
+                        
+                    }
                     VStack {
                         SubtextView(
                             peer: store.state.owner?.address.peer,

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -137,6 +137,10 @@ struct MemoViewerDetailLoadedView: View {
         category: "MemoViewerDetailLoadedView"
     )
     
+    var background: Color? {
+        store.state.themeColor?.toColor()
+    }
+    
     var body: some View {
         GeometryReader { geometry in
             ScrollView {
@@ -177,7 +181,7 @@ struct MemoViewerDetailLoadedView: View {
                     .frame(
                         minHeight: UIFont.appTextMono.lineHeight * 8
                     )
-                    .background(store.state.themeColor?.toColor())
+                    .background(background)
                     .cornerRadius(DeckTheme.cornerRadius, corners: .allCorners)
                     .shadow(style: .transclude)
                     .padding(.bottom, AppTheme.unit4)
@@ -190,7 +194,8 @@ struct MemoViewerDetailLoadedView: View {
                         },
                         onRespond: { comment in
                             notify(.requestQuoteInNewDetail(address, comment: comment))
-                        }
+                        },
+                        background: background ?? .secondary
                     )
                     
                     BacklinksView(


### PR DESCRIPTION
- Reduce card height to account for prompt header
    - Cards grew in height when we introduced prompts and they feel too tall to me now
- Make whitespace around like button consistent between viewer and editor
- Add user profile header to the viewer
    - Optional addition, I felt myself craving it while browsing
- Comments inherit the note color
    - Reduces noise + creates a sense of visual relatedness

<img src="https://github.com/subconsciousnetwork/subconscious/assets/5009316/e315d012-1b58-44d4-ba57-0470cc467ba0" width=320 /> <img src="https://github.com/subconsciousnetwork/subconscious/assets/5009316/f555713d-68e1-489f-89f7-a82f5541eedb" width=320 />