### PR TITLE
Isolate Noosphere wrappers to shared global actor

### DIFF
--- a/xcode/Subconscious/Shared/Services/Noosphere/Noosphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Noosphere.swift
@@ -55,11 +55,17 @@ public struct SphereReceipt:
     }
 }
 
+@globalActor
+public actor NoosphereActor {
+    public static let shared = NoosphereActor()
+}
+
 /// Create a Noosphere instance.
 ///
 /// - Property noosphere: pointer that holds all the internal book keeping.
 ///   DB pointers, key storage interfaces, active HTTP clients etc.
-public actor Noosphere {
+@NoosphereActor
+public final class Noosphere {
     /// Wraps `NS_NOOSPHERE_LOG_*` constants
     enum NoosphereLogLevel: UInt32, CaseIterable {
         /// Equivalent to minimal format / INFO filter

--- a/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/NoosphereService.swift
@@ -205,12 +205,12 @@ actor NoosphereService:
     }
     
     /// Gets or creates memoized Noosphere singleton instance
-    private func noosphere() throws -> Noosphere {
+    private func noosphere() async throws -> Noosphere {
         if let noosphere = self._noosphere {
             return noosphere
         }
         logger.log("Initializing Noosphere")
-        let noosphere = try Noosphere(
+        let noosphere = try await Noosphere(
             globalStoragePath: globalStorageURL.path(percentEncoded: false),
             sphereStoragePath: sphereStorageURL.path(percentEncoded: false),
             gatewayURL: gatewayURL?.absoluteString,
@@ -222,7 +222,7 @@ actor NoosphereService:
     }
     
     /// Get or open default Sphere.
-    private func sphere() throws -> Sphere {
+    private func sphere() async throws -> Sphere {
         if let sphere = self._sphere {
             return sphere
         }
@@ -230,9 +230,9 @@ actor NoosphereService:
             throw NoosphereServiceError.defaultSphereNotFound
         }
         
-        let noosphere = try noosphere()
+        let noosphere = try await noosphere()
         logger.log("Initializing Sphere with identity: \(identity)")
-        let sphere = try Sphere(
+        let sphere = try await Sphere(
             noosphere: noosphere,
             identity: identity
         )
@@ -584,11 +584,11 @@ actor NoosphereService:
         switch address.peer {
         case .none:
             return try await errorLoggingService.capturing {
-                try self.sphere()
+                try await self.sphere()
             }
         case .did(let did) where did == identity:
             return try await errorLoggingService.capturing {
-                try self.sphere()
+                try await self.sphere()
             }
         case .petname(let petname):
             return try await self.traverse(petname: petname)

--- a/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/Sphere.swift
@@ -221,7 +221,8 @@ enum SphereError: Error, LocalizedError {
 
 /// Sphere file system access.
 /// Provides sphere file system methods and manages lifetime of sphere pointer.
-public actor Sphere: SphereProtocol, SpherePublisherProtocol {
+@NoosphereActor
+public final class Sphere: SphereProtocol, SpherePublisherProtocol {
     private let logger = Logger(
         subsystem: Config.default.rdns,
         category: "Sphere"
@@ -350,7 +351,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
         guard let file = try? await readFile(slashlink: slashlink) else {
             return nil
         }
-        return try? await file.readHeaderValueFirst(name: name)
+        return try? file.readHeaderValueFirst(name: name)
     }
     
     /// Read first header value for memo at slashlink
@@ -372,7 +373,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
         guard let file = try? await readFile(slashlink: slashlink) else {
             return nil
         }
-        return try? await file.version()
+        return try? file.version()
     }
     
     /// Get the base64-encoded CID v1 string for the memo that refers to the
@@ -415,7 +416,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
     public func read(slashlink: Slashlink) async throws -> MemoData {
         let file = try await readFile(slashlink: slashlink)
 
-        guard let contentType = try? await file.readHeaderValueFirst(
+        guard let contentType = try? file.readHeaderValueFirst(
             name: "Content-Type"
         ) else {
             throw SphereError.contentTypeMissing(slashlink.description)
@@ -428,7 +429,7 @@ public actor Sphere: SphereProtocol, SpherePublisherProtocol {
             guard name != "Content-Type" else {
                 continue
             }
-            guard let value = try await file.readHeaderValueFirst(
+            guard let value = try file.readHeaderValueFirst(
                 name: name
             ) else {
                 continue

--- a/xcode/Subconscious/Shared/Services/Noosphere/SphereFile.swift
+++ b/xcode/Subconscious/Shared/Services/Noosphere/SphereFile.swift
@@ -28,7 +28,8 @@ enum SphereFileError: Error {
 
 /// Wrapper for sphere file.
 /// Will automatically free sphere file pointer when class de-initializes.
-actor SphereFile: SphereFileProtocol {
+@NoosphereActor
+public final class SphereFile: SphereFileProtocol {
     private var isConsumed = false
     private let noosphere: Noosphere
     let file: OpaquePointer

--- a/xcode/Subconscious/SubconsciousTests/Tests_Noosphere.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Noosphere.swift
@@ -10,6 +10,7 @@ import Noosphere
 @testable import Subconscious
 
 final class Tests_Noosphere: XCTestCase {
+    @NoosphereActor
     func testCallWithError() throws {
         let noosphere = ns_initialize("/tmp/foo", "/tmp/bar", nil, nil)
         defer {

--- a/xcode/Subconscious/SubconsciousTests/Tests_Sphere.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_Sphere.swift
@@ -31,7 +31,7 @@ final class Tests_Sphere: XCTestCase {
         let sphereStoragePath = try createTmpDir(path: "\(base)/sphere")
             .path()
         
-        let noosphere = try Noosphere(
+        let noosphere = try await Noosphere(
             globalStoragePath: globalStoragePath,
             sphereStoragePath: sphereStoragePath
         )
@@ -41,7 +41,7 @@ final class Tests_Sphere: XCTestCase {
         )
         
         do {
-            let sphere = try Sphere(
+            let sphere = try await Sphere(
                 noosphere: noosphere,
                 identity: sphereReceipt.identity
             )
@@ -60,7 +60,7 @@ final class Tests_Sphere: XCTestCase {
         
         // Re-open sphere
         do {
-            let sphere = try Sphere(
+            let sphere = try await Sphere(
                 noosphere: noosphere,
                 identity: sphereReceipt.identity
             )
@@ -78,7 +78,7 @@ final class Tests_Sphere: XCTestCase {
         let sphereStoragePath = try createTmpDir(path: "\(base)/sphere")
             .path()
         
-        let noosphere = try Noosphere(
+        let noosphere = try await Noosphere(
             globalStoragePath: globalStoragePath,
             sphereStoragePath: sphereStoragePath
         )
@@ -87,7 +87,7 @@ final class Tests_Sphere: XCTestCase {
             ownerKeyName: "bob"
         )
         
-        let sphere = try Sphere(
+        let sphere = try await Sphere(
             noosphere: noosphere,
             identity: sphereReceipt.identity
         )
@@ -131,7 +131,7 @@ final class Tests_Sphere: XCTestCase {
         let sphereStoragePath = try createTmpDir(path: "\(base)/sphere")
             .path()
         
-        let noosphere = try Noosphere(
+        let noosphere = try await Noosphere(
             globalStoragePath: globalStoragePath,
             sphereStoragePath: sphereStoragePath
         )
@@ -140,7 +140,7 @@ final class Tests_Sphere: XCTestCase {
             ownerKeyName: "bob"
         )
         
-        let sphere = try Sphere(
+        let sphere = try await Sphere(
             noosphere: noosphere,
             identity: sphereReceipt.identity
         )
@@ -187,7 +187,7 @@ final class Tests_Sphere: XCTestCase {
         let sphereStoragePath = try createTmpDir(path: "\(base)/sphere")
             .path()
         
-        let noosphere = try Noosphere(
+        let noosphere = try await Noosphere(
             globalStoragePath: globalStoragePath,
             sphereStoragePath: sphereStoragePath
         )
@@ -196,7 +196,7 @@ final class Tests_Sphere: XCTestCase {
             ownerKeyName: "bob"
         )
         
-        let sphere = try Sphere(
+        let sphere = try await Sphere(
             noosphere: noosphere,
             identity: sphereReceipt.identity
         )
@@ -255,7 +255,7 @@ final class Tests_Sphere: XCTestCase {
         let sphereStoragePath = try createTmpDir(path: "\(base)/sphere")
             .path()
         
-        let noosphere = try Noosphere(
+        let noosphere = try await Noosphere(
             globalStoragePath: globalStoragePath,
             sphereStoragePath: sphereStoragePath
         )
@@ -264,7 +264,7 @@ final class Tests_Sphere: XCTestCase {
             ownerKeyName: "bob"
         )
         
-        let sphere = try Sphere(
+        let sphere = try await Sphere(
             noosphere: noosphere,
             identity: sphereReceipt.identity
         )
@@ -304,7 +304,7 @@ final class Tests_Sphere: XCTestCase {
         let sphereStoragePath = try createTmpDir(path: "\(base)/sphere")
             .path()
         
-        let noosphere = try Noosphere(
+        let noosphere = try await Noosphere(
             globalStoragePath: globalStoragePath,
             sphereStoragePath: sphereStoragePath
         )
@@ -313,7 +313,7 @@ final class Tests_Sphere: XCTestCase {
             ownerKeyName: "bob"
         )
         
-        let sphere = try Sphere(
+        let sphere = try await Sphere(
             noosphere: noosphere,
             identity: sphereReceipt.identity
         )
@@ -352,7 +352,7 @@ final class Tests_Sphere: XCTestCase {
         let sphereStoragePath = try createTmpDir(path: "\(base)/sphere")
             .path()
         
-        let noosphere = try Noosphere(
+        let noosphere = try await Noosphere(
             globalStoragePath: globalStoragePath,
             sphereStoragePath: sphereStoragePath,
             gatewayURL: "http://fake-gateway.fake"
@@ -362,7 +362,7 @@ final class Tests_Sphere: XCTestCase {
             ownerKeyName: "bob"
         )
         
-        let sphere = try Sphere(
+        let sphere = try await Sphere(
             noosphere: noosphere,
             identity: sphereReceipt.identity
         )
@@ -403,7 +403,7 @@ final class Tests_Sphere: XCTestCase {
         let startVersion: String
         let endVersion: String
         do {
-            let noosphere = try Noosphere(
+            let noosphere = try await Noosphere(
                 globalStoragePath: globalStoragePath,
                 sphereStoragePath: sphereStoragePath
             )
@@ -414,7 +414,7 @@ final class Tests_Sphere: XCTestCase {
             
             sphereIdentity = sphereReceipt.identity
             
-            let sphere = try Sphere(
+            let sphere = try await Sphere(
                 noosphere: noosphere,
                 identity: sphereReceipt.identity
             )
@@ -433,12 +433,12 @@ final class Tests_Sphere: XCTestCase {
         }
         
         do {
-            let noosphere = try Noosphere(
+            let noosphere = try await Noosphere(
                 globalStoragePath: globalStoragePath,
                 sphereStoragePath: sphereStoragePath
             )
             
-            let sphere = try Sphere(
+            let sphere = try await Sphere(
                 noosphere: noosphere,
                 identity: sphereIdentity
             )
@@ -457,7 +457,7 @@ final class Tests_Sphere: XCTestCase {
         let sphereStoragePath = try createTmpDir(path: "\(base)/sphere")
             .path()
         
-        let noosphere = try Noosphere(
+        let noosphere = try await Noosphere(
             globalStoragePath: globalStoragePath,
             sphereStoragePath: sphereStoragePath
         )
@@ -466,7 +466,7 @@ final class Tests_Sphere: XCTestCase {
             ownerKeyName: "bob"
         )
         
-        let sphere = try Sphere(
+        let sphere = try await Sphere(
             noosphere: noosphere,
             identity: sphereReceipt.identity
         )
@@ -490,7 +490,7 @@ final class Tests_Sphere: XCTestCase {
         let sphereStoragePath = try createTmpDir(path: "\(base)/sphere")
             .path()
         
-        let noosphere = try Noosphere(
+        let noosphere = try await Noosphere(
             globalStoragePath: globalStoragePath,
             sphereStoragePath: sphereStoragePath
         )
@@ -499,7 +499,7 @@ final class Tests_Sphere: XCTestCase {
             ownerKeyName: "bob"
         )
                 
-        let sphere = try Sphere(
+        let sphere = try await Sphere(
             noosphere: noosphere,
             identity: sphereReceipt.identity
         )
@@ -524,7 +524,7 @@ final class Tests_Sphere: XCTestCase {
         let sphereStoragePath = try createTmpDir(path: "\(base)/sphere")
             .path()
         
-        let noosphere = try Noosphere(
+        let noosphere = try await Noosphere(
             globalStoragePath: globalStoragePath,
             sphereStoragePath: sphereStoragePath
         )
@@ -533,7 +533,7 @@ final class Tests_Sphere: XCTestCase {
             ownerKeyName: "bob"
         )
                 
-        let sphere = try Sphere(
+        let sphere = try await Sphere(
             noosphere: noosphere,
             identity: sphereReceipt.identity
         )

--- a/xcode/Subconscious/SubconsciousTests/Tests_SphereFile.swift
+++ b/xcode/Subconscious/SubconsciousTests/Tests_SphereFile.swift
@@ -14,7 +14,7 @@ final class Tests_SphereFile: XCTestCase {
         let globalStorageURL = tmp.appending(path: "noosphere")
         let sphereStorageURL = tmp.appending(path: "sphere")
         let gatewayURL = "https://fake.website.example.com"
-        let noosphere = try Noosphere(
+        let noosphere = try await Noosphere(
             globalStoragePath: globalStorageURL.path(percentEncoded: false),
             sphereStoragePath: sphereStorageURL.path(percentEncoded: false),
             gatewayURL: gatewayURL
@@ -25,7 +25,7 @@ final class Tests_SphereFile: XCTestCase {
     func testVersion() async throws {
         let noosphere = try await createNoosphere()
         let receipt = try await noosphere.createSphere(ownerKeyName: "bob")
-        let sphere = try Sphere(
+        let sphere = try await Sphere(
             noosphere: noosphere,
             identity: receipt.identity
         )
@@ -43,7 +43,7 @@ final class Tests_SphereFile: XCTestCase {
     func testReadHeaderValueFirst() async throws {
         let noosphere = try await createNoosphere()
         let receipt = try await noosphere.createSphere(ownerKeyName: "bob")
-        let sphere = try Sphere(
+        let sphere = try await Sphere(
             noosphere: noosphere,
             identity: receipt.identity
         )
@@ -64,7 +64,7 @@ final class Tests_SphereFile: XCTestCase {
     func testReadHeaderNames() async throws {
         let noosphere = try await createNoosphere()
         let receipt = try await noosphere.createSphere(ownerKeyName: "bob")
-        let sphere = try Sphere(
+        let sphere = try await Sphere(
             noosphere: noosphere,
             identity: receipt.identity
         )
@@ -85,7 +85,7 @@ final class Tests_SphereFile: XCTestCase {
     func testConsume() async throws {
         let noosphere = try await createNoosphere()
         let receipt = try await noosphere.createSphere(ownerKeyName: "bob")
-        let sphere = try Sphere(
+        let sphere = try await Sphere(
             noosphere: noosphere,
             identity: receipt.identity
         )
@@ -105,7 +105,7 @@ final class Tests_SphereFile: XCTestCase {
     func testUseAfterConsumeThrows() async throws {
         let noosphere = try await createNoosphere()
         let receipt = try await noosphere.createSphere(ownerKeyName: "bob")
-        let sphere = try Sphere(
+        let sphere = try await Sphere(
             noosphere: noosphere,
             identity: receipt.identity
         )
@@ -134,7 +134,7 @@ final class Tests_SphereFile: XCTestCase {
     func testUseAfterConsumeThrows2() async throws {
         let noosphere = try await createNoosphere()
         let receipt = try await noosphere.createSphere(ownerKeyName: "bob")
-        let sphere = try Sphere(
+        let sphere = try await Sphere(
             noosphere: noosphere,
             identity: receipt.identity
         )


### PR DESCRIPTION
As of XCode 15.3 (15E204a) we are getting a slew of new warnings about OpaquePointers in the Noosphere wrappers.

## Problem

The problem stems from our Noosphere wrappers being individual actors, and OpaquePointers not being a sendable type (e.g. they should not cross state synchronization boundaries). That makes sense.

## Design considerations

We implement Noosphere, Sphere, and SphereFile as actors because:

- We want to get Noosphere work off the main thread. Actors nudge code off the main thread
  - Although this is not a hard guarantee of the green thread runtime IIRC, but it should do whatever it needs to do keep the main thread clear for UI.
- We want the state isolation and synchronization guarantees provided by an actor.

Since they're currently separate actors, we're passing OpaquePointers across actor boundaries. Anything passed across actor boundaries should be sendable (e.g. no shared mutable state. However, it's not really necessary that these be *separate* actors, just that they have actor isolation. Preferably, we should have them isolated to the same actor.

## Solution: global actor

Swift introduced `@globalActor` to solve for this kind of "many things isolated to the same actor context" problem.

By wrapping a new `NoosphereActor` shared actor in `@globalActor` and conforming to the protocol, we get a `@NoosphereActor` decorator we can use to isolate classes and functions.

`Noosphere`, `Sphere`, and `SphereFile` all become final classes, isolated. to `@globalActor`.

## Resources

- https://developer.apple.com/documentation/swift/globalactor
- https://github.com/apple/swift-evolution/blob/main/proposals/0316-global-actors.md 