### PR TITLE
Improve indexing performance

### DIFF
--- a/xcode/Subconscious/Shared/Components/AppView.swift
+++ b/xcode/Subconscious/Shared/Components/AppView.swift
@@ -100,7 +100,12 @@ struct PeerIndexError: Error, Hashable {
     let petname: Petname
 }
 
-typealias PeerIndexResult = Result<PeerRecord, PeerIndexError>
+struct PeerIndexSuccess: Hashable {
+    let changeCount: Int
+    let peer: PeerRecord
+}
+
+typealias PeerIndexResult = Result<PeerIndexSuccess, PeerIndexError>
 
 // MARK: Action
 enum AppAction: Hashable {
@@ -2447,13 +2452,13 @@ struct AppModel: ModelProtocol {
     ) -> Update<Self> {
         for result in results {
             switch (result) {
-            case .success(let peer):
+            case .success(let result):
                 logger.log(
                     "Indexed peer",
                     metadata: [
-                        "petname": peer.petname.description,
-                        "identity": peer.identity.description,
-                        "since": peer.since ?? "nil"
+                        "petname": result.peer.petname.description,
+                        "identity": result.peer.identity.description,
+                        "since": result.peer.since ?? "nil"
                     ]
                 )
                 break

--- a/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/UserProfileDetailView.swift
@@ -1192,7 +1192,7 @@ struct UserProfileDetailModel: ModelProtocol {
         // Check if we're in the list of successfully indexed peers
         let shouldRefresh = results.contains(where: { result in
             switch (result) {
-            case .success(let peer) where peer.identity == state.user?.did:
+            case .success(let result) where result.peer.identity == state.user?.did:
                 return true
             default:
                 return false

--- a/xcode/Subconscious/Shared/Models/Memo.swift
+++ b/xcode/Subconscious/Shared/Models/Memo.swift
@@ -173,6 +173,8 @@ extension MemoRecord {
         memo: Memo,
         size: Int? = nil
     ) throws {
+        let dom = memo.dom()
+        
         try self.init(
             did: did,
             petname: petname,
@@ -180,13 +182,13 @@ extension MemoRecord {
             contentType: memo.contentType,
             created: memo.created,
             modified: memo.modified,
-            title: memo.title(),
+            title: dom.title(),
             fileExtension: memo.fileExtension,
             headers: memo.headers,
             body: memo.body,
             description: memo.plain(),
-            excerpt: memo.excerpt(),
-            links: memo.slugs(),
+            excerpt: dom.excerpt().description,
+            links: dom.slugs,
             size: size
         )
     }

--- a/xcode/Subconscious/Shared/Models/Memo.swift
+++ b/xcode/Subconscious/Shared/Models/Memo.swift
@@ -173,7 +173,7 @@ extension MemoRecord {
         memo: Memo,
         size: Int? = nil
     ) throws {
-        let dom = memo.dom()
+        let dom = Subtext.excerpt(markup: memo.body)
         
         try self.init(
             did: did,
@@ -187,7 +187,7 @@ extension MemoRecord {
             headers: memo.headers,
             body: memo.body,
             description: memo.plain(),
-            excerpt: dom.excerpt().description,
+            excerpt: dom.description,
             links: dom.slugs,
             size: size
         )

--- a/xcode/Subconscious/Shared/Parsers/Tape.swift
+++ b/xcode/Subconscious/Shared/Parsers/Tape.swift
@@ -84,10 +84,23 @@ struct Tape {
     /// Peek forward, and consume if substrings match
     mutating func consumeMatch(_ subsequence: Substring) -> Bool {
         if let endIndex = offset(by: subsequence.count) {
-            if rest[currentIndex..<endIndex] == subsequence {
-                self.currentIndex = endIndex
-                return true
-            }
+            var idxA = currentIndex
+            var idxB = subsequence.startIndex
+            
+            // iterating through both indices is MUCH faster than constructing and comparing
+            // a substring slice, especially since we get early exist on the first mismatched
+            // character.
+            repeat {
+                if rest[idxA] != subsequence[idxB] {
+                    return false
+                }
+                
+                idxA = rest.index(after: idxA)
+                idxB = subsequence.index(after: idxB)
+            } while idxB < subsequence.endIndex
+            
+            self.currentIndex = endIndex
+            return true
         }
         return false
     }

--- a/xcode/Subconscious/Shared/Services/DataService.swift
+++ b/xcode/Subconscious/Shared/Services/DataService.swift
@@ -171,13 +171,11 @@ actor DataService {
                 }
             }
             
-            await Task.yield()
-            
             let records = try await withThrowingTaskGroup(of: MemoRecord.self) { group in
                 var records = [MemoRecord]()
                 
                 for (slug, memo) in toUpdate {
-                    group.addTask {
+                    group.addTask(priority: .background) {
                         // Each task attempts to instantiate a MemoRecord
                         return try MemoRecord(did: identity, petname: petname, slug: slug, memo: memo)
                     }
@@ -190,6 +188,8 @@ actor DataService {
                 
                 return records
             }
+            
+            await Task.yield()
             
             for record in records {
                 try database.writeMemo(record)
@@ -295,7 +295,7 @@ actor DataService {
         let results = await withTaskGroup(of: PeerIndexResult.self) { group in
             var results: [PeerIndexResult] = []
             for petname in petnames {
-                group.addTask {
+                group.addTask(priority: .background) {
                     await self.logger.log(
                         "Indexing peer",
                         metadata: [


### PR DESCRIPTION
- Batch reads and database calls in tight loops
- Reduce re-parsing cost in MemoRecord init
- Index peers in TaskGroup
- Reduce re-parsing again
- Adjust task priority

Speeds up indexing between 4x and 6x.

Before

<img width="900" alt="image" src="https://github.com/subconsciousnetwork/subconscious/assets/5009316/61b24d0b-2bdf-4dfa-89dd-c0b3e840e545">

After

<img width="905" alt="image" src="https://github.com/subconsciousnetwork/subconscious/assets/5009316/baac1f3c-e73c-4b88-9b58-7a04c742a766">

