### PR TITLE
Fix unstable derived note colors

### DIFF
--- a/xcode/Subconscious/Shared/Components/BacklinksView.swift
+++ b/xcode/Subconscious/Shared/Components/BacklinksView.swift
@@ -30,7 +30,7 @@ struct BacklinksView: View {
                             .buttonStyle(RelatedNoteButtonStyle(color: entry.color))
                         }
                         .tint(
-                            entry.headers.themeColor?.toHighlightColor()
+                            entry.highlightColor
                         )
                     }
                 }

--- a/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeListView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/Transclude/TranscludeListView.swift
@@ -26,7 +26,7 @@ struct TranscludeListView: View {
                     )
                 }
                 .tint(
-                    entry.headers.themeColor?.toHighlightColor()
+                    entry.highlightColor
                 )
             }
         }

--- a/xcode/Subconscious/Shared/Components/Deck/DeckTheme.swift
+++ b/xcode/Subconscious/Shared/Components/Deck/DeckTheme.swift
@@ -137,7 +137,7 @@ extension String {
         // execution
         let hash = self.utf8.reduce(0) { $0 + Int($1) }
         
-        return colors[abs(hash.hashValue) % colors.count]
+        return colors[abs(hash) % colors.count]
     }
 }
 


### PR DESCRIPTION
Note colors can change between app restarts. Apparently I messed this up again even after trying to fix it in https://github.com/subconsciousnetwork/subconscious/pull/1114

The mistake was subtle, so I'll give myself a pass.
