### PR TITLE
Prevent runaway autosave polling + concurrent save attempts

### DIFF
--- a/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoEditorDetail.swift
@@ -1748,7 +1748,9 @@ struct MemoEditorDetailModel: ModelProtocol {
             )
         }
         
-        guard let entry = state.snapshotEntry() else {
+        // Ensure we have something to actually save
+        guard let entry = state.snapshotEntry(),
+              state.saveState != .saved else {
             return Update(state: state)
         }
         


### PR DESCRIPTION
Fixes https://github.com/subconsciousnetwork/subconscious/issues/1065
Fixes https://github.com/subconsciousnetwork/subconscious/issues/1100 (I think)

- Do not actually attempt to save a note unless it has been modified
- Cancel polling action once editor closes
