### PR TITLE
Introduce metasheet action to share text

### DIFF
--- a/xcode/Subconscious/Shared/Components/Common/MetaTableView.swift
+++ b/xcode/Subconscious/Shared/Components/Common/MetaTableView.swift
@@ -70,6 +70,45 @@ struct MetaTableItemShareLinkView: View {
     }
 }
 
+struct MetaTableCopyItemView: View {
+    var label: String
+    var item: String
+    
+    @State var copied = false
+    var feedback: UIImpactFeedbackGenerator = Self.feedbackGenerator()
+    
+    private static func feedbackGenerator() -> UIImpactFeedbackGenerator {
+        let generator = UIImpactFeedbackGenerator(style: .light)
+        generator.prepare()
+        return generator
+    }
+    
+    var body: some View {
+        Button(
+            action: {
+                guard !copied else {
+                    return
+                }
+                
+                Task {
+                    UIPasteboard.general.string = item
+                    feedback.impactOccurred()
+                    copied = true
+                    
+                    try? await Task.sleep(nanoseconds: 500_000_000)
+                    
+                    copied = false
+                    feedback.prepare()
+                }
+            }
+        ) {
+            Label(copied ? "Copied!" : label , systemImage: copied ? "checkmark" : "link")
+        }
+        .buttonStyle(RowButtonStyle(color: copied ? .secondary : .primaryButtonText))
+        .animation(.easeOutCubic(), value: copied)
+    }
+}
+
 struct MetaTableItemButtonView: View {
     var label: String
     var systemImage: String

--- a/xcode/Subconscious/Shared/Components/Common/RowButtonStyle.swift
+++ b/xcode/Subconscious/Shared/Components/Common/RowButtonStyle.swift
@@ -24,15 +24,16 @@ struct RowLabelStyle: LabelStyle {
 /// Underlays a fill on tap when active, much like a UITableView row.
 struct RowButtonStyle: ButtonStyle {
     var insets: EdgeInsets = AppTheme.defaultRowButtonInsets
+    var color: Color = .primaryButtonText
 
     func makeBody(configuration: Configuration) -> some View {
         HStack {
             configuration.label
                 .labelStyle(RowLabelStyle())
                 .foregroundColor(
-                    configuration.role == .destructive ?
-                    Color.red :
-                    Color.primaryButtonText
+                    configuration.role == .destructive
+                        ? Color.red
+                        : color
                 )
         }
         .padding(insets)

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailMetaSheetView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailMetaSheetView.swift
@@ -46,6 +46,14 @@ struct MemoViewerDetailMetaSheetView: View {
                         .disabled(store.state.shareableLink == nil)
                         
                         Divider()
+
+                        MetaTableItemShareLinkView(
+                            label: "Share text",
+                            item: store.state.shareableText ?? ""
+                        )
+                        .disabled(store.state.shareableText == nil)
+                        
+                        Divider()
                         
                         if let address = store.state.address {
                             if store.state.liked {
@@ -148,6 +156,7 @@ struct MemoViewerDetailMetaSheetView: View {
 
 enum MemoViewerDetailMetaSheetAction: Hashable {
     case setAddress(_ address: Slashlink)
+    case setShareableText(_ text: String)
     case setAuthor(_ author: UserProfile)
     case setLiked(_ liked: Bool)
     case requestDismiss
@@ -205,6 +214,7 @@ struct MemoViewerDetailMetaSheetModel: ModelProtocol {
     
     var author: UserProfile?
     var address: Slashlink?
+    var shareableText: String?
     var memoVersion: String?
     var noteVersion: String?
     var authorKey: String?
@@ -231,6 +241,12 @@ struct MemoViewerDetailMetaSheetModel: ModelProtocol {
                 state: state,
                 environment: environment,
                 address: address
+            )
+        case let .setShareableText(text):
+            return setShareableText(
+                state: state,
+                environment: environment,
+                text: text
             )
         case let .setAuthor(author):
             return setAuthor(
@@ -277,6 +293,16 @@ struct MemoViewerDetailMetaSheetModel: ModelProtocol {
     ) -> Update<Self> {
         var model = state
         model.address = address
+        return Update(state: model)
+    }
+    
+    static func setShareableText(
+        state: Self,
+        environment: Environment,
+        text: String
+    ) -> Update<Self> {
+        var model = state
+        model.shareableText = text
         return Update(state: model)
     }
     

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailMetaSheetView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailMetaSheetView.swift
@@ -39,8 +39,8 @@ struct MemoViewerDetailMetaSheetView: View {
             ScrollView {
                 VStack(spacing: AppTheme.unit4) {
                     MetaTableView {
-                        MetaTableItemShareLinkView(
-                            label: "Share link",
+                        MetaTableCopyItemView(
+                            label: "Copy link",
                             item: store.state.shareableLink ?? ""
                         )
                         .disabled(store.state.shareableLink == nil)
@@ -48,7 +48,7 @@ struct MemoViewerDetailMetaSheetView: View {
                         Divider()
 
                         MetaTableItemShareLinkView(
-                            label: "Share text",
+                            label: "Share",
                             item: store.state.shareableText ?? ""
                         )
                         .disabled(store.state.shareableText == nil)
@@ -108,7 +108,7 @@ struct MemoViewerDetailMetaSheetView: View {
                             },
                             label: {
                                 Label(
-                                    "Append to note",
+                                    "Add to note",
                                     systemImage: "link.badge.plus"
                                 )
                             }
@@ -124,7 +124,7 @@ struct MemoViewerDetailMetaSheetView: View {
                                 },
                                 label: {
                                     Label(
-                                        "View Author Profile",
+                                        "Author",
                                         systemImage: "person"
                                     )
                                 }

--- a/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
+++ b/xcode/Subconscious/Shared/Components/Detail/MemoViewerDetailView.swift
@@ -614,6 +614,7 @@ struct MemoViewerDetailModel: ModelProtocol {
             state: model,
             actions: [
                 .setDom(dom),
+                .metaSheet(.setShareableText(entry.contents.description)),
                 .refreshLikedStatus
             ],
             environment: environment


### PR DESCRIPTION
Related to https://github.com/subconsciousnetwork/subconscious/issues/653

Introduces a "Share text" meta sheet action. I have been reaching for this functionality recently while going back and forth between my computer & phone.

**Consideration: do we want to remove "Share Link", it's unclear why you would want to copy the link outside the app until we have `http` URLs to pass around.**

https://github.com/subconsciousnetwork/subconscious/assets/5009316/153244b3-e9b8-4412-a4cd-22d9e9fa8370

